### PR TITLE
feat(testing): adds goleak check to each suite and template

### DIFF
--- a/cmd/ike/session/session_suite_test.go
+++ b/cmd/ike/session/session_suite_test.go
@@ -3,6 +3,8 @@ package session_test
 import (
 	"testing"
 
+	"go.uber.org/goleak"
+
 	. "github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
@@ -13,3 +15,10 @@ func TestSession(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "Session Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/cmd/ike/watch/watch_suite_test.go
+++ b/cmd/ike/watch/watch_suite_test.go
@@ -3,6 +3,8 @@ package watch_test
 import (
 	"testing"
 
+	"go.uber.org/goleak"
+
 	. "github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
@@ -13,3 +15,12 @@ func TestWatch(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "Watch Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+
+	CleanUpTmpFiles(GinkgoT())
+})

--- a/cmd/ike/watch/watch_test.go
+++ b/cmd/ike/watch/watch_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/maistra/istio-workspace/cmd/ike/watch"
 
-	"go.uber.org/goleak"
-
 	"github.com/fsnotify/fsnotify"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,14 +14,6 @@ import (
 )
 
 var _ = Describe("File changes watch", func() {
-
-	AfterSuite(func() {
-		goleak.VerifyNone(GinkgoT(),
-			goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
-			goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
-		)
-		CleanUpTmpFiles(GinkgoT())
-	})
 
 	It("should recognize file change", func() {
 		// given

--- a/e2e/infra/istio_setup.go
+++ b/e2e/infra/istio_setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
+// LoadIstio calls make load-istio target and waits until operator sets up mesh
 func LoadIstio() {
 	projectDir := os.Getenv("CUR_DIR")
 	<-cmd.Execute("oc login -u system:admin").Done()
@@ -17,12 +18,14 @@ func LoadIstio() {
 		10*time.Minute, 5*time.Second).Should(gomega.ContainSubstring("Completed"))
 }
 
+// DeployBookinfoInto deploys book info sample application into specified namespace
 func DeployBookinfoInto(namespace string) {
 	projectDir := os.Getenv("CUR_DIR")
 	<-cmd.Execute("oc login -u system:admin").Done()
 	<-cmd.ExecuteInDir(projectDir, "make", "deploy-bookinfo", "EXAMPLE_NAMESPACE="+namespace).Done()
 }
 
+// BuildOperator builds istio-workspace operator and pushes it to specified registry
 func BuildOperator() (registry string) {
 	projectDir := os.Getenv("CUR_DIR")
 	_, registry = setDockerEnv()
@@ -32,6 +35,7 @@ func BuildOperator() (registry string) {
 	return
 }
 
+// DeployOperator deploys istio-workspace operator into specified namespace
 func DeployOperator() (namespace string) {
 	projectDir := os.Getenv("CUR_DIR")
 	gomega.Expect(projectDir).To(gomega.Not(gomega.BeEmpty()))

--- a/pkg/controller/session/session_suite_test.go
+++ b/pkg/controller/session/session_suite_test.go
@@ -3,6 +3,8 @@ package session_test
 import (
 	"testing"
 
+	"go.uber.org/goleak"
+
 	. "github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
@@ -13,3 +15,10 @@ func TestSessionController(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "Session reconciler Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/pkg/istio/istio_suite_test.go
+++ b/pkg/istio/istio_suite_test.go
@@ -3,6 +3,8 @@ package istio_test
 import (
 	"testing"
 
+	"go.uber.org/goleak"
+
 	. "github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
@@ -13,3 +15,10 @@ func TestK8(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "Istio object Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -1,8 +1,9 @@
 package k8s
 
 import (
-	"github.com/maistra/istio-workspace/pkg/model"
 	"os"
+
+	"github.com/maistra/istio-workspace/pkg/model"
 
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -101,7 +102,7 @@ func cloneDeployment(deployment *appsv1.Deployment, version string) *appsv1.Depl
 	}
 
 	container := deploymentClone.Spec.Template.Spec.Containers[0]
-	container.Image = "datawire/telepresence-k8s:"+tpVersion
+	container.Image = "datawire/telepresence-k8s:" + tpVersion
 	container.Env = append(container.Env, corev1.EnvVar{
 		Name: "TELEPRESENCE_CONTAINER_NAMESPACE",
 		ValueFrom: &corev1.EnvVarSource{

--- a/pkg/k8s/k8s_suite_test.go
+++ b/pkg/k8s/k8s_suite_test.go
@@ -3,6 +3,8 @@ package k8s_test
 import (
 	"testing"
 
+	"go.uber.org/goleak"
+
 	. "github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
@@ -13,3 +15,10 @@ func TestK8(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "k8s object Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/pkg/naming/k8s_naming_suite_test.go
+++ b/pkg/naming/k8s_naming_suite_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
+
 	. "github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
@@ -16,3 +18,10 @@ func TestNamingGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "Names Generator Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/test/test_suite.tpl
+++ b/test/test_suite.tpl
@@ -1,6 +1,7 @@
 package {{.Package}}
 
 import (
+	"go.uber.org/goleak"
 	"testing"
 
 	. "github.com/maistra/istio-workspace/test"
@@ -13,3 +14,10 @@ func Test{{.FormattedName}}(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "{{.FormattedName}} Suite")
 }
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})


### PR DESCRIPTION
#### Short description of what this resolves:

I've added goleak when testing watch functionality - helped me finding a few corner cases in this part.

We somehow forgot to add that across the whole test suite.

#### Changes proposed in this pull request:

- adds `AfterSuite` in each `_suite_test.go` with calls to goleak detection
- enhances ginkgo template so that new suites will have that check right from the beginning

