### PR TITLE
chore(lint): bumps deadline to unblock CI builds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters:
     - gochecknoglobals # TODO discuss
 
 run:
+  deadline: 10m
   skip-dirs:
     - ./pkg/apis/istio
     - ./pkg/client/clientset


### PR DESCRIPTION
<!-- 
Many thanks for contributing to istio-workspace! Together we can make the cloud development world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please but you would like our early feedback, please mark this pull request as draft

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:

CircleCI started having hiccups with linter. This PR extends deadline (defaults to 1m) to 10m

#### Changes proposed in this pull request:

- `.golangci.yml` deadline settings extended to 10m