### PR TITLE
fix: versioning for operator installer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     - 386
     - amd64
   ldflags:
-    ## Overlaps with what is defined in Makefile - we should find a away of having it defined only once
+    ## FIXME Overlaps with what is defined in Makefile - we should find a away of having it defined only once
     - -s -w -X {{.Env.PACKAGE_NAME}}/version.Version={{.Version}} -X {{.Env.PACKAGE_NAME}}/version.Commit={{.ShortCommit}} -X {{.Env.PACKAGE_NAME}}/version.BuildTime={{.Date}}
 archives:
   - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,7 @@ $(BINARY_DIR)/$(TEST_BINARY_NAME): $(BINARY_DIR) $(SRCS)
 
 IKE_IMAGE_NAME?=$(PROJECT_NAME)
 IKE_TEST_IMAGE_NAME?=$(IKE_IMAGE_NAME)-test
-### If on the clean git tag - use that instead of commit
-IKE_IMAGE_TAG?=$(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null || echo $(VERSION))
-ifneq ($(GITUNTRACKEDCHANGES),)
-	IKE_IMAGE_TAG:=$(VERSION)
-endif
+IKE_IMAGE_TAG?=$(VERSION)
 export IKE_IMAGE_TAG
 IKE_DOCKER_REGISTRY?=docker.io
 IKE_DOCKER_REPOSITORY?=maistra

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,16 @@ COMMIT:=$(shell git rev-parse --short HEAD)
 ifneq ($(GITUNTRACKEDCHANGES),)
 	COMMIT:=$(COMMIT)-dirty-$(shell date +%s)
 endif
-VERSION?=$(shell echo "$(git describe --tags 2>/dev/null || echo 'v0.0.0')-next")
-LDFLAGS="-w -X ${PACKAGE_NAME}/version.Version=${VERSION} -X ${PACKAGE_NAME}/version.Commit=${COMMIT} -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}"
 
+VERSION:=$(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+GIT_TAG:=$(shell git describe --tags --abbrev=0 --exact-match > /dev/null 2>&1; echo $$?)
+ifneq ($(GIT_TAG),0)
+	VERSION:=$(VERSION)-next-$(COMMIT)
+else ifneq ($(GITUNTRACKEDCHANGES),)
+	VERSION:=$(VERSION)-dirty-$(shell date +%s)
+endif
+
+LDFLAGS="-w -X ${PACKAGE_NAME}/version.Version=${VERSION} -X ${PACKAGE_NAME}/version.Commit=${COMMIT} -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}"
 SRCS=$(shell find ./pkg -name "*.go") $(shell find ./cmd -name "*.go") $(shell find ./version -name "*.go")
 
 $(BINARY_DIR):
@@ -128,13 +135,17 @@ $(BINARY_DIR)/$(TEST_BINARY_NAME): $(BINARY_DIR) $(SRCS)
 
 IKE_IMAGE_NAME?=$(PROJECT_NAME)
 IKE_TEST_IMAGE_NAME?=$(IKE_IMAGE_NAME)-test
-IKE_IMAGE_TAG?=$(COMMIT)
+### If on the clean git tag - use that instead of commit
+IKE_IMAGE_TAG?=$(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null || echo $(VERSION))
+ifneq ($(GITUNTRACKEDCHANGES),)
+	IKE_IMAGE_TAG:=$(VERSION)
+endif
 export IKE_IMAGE_TAG
 IKE_DOCKER_REGISTRY?=docker.io
 IKE_DOCKER_REPOSITORY?=maistra
 
 .PHONY: docker-build
-docker-build: ## Builds the docker image
+docker-build: compile ## Builds the docker image
 	$(call header,"Building docker image $(IKE_IMAGE_NAME)")
 	docker build \
 		-t $(IKE_DOCKER_REGISTRY)/$(IKE_DOCKER_REPOSITORY)/$(IKE_IMAGE_NAME):$(IKE_IMAGE_TAG) \

--- a/cmd/ike/cmd/install.go
+++ b/cmd/ike/cmd/install.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/maistra/istio-workspace/version"
+
 	"github.com/maistra/istio-workspace/pkg/openshift/parser"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,10 +44,21 @@ func installOperator(cmd *cobra.Command, args []string) error { //nolint[:unpara
 	if err != nil {
 		return err
 	}
+
 	// Propagates NAMESPACE env var which is used by templates
-	if envErr := os.Setenv("NAMESPACE", namespace); envErr != nil {
-		return envErr
+	if os.Getenv("NAMESPACE") == "" {
+		if envErr := os.Setenv("NAMESPACE", namespace); envErr != nil {
+			return envErr
+		}
 	}
+
+	// Propagates IKE_IMAGE_TAG env var which is used by templates to be aligned with the version of the actual built binary
+	if os.Getenv("IKE_IMAGE_TAG") == "" {
+		if envErr := os.Setenv("IKE_IMAGE_TAG", version.Version); envErr != nil {
+			return envErr
+		}
+	}
+
 	app, err := newApplier(namespace)
 	if err != nil {
 		return err

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// Version hold a semantic version of the running binary
-	Version = "0.0.0"
+	Version = "v0.0.0"
 	// Commit holds the commit hash against which the binary build was ran
 	Commit string
 	// BuildTime holds timestamp when the binary build was ran

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// Version hold a semantic version of the running binary
-	Version = "0.0.1"
+	Version = "0.0.0"
 	// Commit holds the commit hash against which the binary build was ran
 	Commit string
 	// BuildTime holds timestamp when the binary build was ran


### PR DESCRIPTION
#### Short description of what this resolves:

Simplifies versioning and re-use the version in the operator installation process.

#### Changes proposed in this pull request:

- cleaned up versioning scheme
- docker image tag is same as `VERSION` now
- makes `docker-build` rely on `compile` to always build latest binary
- `ike install-operator` uses compile-time defined `version.Version` param to use for template processing if `IKE_IMAGE_TAG` is not defined as env var

#### Versioning scheme
Following versioning scheme is proposed. Let's take the following sequence of commits:

`--> a4f --> b5d (tag: v0.0.1) --> cdf --> d56 (tag: v0.0.2) --> 4cb --> ...`

- binary built against `b5d` will have a version `v0.0.1` and it will push docker image tagged with the same
- if there are changes on this commit subsequent builds will be labeled `v0.0.1-dirty-TIMESTAMP`
- build on `cdf` will have `v0.0.1-next` prefix with the same dirty rules as above
- build on `4cb` will have `v0.0.2-next` prefix with the same dirty rules as above
