### PR TITLE
fix(docs): working link to docs in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ image:https://circleci.com/gh/Maistra/istio-workspace.svg?style=svg["CircleCI", 
 
 === Documentation
 
-Full documentation preview can be found https://istio-workspace-docs.netlify.com/istio-workspace/[here].
+Full documentation preview can be found https://istio-workspace-docs.netlify.com/[here].
 
 ==== Setup
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,9 @@ image:https://circleci.com/gh/Maistra/istio-workspace.svg?style=svg["CircleCI", 
 
 === Documentation
 
-Full documentation preview can be found https://istio-workspace-docs.netlify.com/[here].
+More details can be found on our https://istio-workspace-docs.netlify.com/[documentation page]. 
+
+We use amazing https://antora.org/[Antora] project to build it and you should too!
 
 ==== Setup
 


### PR DESCRIPTION
#### Short description of what this resolves:

The previous link seems to be broken. Linking to the root URL instead.

@aslakknutsen This PR will be exceptionally merged w/o the review as you are not available this and coming week. Adding you as a reviewer though so you can see what has been changed.