### PR TITLE
feat: download script for ike binary

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ curl -sL http://git.io/get-ike | bash
 
 TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s -- --version=v0.0.1 --dir=~/bin`
 
-When logged in to the cluster  simply run:
+When logged in to the cluster simply run:
 
 [source,bash]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,27 @@ More details can be found on our https://istio-workspace-docs.netlify.com/[docum
 
 We use amazing https://antora.org/[Antora] project to build it and you should too!
 
-==== Setup
+=== Install (in two easy steps)
+
+Get latest `ike` binary through simple download script:
+
+[source,bash]
+----
+curl -sL http://git.io/get-ike | bash
+----
+
+TIP: You can also specify the version before executing the script `| VERSION=v0.0.1 bash`
+
+When logged in to the cluster  simply run:
+
+[source,bash]
+----
+ike install-operator
+----
+
+And you are all set!
+
+=== Development Setup
 
 Assuming that you have all the https://golang.org/doc/install[Golang prerequisites] in place, clone the repository first:
 

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ Get latest `ike` binary through simple download script:
 curl -sL http://git.io/get-ike | bash
 ----
 
-TIP: You can also specify the version before executing the script `| VERSION=v0.0.1 bash`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s -- --version=v0.0.1 --dir=~/bin`
 
 When logged in to the cluster  simply run:
 

--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -20,7 +20,7 @@ curl -sL http://git.io/get-ike | bash
 
 to get latest `ike` binary.
 
-TIP: You can also specify the version before executing the script `| VERSION=v0.0.1 bash`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s -- --version=v0.0.1 --dir=~/bin`
 
 == Installing cluster component
 

--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -9,6 +9,19 @@ In this section we walk you through necessary steps to start using `ike`. It wil
 * [x] Ike binary
 * [x] Kubernetes cluster with Istio (i.e. Maistra)
 
+== Installing `ike` CLI
+
+Run:
+
+[source,bash]
+----
+curl -sL http://git.io/get-ike | bash
+----
+
+to get latest `ike` binary.
+
+TIP: You can also specify the version before executing the script `| VERSION=v0.0.1 bash`
+
 == Installing cluster component
 
 Before you can start using CLI we have to add few backend bits to the cluster, so that we can safely swap services you will work on.

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -68,7 +68,7 @@ while test $# -gt 0; do
             if test $# -gt 0; then
               dir=$1
             else
-              die "Please provide a version name"
+              die "Please provide a version"
             fi
             shift
             ;;

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+## Derived from https://github.com/goreleaser/get/blob/03c4bfde763b30bfe270892ab3ff74949d8e9351/get
+
+set -e
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+TAR_FILE="/tmp/ike.tar.gz"
+RELEASES_URL="https://github.com/maistra/istio-workspace/releases"
+
+last_version() {
+  curl -sL -o /dev/null -w %{url_effective} "$RELEASES_URL/latest" |
+    rev |
+    cut -f1 -d'/'|
+    rev
+}
+
+download() {
+  rm -f "$TAR_FILE"
+  curl -s -L -o "$TAR_FILE" \
+    "$RELEASES_URL/download/$VERSION/ike_${VERSION:1}_$(uname -s)_$(uname -m).tar.gz"
+}
+
+test -z "$VERSION" && VERSION="$(last_version)"
+test -z "$VERSION" && {
+  die "Unable to get ike version. You can still try to download manually from $RELEASES_URL"
+}
+test -z "$TMPDIR" && TMPDIR="$(mktemp -d --suffix=-ike-${VERSION})"
+
+download
+tar -xf "$TAR_FILE" -C "$TMPDIR"
+
+echo "Downloaded ike binary to $TMPDIR"
+echo -e "You can add it to your path by typing following in your terminal:\n$ export PATH=\"\$PATH:$TMPDIR\""

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -12,6 +12,17 @@ die () {
 TAR_FILE="/tmp/ike.tar.gz"
 RELEASES_URL="https://github.com/maistra/istio-workspace/releases"
 
+show_help() {
+  echo "get - downloads ike binary matching your operating system"
+  echo " "
+  echo "./get.sh [options]"
+  echo " "
+  echo "Options:"
+  echo "-h, --help          shows brief help"
+  echo "-v, --version       defines version specific version of the binary to download (defaults to latest)"
+  echo "-d, --dir           target directory to which the binary is downloaded (defaults to random tmp dir in /tmp suffixed with ike-version)"
+}
+
 last_version() {
   curl -sL -o /dev/null -w %{url_effective} "$RELEASES_URL/latest" |
     rev |
@@ -20,19 +31,66 @@ last_version() {
 }
 
 download() {
+  version=$1
+  if [[ ${version} == "" ]]; then
+    echo >&2 "Undefined version (pass using -v|--version). Please use semantic version. Read more about it here: https://semver.org/ \n\n"
+    show_help
+    exit 1
+  fi
+
+  url="$RELEASES_URL/download/$version/ike_${version:1}_$(uname -s)_$(uname -m).tar.gz"
+
   rm -f "$TAR_FILE"
-  curl -s -L -o "$TAR_FILE" \
-    "$RELEASES_URL/download/$VERSION/ike_${VERSION:1}_$(uname -s)_$(uname -m).tar.gz"
+  curl -fsLo "$TAR_FILE" "$url" || die "Unable to download $url"
 }
 
-test -z "$VERSION" && VERSION="$(last_version)"
-test -z "$VERSION" && {
-  die "Unable to get ike version. You can still try to download manually from $RELEASES_URL"
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+            show_help
+            exit 0
+            ;;
+    -v)
+            shift
+            if test $# -gt 0; then
+              version=$1
+            else
+              die "Please provide a version name"
+            fi
+            shift
+            ;;
+    --version*)
+            version=`echo $1 | sed -e 's/^[^=]*=//g'`
+            shift
+            ;;
+    -d)
+            shift
+            if test $# -gt 0; then
+              dir=$1
+            else
+              die "Please provide a version name"
+            fi
+            shift
+            ;;
+    --dir*)
+            dir=`echo $1 | sed -e 's/^[^=]*=//g'`
+            shift
+            ;;
+    *)
+            die "Unknown param $1"
+            break
+            ;;
+  esac
+done
+
+test -z "$version" && version="$(last_version)"
+test -z "$version" && {
+  die "Unable to get ike version. You can still try to download it manually from $RELEASES_URL."
 }
-test -z "$TMPDIR" && TMPDIR="$(mktemp -d --suffix=-ike-${VERSION})"
+test -z "$dir" &&  dir="$(mktemp -d --suffix=-ike-${version})"
 
-download
-tar -xf "$TAR_FILE" -C "$TMPDIR"
+download ${version}
+tar -C "$dir" -xzf "$TAR_FILE" ike
 
-echo "Downloaded ike binary to $TMPDIR"
-echo -e "You can add it to your path by typing following in your terminal:\n$ export PATH=\"\$PATH:$TMPDIR\""
+echo "Downloaded ike binary ($version) to $dir"
+echo "Make sure it's on your \$PATH."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,7 +69,7 @@ while test $# -gt 0; do
             if test $# -gt 0; then
               version=$1
             else
-              die "Please provide tag name"
+              die "Please provide version (according https://semver.org/)"
             fi
             shift
             ;;


### PR DESCRIPTION
#### Short description of what this resolves:

`get.sh` script (inspired by [goreleaser](https://github.com/goreleaser/get/blob/03c4bfde763b30bfe270892ab3ff74949d8e9351/get)). It downloads the binary to the and hints how to add it 

It's purposefully called `get.sh` (which is somewhat generic) instead of `download.sh`, because if we evolve it to the actual installer we still can keep `curl -sL http://git.io/get-ike | bash` snippet. The URL has been created for `get.sh` and there's no way to overwrite it in the future.

#### Changes proposed in this pull request:

- general purpose `get.sh` script which will download latest version of the binary for the given system
- update of docs
- update of README


Fixes #116 