### PR TITLE
chore(deps): lock spf13/cobra and viper deps

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,3 +92,11 @@ required = [
 [[constraint]]
   name = "github.com/sabhiram/go-gitignore"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/spf13/viper"
+  version = "=v1.4.0"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version = "=v0.0.5"


### PR DESCRIPTION
#### Short description of what this resolves:

Without locking deps we can encounter nondeterministic builds, even on `master`.

In addition, this will let us get automated PRs from dependabot to test any new version before we make the update.

#### Changes proposed in this pull request:

- blocks spf13/cobra to latest `v0.0.5`
- blocks spf13/viper to latest `v1.4.0`
