### PR TITLE
chore: updates Telepresence to latest 0.101

### DIFF
--- a/deploy/istio-workspace/operator.yaml
+++ b/deploy/istio-workspace/operator.yaml
@@ -20,7 +20,7 @@ parameters:
   - name: TELEPRESENCE_VERSION
     description: "Underlying Telepresence version used to deploy its images when swapping deployments in the cluster"
     required: true
-    value: "0.100"
+    value: "0.101"
 objects:
   - kind: Deployment
     apiVersion: apps/v1

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -101,7 +101,7 @@ func cloneDeployment(deployment *appsv1.Deployment, version string) *appsv1.Depl
 
 	tpVersion, found := os.LookupEnv("TELEPRESENCE_VERSION")
 	if !found {
-		tpVersion = "0.100"
+		tpVersion = "0.101"
 	}
 
 	container := deploymentClone.Spec.Template.Spec.Containers[0]

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -104,7 +104,7 @@ func cloneDeployment(deployment *appsv1.DeploymentConfig, version string) *appsv
 
 	tpVersion, found := os.LookupEnv("TELEPRESENCE_VERSION")
 	if !found {
-		tpVersion = "0.100"
+		tpVersion = "0.101"
 	}
 
 	container := deploymentClone.Spec.Template.Spec.Containers[0]

--- a/pkg/openshift/parser/template_test.go
+++ b/pkg/openshift/parser/template_test.go
@@ -135,7 +135,7 @@ parameters:
   - name: TELEPRESENCE_VERSION
     description: "Underlying Telepresence version used to deploy its images when swapping deployments in the cluster"
     required: true
-    value: "0.100"
+    value: "0.101"
 objects:
   - kind: Deployment
     apiVersion: apps/v1
@@ -170,5 +170,5 @@ objects:
                 - name: OPERATOR_NAME
                   value: "istio-workspace"
                 - name: TELEPRESENCE_VERSION
-                  value: "0.100"
+                  value: "0.101"
 `


### PR DESCRIPTION
#### Short description of what this resolves:

There's a new version of Telepresence (0.101) out, so we should bump that in our tool.


#### Changes proposed in this pull request:

- default TP version to 0.101
- updates operator template
