### PR TITLE
feat: adds --version flag to root cmd

### DIFF
--- a/cmd/ike/cmd/root.go
+++ b/cmd/ike/cmd/root.go
@@ -38,6 +38,10 @@ func NewRootCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 			printVersion()
+			justPrintVersion, _ := cmd.Flags().GetBool("version")
+			if justPrintVersion {
+				return nil
+			}
 			return startOperator()
 		},
 	}
@@ -45,7 +49,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().
 		StringVarP(&configFile, "config", "c", ".ike.config.yaml",
 			fmt.Sprintf("config file (supported formats: %s)", strings.Join(config.SupportedExtensions(), ", ")))
-
+	rootCmd.Flags().Bool("version", false, "prints the version number of ike cli")
 	return rootCmd
 }
 

--- a/cmd/ike/cmd/version.go
+++ b/cmd/ike/cmd/version.go
@@ -18,7 +18,7 @@ func NewVersionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the version number of ike cli",
-		Long:  `All software has versions. This is Ike's`,
+		Long:  "All software has versions. This is Ike's",
 		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 			printVersion()
 			return nil


### PR DESCRIPTION
#### Short description of what this resolves:

Among the cli tools you can find both `cmd --version` and `cmd version` way of getting information about the version of the tool in use. I frequently mix it up so I thought it would be good to actually have both available :)

#### Changes proposed in this pull request:

- adds `--version` flag to root command which only prints version and skips operator start

