### PR TITLE
chore: allows to use strings for simple cmd

### DIFF
--- a/cmd/ike/cmd/cmd_func.go
+++ b/cmd/ike/cmd/cmd_func.go
@@ -40,8 +40,9 @@ func Start(cmd *gocmd.Cmd, done chan gocmd.Status) {
 
 // Execute executes given command in the current directory
 // Adds shutdown hook and redirects streams to stdout/err
-func Execute(name string, args ...string) *gocmd.Cmd {
-	return ExecuteInDir("", name, args...)
+func Execute(command string) *gocmd.Cmd {
+	cmd := strings.Split(command, " ")
+	return ExecuteInDir("", cmd[0], cmd[1:]...)
 }
 
 // ExecuteInDir executes given command in the defined directory

--- a/e2e/infra/cluster_setup.go
+++ b/e2e/infra/cluster_setup.go
@@ -3,23 +3,24 @@ package infra
 import "github.com/maistra/istio-workspace/cmd/ike/cmd"
 
 func CreateNewApp(name string) {
-	<-cmd.Execute("oc", "login", "-u", "developer").Done()
+	<-cmd.Execute("oc login -u developer").Done()
 
-	<-cmd.Execute("oc", "new-project", name).Done()
+	<-cmd.Execute("oc new-project " + name).Done()
 
 	UpdateSecurityConstraintsFor(name)
 
-	<-cmd.Execute("oc", "new-app",
+	<-cmd.ExecuteInDir(".",
+		"oc", "new-app",
 		"--docker-image", "datawire/hello-world",
 		"--name", name,
 		"--allow-missing-images",
 	).Done()
-	<-cmd.Execute("oc", "expose", "svc/"+name).Done()
-	<-cmd.Execute("oc", "status").Done()
+	<-cmd.Execute("oc expose svc/" + name).Done()
+	<-cmd.Execute("oc status").Done()
 }
 
 func UpdateSecurityConstraintsFor(namespace string) {
-	<-cmd.Execute("oc", "login", "-u", "system:admin").Done()
-	<-cmd.Execute("oc", "adm", "policy", "add-scc-to-user", "anyuid", "-z", "default", "-n", namespace).Done()
-	<-cmd.Execute("oc", "adm", "policy", "add-scc-to-user", "privileged", "-z", "default", "-n", namespace).Done()
+	<-cmd.Execute("oc login -u system:admin").Done()
+	<-cmd.Execute("oc adm policy add-scc-to-user anyuid -z default -n " + namespace).Done()
+	<-cmd.Execute("oc adm policy add-scc-to-user privileged -z default -n" + namespace).Done()
 }

--- a/e2e/infra/istio_setup.go
+++ b/e2e/infra/istio_setup.go
@@ -11,7 +11,7 @@ import (
 
 func LoadIstio() {
 	projectDir := os.Getenv("CUR_DIR")
-	<-cmd.Execute("oc", "login", "-u", "system:admin").Done()
+	<-cmd.Execute("oc login -u system:admin").Done()
 	<-cmd.ExecuteInDir(projectDir, "make", "load-istio").Done()
 	gomega.Eventually(PodCompletedStatus("istio-system", "job-name=openshift-ansible-istio-installer-job"),
 		10*time.Minute, 5*time.Second).Should(gomega.ContainSubstring("Completed"))
@@ -19,15 +19,15 @@ func LoadIstio() {
 
 func DeployBookinfoInto(namespace string) {
 	projectDir := os.Getenv("CUR_DIR")
-	<-cmd.Execute("oc", "login", "-u", "system:admin").Done()
+	<-cmd.Execute("oc login -u system:admin").Done()
 	<-cmd.ExecuteInDir(projectDir, "make", "deploy-bookinfo", "EXAMPLE_NAMESPACE="+namespace).Done()
 }
 
 func BuildOperator() (registry string) {
 	projectDir := os.Getenv("CUR_DIR")
 	_, registry = setDockerEnv()
-	<-cmd.Execute("oc", "login", "-u", "admin", "-p", "admin").Done()
-	<-cmd.Execute("bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
+	<-cmd.Execute("oc login -u admin -p admin").Done()
+	<-cmd.ExecuteInDir(".", "bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
 	<-cmd.ExecuteInDir(projectDir, "make", "docker-build", "docker-push").Done()
 	return
 }
@@ -35,7 +35,7 @@ func BuildOperator() (registry string) {
 func DeployOperator() (namespace string) {
 	projectDir := os.Getenv("CUR_DIR")
 	gomega.Expect(projectDir).To(gomega.Not(gomega.BeEmpty()))
-	<-cmd.Execute("oc", "login", "-u", "system:admin").Done()
+	<-cmd.Execute("oc login -u system:admin").Done()
 
 	namespace, _ = setDockerEnv()
 	// override and use internal address on Deployment

--- a/e2e/infra/pod_state.go
+++ b/e2e/infra/pod_state.go
@@ -8,7 +8,8 @@ import (
 
 func AllPodsNotInState(namespace, state string) func() string {
 	return func() string {
-		ocGetPods := cmd.Execute("oc", "get", "pods",
+		ocGetPods := cmd.ExecuteInDir(".",
+			"oc", "get", "pods",
 			"-n", namespace,
 			"--field-selector", "status.phase!="+state,
 		)
@@ -19,7 +20,8 @@ func AllPodsNotInState(namespace, state string) func() string {
 
 func PodStatus(namespace, label, state string) func() string { //nolint[:unused]
 	return func() string {
-		ocGetPods := cmd.Execute("oc", "get", "pods",
+		ocGetPods := cmd.ExecuteInDir(".",
+			"oc", "get", "pods",
 			"-n", namespace,
 			"-l", label,
 			"--field-selector", "status.phase=="+state,
@@ -31,7 +33,8 @@ func PodStatus(namespace, label, state string) func() string { //nolint[:unused]
 
 func PodCompletedStatus(namespace, label string) func() string {
 	return func() string {
-		ocGetPods := cmd.Execute("oc", "get", "pods",
+		ocGetPods := cmd.ExecuteInDir(".",
+			"oc", "get", "pods",
 			"-n", namespace,
 			"-l", label,
 			"-o", "go-template='{{range .items}}{{range .status.containerStatuses}}{{.state.terminated.reason}}{{end}}{{end}}'",


### PR DESCRIPTION
Instead of breaking down the command to separate string for each token we can now just pass a string. 

Shortcoming - this does not work for sub-commands, e.g. `docker login -u $(oc whoami)`.

#### Why

I am working on the docs and aiming for extracting cmd samples from tests directly to the docs so we can have them always up-to-date. That's a first step. 