### PR TITLE
feat: release dry-run mode

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,4 +107,5 @@ if ! ${dry_run}; then
   git push && git push --tags
 else
   echo "In dry-run mode, not pushing changes to remote"
+  echo "Don't forget to revert commits (i.e. git reset --hard HEAD~~) and delete the tag (git tag -d ${version})"
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -104,7 +104,7 @@ git commit -am"release: next iteration"
 
 if ! ${dry_run}; then
   echo "Pushing changes to remote"
-  # git push && git push --tags
+  git push && git push --tags
 else
   echo "In dry-run mode, not pushing changes to remote"
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,54 +1,110 @@
 #!/bin/bash
 
-validate_tag() {
-  git_tag=$1
+die () {
+    echo >&2 "$@"
+    exit 1
+}
 
-  tag_exists=$(git --no-pager tag --list | grep -c ${git_tag})
-  if [[ ${tag_exists} -ne 0 ]]; then
-    echo "Tag ${git_tag} already exists!" >&2
+show_help() {
+  echo "release - attempts to release new version of this project"
+  echo " "
+  echo "./release.sh [options]"
+  echo " "
+  echo "Options:"
+  echo "-h, --help                shows brief help"
+  echo "-v, --version=vx.y.yz     defines version for coming release. must be non-existing and following semantic rules"
+  echo "-d, --dry-run             runs release process without doing actual push to git remote"
+}
+
+validate_version() {
+  version=$1
+
+  if [[ ${version} == "" ]]; then
+    echo >&2 "Undefined version (pass using -v|--version). Please use semantic version. Read more about it here: https://semver.org/ \n\n"
+    show_help
     exit 1
   fi
 
+  tag_exists=$(git --no-pager tag --list | grep -c ${version})
+  if [[ ${tag_exists} -ne 0 ]]; then
+    die "Tag ${version} already exists!"
+  fi
+
+  # ensure defined version matches semver rules
   sem_ver_pattern="^[vV]?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
-  if [[ ! "${git_tag}" =~ $sem_ver_pattern ]]; then
-    echo "Git tag you defined (${git_tag}) does not match semantic version. Read more about it here: https://semver.org/" >&2
-    exit 1
+  if [[ ! "${version}" =~ $sem_ver_pattern ]]; then
+    die "Version (${version}) you defined does not match semantic version. Read more about it here: https://semver.org/"
   fi
 
   # ensure release notes exist
-  if [[ ! -f "docs/modules/ROOT/pages/release_notes/${git_tag}.adoc" ]]; then
-    echo "Please create release notes in docs/modules/ROOT/pages/release_notes/${git_tag}.adoc and submit it over a Pull Request." >&2
-    exit 1
+  if [[ ! -f "docs/modules/ROOT/pages/release_notes/${version}.adoc" ]]; then
+    die "Please create release notes in docs/modules/ROOT/pages/release_notes/${version}.adoc and submit it over a Pull Request."
   fi
 
   # ensure you are on master
   current_branch=$(git branch | grep \* | cut -d ' ' -f2)
   if [[ ${current_branch} != "master" ]]; then
-    echo "You are on ${current_branch} branch. Switch to master!" >&2
-    exit 1
+    die "You are on ${current_branch} branch. Switch to master!"
   fi
 
 }
 
 BASEDIR=$(git rev-parse --show-toplevel)
+version=""
+dry_run=false
 
-if [[ -z "$1" ]]; then
-  echo "Please provide tag name" >&2
-  exit 1
+if [[ "$#" -eq 0 ]]; then
+  show_help
+  exit 0
 fi
 
-git_tag=$1
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+            show_help
+            exit 0
+            ;;
+    -v)
+            shift
+            if test $# -gt 0; then
+              version=$1
+            else
+              die "Please provide tag name"
+            fi
+            shift
+            ;;
+    --version*)
+            version=`echo $1 | sed -e 's/^[^=]*=//g'`
+            shift
+            ;;
+    -d|--dry-run)
+            shift
+            dry_run=true
+            shift
+            ;;
+    *)
+            die "Unknown param $1"
+            break
+            ;;
+  esac
+done
 
-validate_tag ${git_tag}
+validate_version ${version}
 
-sed -i "/version:/c\version: ${git_tag}" docs/antora.yml
-sed -i "/^== Releases.*/a include::release_notes\/${git_tag}.adoc[]\n" docs/modules/ROOT/pages/release_notes.adoc
+## Replace antora version for docs build
+sed -i "/version:/c\version: ${version}" docs/antora.yml
+sed -i "/^== Releases.*/a include::release_notes\/${version}.adoc[]\n" docs/modules/ROOT/pages/release_notes.adoc
 
-git commit -am"release: ${git_tag}"
-git tag -a "${git_tag}" -m"Automatically created release tag"
+git commit -am"release: ${version}"
+git tag -a "${version}" -m"Automatically created release tag"
 
 ## Prepare next release iteration
 sed -i "/version:/c\version: latest" docs/antora.yml
 git commit -am"release: next iteration"
 
-git push && git push --tags
+if ! ${dry_run}; then
+  echo "Pushing changes to remote"
+  # git push && git push --tags
+else
+  echo "In dry-run mode, not pushing changes to remote"
+fi


### PR DESCRIPTION
#### Short description of what this resolves:

Sometimes we might want to just see the changes locally without pushing all at once

#### Changes proposed in this pull request:

- `-v|--version` flag to define the released version
- `-d|-dry-run` flag to skip actual push to the repo
- `-h|--help`
- improvements in the arguments validation
