### PR TITLE
feat(circle): disables linter for ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: "Runs the build"
           command: |
             make tools && \
-            make
+            make build-ci
       - save_cache:
           key: vendor-cache-{{ checksum "Gopkg.lock" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ define header =
 @echo -e "\n\e[92m\e[4m\e[1m$(1)\e[0m\n"
 endef
 
+.DEFAULT_GOAL:=all
+
 .PHONY: all
 all: deps format lint test compile ## (default) Runs 'deps format lint test compile' targets
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ endef
 .DEFAULT_GOAL:=all
 
 .PHONY: all
-all: deps format lint test compile ## (default) Runs 'deps format lint test compile' targets
+all: deps format lint compile test ## (default) Runs 'deps format lint test compile' targets
+
+.PHONY: build-ci
+build-ci: deps format compile test ## Like 'all', but without linter which is executed as separated PR check
 
 export CUR_DIR
 


### PR DESCRIPTION
#### Short description of what this resolves:

As we have now golangci as separated PR check this will disable linter for CI build on CircleCI.

#### Changes proposed in this pull request:

- explicitly defines the default goal (all)
- introduces `build-ci` target without linter
- switches to `build-ci` for circle-ci builds
- first `compiles` then run `tests` for `all` and `build-ci`


Fixes #157 