### PR TITLE
Makefile docker chores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ define header =
 @echo -e "\n\e[92m\e[4m\e[1m$(1)\e[0m\n"
 endef
 
-##@ Default (all you need - just run "make")
+##@ Default target (all you need - just run "make")
 .DEFAULT_GOAL:=all
 .PHONY: all
 all: deps format lint compile test ## Runs 'deps format lint test compile' targets
@@ -130,7 +130,7 @@ $(CUR_DIR)/$(ASSETS): $(ASSET_SRCS)
 
 
 # ##########################################################################
-##@ Docker build
+##@ Docker
 # ##########################################################################
 
 IKE_IMAGE_NAME?=$(PROJECT_NAME)
@@ -258,5 +258,5 @@ undeploy-test-%:
 ##@ Helpers
 
 .PHONY: help
-help:  ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[4m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+help:  ## Displays this help \o/
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m\033[2m %s\033[0m\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ docker-push-test:
 	docker push $(IKE_DOCKER_REGISTRY)/$(IKE_DOCKER_REPOSITORY)/$(IKE_TEST_IMAGE_NAME):latest
 
 # ##########################################################################
-##@ Istio operator deployment
+##@ Istio-workspace operator deployment
 # ##########################################################################
 
 define process_template # params: template location
@@ -194,7 +194,7 @@ define process_template # params: template location
 endef
 
 .PHONY: load-istio
-load-istio: ## Triggers installation of istio in the cluster
+load-istio: ## Triggers installation of minimal Istio in the cluster (see deploy/istio/minimal-cr.yaml)
 	$(call header,"Deploys minimal istio operator")
 	oc create -n istio-operator -f deploy/istio/minimal-cr.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -239,20 +239,21 @@ undeploy-example: ## Undeploys istio-workspace specific resources from defined T
 # ##########################################################################
 
 deploy-test-%: ## Deploys bookinfo app into defined TEST_NAMESPACE
-	$(call header,"Deploying bookinfo app to $(TEST_NAMESPACE)")
+	$(eval scenario:=$(subst deploy-test-,,$@))
+	$(call header,"Deploying bookinfo $(scenario) app to $(TEST_NAMESPACE)")
+
 	oc new-project $(TEST_NAMESPACE) || true
 	oc adm policy add-scc-to-user anyuid -z default -n $(TEST_NAMESPACE)
 	oc adm policy add-scc-to-user privileged -z default -n $(TEST_NAMESPACE)
 	oc apply -n $(TEST_NAMESPACE) -f deploy/bookinfo/session_role.yaml
 	oc apply -n $(TEST_NAMESPACE) -f deploy/bookinfo/session_rolebinding.yaml
 
-	$(eval scenario:=$(subst deploy-test-,,$@))
 	go run ./test/cmd/test-scenario/ $(scenario) | oc apply -n $(TEST_NAMESPACE) -f -
 
 undeploy-test-%: ## Undeploys bookinfo app into defined TEST_NAMESPACE
-	$(call header,"Undeploying bookinfo app to $(TEST_NAMESPACE)")
-
 	$(eval scenario:=$(subst undeploy-test-,,$@))
+	$(call header,"Undeploying bookinfo $(scenario) app from $(TEST_NAMESPACE)")
+
 	go run ./test/cmd/test-scenario/ $(scenario) | oc delete -n $(TEST_NAMESPACE) -f -
 	oc delete -n $(TEST_NAMESPACE) -f deploy/bookinfo/session_rolebinding.yaml
 	oc delete -n $(TEST_NAMESPACE) -f deploy/bookinfo/session_role.yaml

--- a/Makefile
+++ b/Makefile
@@ -151,17 +151,14 @@ docker-build: compile ## Builds the docker image
 		$(IKE_DOCKER_REGISTRY)/$(IKE_DOCKER_REPOSITORY)/$(IKE_IMAGE_NAME):latest
 
 .PHONY: docker-push
-docker-push: docker-push-latest docker-push-versioned ## Pushes docker images to the registry
+docker-push: docker-push--latest docker-push-versioned ## Pushes docker images to the registry
 
-.PHONY: docker-push-latest
-docker-push-latest:  ## Pushes latest docker image to the registry
-	$(call header,"Pushing docker image :latest")
-	docker push $(IKE_DOCKER_REGISTRY)/$(IKE_DOCKER_REPOSITORY)/$(IKE_IMAGE_NAME):latest
+docker-push-versioned: docker-push--$(IKE_IMAGE_TAG) ## Left only for CI to have simple target to call
 
-.PHONY: docker-push-versioned
-docker-push-versioned:  ## Pushes versioned docker image to the registry
-	$(call header,"Pushing docker image :$(IKE_IMAGE_NAME)")
-	docker push $(IKE_DOCKER_REGISTRY)/$(IKE_DOCKER_REPOSITORY)/$(IKE_IMAGE_NAME):$(IKE_IMAGE_TAG)
+docker-push--%:
+	$(eval image_tag:=$(subst docker-push--,,$@))
+	$(call header,"Pushing docker image $(image_tag)")
+	docker push $(IKE_DOCKER_REGISTRY)/$(IKE_DOCKER_REPOSITORY)/$(IKE_IMAGE_NAME):$(image_tag)
 
 .PHONY: docker-build-test
 docker-build-test: $(BINARY_DIR)/$(TEST_BINARY_NAME) ## Builds the docker test image


### PR DESCRIPTION
#### Short description of what this resolves:

Cleans up docker targets and revamps `make help`.

##### Before

```
╰─ make help
all                          (default) Runs 'deps format lint test compile' targets
build-ci                     Like 'all', but without linter which is executed as separated PR check
clean                        Removes build artifacts
codegen                      Generates operator-sdk code and bundles packages using go-bindata
compile                      Compiles binaries
$(CUR_DIR)/bin/operator-sdk  Downloads operator-sdk cli tool aligned with version defined in Gopkg
deploy-example               Deploys istio-workspace specific resources to defined TEST_NAMESPACE
deploy-operator              Deploys operator resources to defined OPERATOR_NAMESPACE
deploy-test-%                Deploys bookinfo app into defined TEST_NAMESPACE
deps                         Fetches all dependencies
docker-build                 Builds the docker image
docker-build-test            Builds the docker test image
docker-push                  Pushes docker images to the registry
docker-push-latest           Pushes latest docker image to the registry
docker-push-test             Pushes docker image to the registry
docker-push-versioned        Pushes versioned docker image to the registry
format                       Removes unneeded imports and formats source code
lint                         Concurrently runs a whole bunch of static analysis tools
load-istio                   Triggers installation of istio in the cluster
test                         Runs tests
test-e2e                     Runs end-to-end tests
tools                        Installs required go tools
undeploy-example             Undeploys istio-workspace specific resources from defined TEST_NAMESPACE
undeploy-operator            Undeploys operator resources from defined OPERATOR_NAMESPACE
undeploy-test-%              Undeploys bookinfo app into defined TEST_NAMESPACE

```

##### After

```
╰─ make help

Usage:
  make <target>

Default target (all you need - just run "make")
  all                   Runs 'deps format lint test compile' targets

Build
  compile               Compiles binaries
  test                  Runs tests
  clean                 Removes build artifacts
  deps                  Fetches all dependencies
  format                Removes unneeded imports and formats source code
  lint                  Concurrently runs a whole bunch of static analysis tools
  codegen               Generates operator-sdk code and bundles packages using go-bindata

Setup
  tools                 Installs required go tools

Docker
  docker-build          Builds the docker image
  docker-push           Pushes docker images to the registry

Istio operator deployment
  load-istio            Triggers installation of istio in the cluster
  deploy-operator       Deploys istio-workspace operator resources to defined OPERATOR_NAMESPACE
  undeploy-operator     Undeploys istio-workspace operator resources from defined OPERATOR_NAMESPACE

Istio-workspace example deployment
  deploy-example        Deploys istio-workspace specific resources to defined TEST_NAMESPACE
  undeploy-example      Undeploys istio-workspace specific resources from defined TEST_NAMESPACE

Helpers
  help                  Displays this help \o/
```

#### Changes proposed in this pull request:

- introduces wildcard target for pushing operator images
- provides new help creation with ability to "group" related targes. That's very simple approach of groupping targets in the `Makefile` itself in the sections labeled with `##@ Category`, so this will be displayed in the console
- few targets lost `## comment` so that they are not shown when running `make help` - they are simply our internal targets
- minor typos

