### PR TITLE
feat(build): adds goreleaser config for cross-compiling

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+before:
+  hooks:
+    - make deps codegen
+builds:
+- env:
+  - CGO_ENABLED=0
+  ## Overlaps with what is defined in Makefile - we should find a away of having it defined only once
+  - PACKAGE_NAME=github.com/maistra/istio-workspace
+  main: ./cmd/ike
+  binary: ike
+  goos:
+    - linux
+    - darwin
+  goarch:
+    - 386
+    - amd64
+  ldflags:
+    ## Overlaps with what is defined in Makefile - we should find a away of having it defined only once
+    - -s -w -X {{.Env.PACKAGE_NAME}}/version.Version={{.Version}} -X {{.Env.PACKAGE_NAME}}/version.Commit={{.ShortCommit}} -X {{.Env.PACKAGE_NAME}}/version.BuildTime={{.Date}}
+archives:
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs'
+    - '^test'
+    - '^chore'
+    - '^build'
+    - '^task'
+    - '(github):'
+    - '(docs):'
+    - '(travis):'
+    - '(circle):'
+    - '(circleci):'

--- a/pkg/assets/isto-workspace-deploy.go
+++ b/pkg/assets/isto-workspace-deploy.go
@@ -116,7 +116,7 @@ func deployIstioWorkspaceOperatorYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/istio-workspace/operator.yaml", size: 1798, mode: os.FileMode(436), modTime: time.Unix(1560431092, 0)}
+	info := bindataFileInfo{name: "deploy/istio-workspace/operator.yaml", size: 1798, mode: os.FileMode(436), modTime: time.Unix(1561109514, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Provides initial config for [`goreleaser`](https://github.com/goreleaser/goreleaser).

#### Changes proposed in this pull request:

- cross-compilation for Linux and MacOS (see #159 for the reasons why Windows is not yet supported)
- filtering out certain labels for auto generated changelog.

See #161 #163 #164 for further enhancements.

Fixes #42 