### PR TITLE
chore(make): extracts version from git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ COMMIT:=$(shell git rev-parse --short HEAD)
 ifneq ($(GITUNTRACKEDCHANGES),)
 	COMMIT:=$(COMMIT)-dirty-$(shell date +%s)
 endif
-VERSION?=0.0.1
+VERSION?=$(shell echo "$(git describe --tags 2>/dev/null || echo 'v0.0.0')-snapshot")
 LDFLAGS="-w -X ${PACKAGE_NAME}/version.Version=${VERSION} -X ${PACKAGE_NAME}/version.Commit=${COMMIT} -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}"
 
 SRCS=$(shell find ./pkg -name "*.go") $(shell find ./cmd -name "*.go") $(shell find ./version -name "*.go")

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ COMMIT:=$(shell git rev-parse --short HEAD)
 ifneq ($(GITUNTRACKEDCHANGES),)
 	COMMIT:=$(COMMIT)-dirty-$(shell date +%s)
 endif
-VERSION?=$(shell echo "$(git describe --tags 2>/dev/null || echo 'v0.0.0')-snapshot")
+VERSION?=$(shell echo "$(git describe --tags 2>/dev/null || echo 'v0.0.0')-next")
 LDFLAGS="-w -X ${PACKAGE_NAME}/version.Version=${VERSION} -X ${PACKAGE_NAME}/version.Commit=${COMMIT} -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}"
 
 SRCS=$(shell find ./pkg -name "*.go") $(shell find ./cmd -name "*.go") $(shell find ./version -name "*.go")


### PR DESCRIPTION
Ongoing version in the built binary will be `latest-tag-next`, so that we know from which stable release it evolved.