### PR TITLE
chore: updates apiVersion to fully qualified template group

### DIFF
--- a/deploy/istio-workspace/operator.yaml
+++ b/deploy/istio-workspace/operator.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 parameters:
   - name: IKE_DOCKER_REGISTRY
     required: true

--- a/deploy/istio-workspace/role_binding.yaml
+++ b/deploy/istio-workspace/role_binding.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 parameters:
   - name: NAMESPACE
     required: true


### PR DESCRIPTION
#### Short description of what this resolves:

Old, unqualified template api version is `legacy` in openshift, thus I added group `template.openshift.io` instead of plain version.