### PR TITLE
chore(circleci): bumps golang to latest and introduces yaml anchors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults:
       sudo rm -rf /usr/local/go
       sudo circleci-install golang 1.12.7
   docker:
-    - image: &golang-img circleci/1.12.7
+    - image: &golang-img circleci/golang:1.12.6
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,12 @@
+defaults:
+  golang-install: &golang-install
+    name: "Installs latest Golang"
+    command: |
+      sudo rm -rf /usr/local/go
+      sudo circleci-install golang 1.12.7
+  docker:
+    - image: &golang-img circleci/1.12.7
+
 version: 2.1
 jobs:
 
@@ -5,7 +14,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/maistra/istio-workspace
     docker:
-      - image: circleci/golang:1.12.6
+      - image: *golang-img
     steps:
       - checkout
       - restore_cache:
@@ -45,10 +54,7 @@ jobs:
             sudo service docker restart
             echo "Configured Docker daemon with insecure-registry"
       - run:
-          name: "Installs latest Golang"
-          command: |
-            sudo rm -rf /usr/local/go
-            sudo circleci-install golang 1.12.6
+          <<: *golang-install
       - run:
           name: "Installs telepresence"
           command: |
@@ -100,10 +106,7 @@ jobs:
             gem install asciidoctor
             sudo apt-get install pandoc
       - run:
-          name: "Installs latest Golang"
-          command: |
-            sudo rm -rf /usr/local/go
-            sudo circleci-install golang 1.12.6
+          <<: *golang-install
       - run:
           name: "Installs Golang project prerequisites"
           command: make tools


### PR DESCRIPTION
#### Changes proposed in this pull request:

- bumps golang for circleci to 1.12.7
- introduces re-usable yaml parts for golang (i.e. version in one place)