### PR TITLE
feat(circle): introduces skip e2e commit directive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Checks for [skip-e2e] directive"
           command: |
             COMMIT_MSG=$(git log --format=oneline -n 1 $CIRCLE_SHA1)
             if [[ $COMMIT_MSG == *"[skip-e2e]"* ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,13 @@ jobs:
     steps:
       - checkout
       - run:
+          command: |
+            COMMIT_MSG=$(git log --format=oneline -n 1 $CIRCLE_SHA1)
+            if [[ $COMMIT_MSG == *"[skip-e2e]"* ]]; then
+              echo "[skip-e2e] detected. Explictly stopping e2e tests."
+              circleci step halt
+            fi
+      - run:
           name: "Configures Docker daemon with insecure-registry"
           command: |
             json=`mktemp`


### PR DESCRIPTION
#### Short description of what this resolves:

Some of the PRs don't need the e2e tests to be executed (i.e. no code changes). For example, docs updates are a good example.

Use with caution though.

#### Changes proposed in this pull request:

- `[skip-e2e]` in the commit message will skip e2e job and mark it as a success.

@aslakknutsen This PR will be exceptionally merged w/o the review as you are not available this and coming week. Adding you as a reviewer though so you can see what has been changed.