### PR TITLE
fix(macos): ensures istio-workspace builds on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ PACKAGE_NAME:=github.com/maistra/istio-workspace
 OPERATOR_NAMESPACE?=istio-workspace-operator
 TEST_NAMESPACE?=bookinfo
 
+ifeq ($(shell uname), Linux)
+PLATFORM = linux-gnu
+else
+PLATFORM = apple-darwin
+endif
+
+ARCH:=$(shell uname -m)
+
 CUR_DIR:=$(shell pwd)
 export CUR_DIR
 BUILD_DIR:=$(CUR_DIR)/build
@@ -121,7 +129,7 @@ $(CUR_DIR)/bin/operator-sdk:
 	$(call header,"Installing operator-sdk cli tool")
 	mkdir -p $(CUR_DIR)/bin/
 	$(eval OPERATOR_SDK_VERSION:=$(shell dep status -f='{{if eq .ProjectRoot "github.com/operator-framework/operator-sdk"}}{{.Version}}{{end}}'))
-	wget -c https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu -O $(CUR_DIR)/bin/operator-sdk
+	wget -c https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(ARCH)-$(PLATFORM) -O $(CUR_DIR)/bin/operator-sdk
 	chmod +x $(CUR_DIR)/bin/operator-sdk
 
 $(CUR_DIR)/$(ASSETS): $(ASSET_SRCS)

--- a/Makefile
+++ b/Makefile
@@ -102,17 +102,17 @@ endif
 
 LDFLAGS="-w -X ${PACKAGE_NAME}/version.Version=${VERSION} -X ${PACKAGE_NAME}/version.Commit=${COMMIT} -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}"
 SRCS=$(shell find ./pkg -name "*.go") $(shell find ./cmd -name "*.go") $(shell find ./version -name "*.go")
-
+GOOS?=$(shell uname -s | awk '{print tolower($$0)}')
 $(BINARY_DIR):
 	[ -d $@ ] || mkdir -p $@
 
 $(BINARY_DIR)/$(BINARY_NAME): $(BINARY_DIR) $(SRCS)
 	$(call header,"Compiling... carry on!")
-	GOOS=linux CGO_ENABLED=0 go build -ldflags ${LDFLAGS} -o $@ ./cmd/$(BINARY_NAME)/
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags ${LDFLAGS} -o $@ ./cmd/$(BINARY_NAME)/
 
 $(BINARY_DIR)/$(TEST_BINARY_NAME): $(BINARY_DIR) $(SRCS)
 	$(call header,"Compiling test service... carry on!")
-	GOOS=linux CGO_ENABLED=0 go build -ldflags ${LDFLAGS} -o $@ ./test/cmd/$(TEST_BINARY_NAME)/
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags ${LDFLAGS} -o $@ ./test/cmd/$(TEST_BINARY_NAME)/
 
 ##@ Setup
 
@@ -149,6 +149,7 @@ IKE_DOCKER_REGISTRY?=quay.io
 IKE_DOCKER_REPOSITORY?=maistra
 
 .PHONY: docker-build
+docker-build: GOOS=linux
 docker-build: compile ## Builds the docker image
 	$(call header,"Building docker image $(IKE_IMAGE_NAME)")
 	docker build \

--- a/pkg/cmd/watch/watch_test.go
+++ b/pkg/cmd/watch/watch_test.go
@@ -39,15 +39,16 @@ var _ = Describe("Usage of ike watch command", func() {
 
 		It("should re-build and re-run java process", func() {
 			// given
-			code := TmpFile(GinkgoT(), "/tmp/watch-test/rating.java", "content")
-			telepresenceLog := TmpFile(GinkgoT(), "/tmp/watch-test/telepresence.log", "content")
+			tmpDir := TmpDir(GinkgoT(), "re-run")
+			code := TmpFile(GinkgoT(), tmpDir+"/watch-test/rating.java", "content")
+			telepresenceLog := TmpFile(GinkgoT(), tmpDir+"/watch-test/telepresence.log", "content")
 			outputChan := make(chan string)
 
 			go shell.ExecuteCommand(outputChan, func() (string, error) {
 				return Run(watchCmd).Passing(
 					"--run", "java -jar rating.jar",
 					"--build", "mvn clean install",
-					"--dir", "/tmp/watch-test",
+					"--dir", tmpDir+"/watch-test",
 					// for testing purposes we handle file change events more frequently to avoid excessively long tests
 					"--interval", "10",
 				)
@@ -69,13 +70,14 @@ var _ = Describe("Usage of ike watch command", func() {
 
 		It("should start java process once if only log file is changing", func() {
 			// given
-			logFile := TmpFile(GinkgoT(), "/tmp/watch-test/tomcat.log", "content")
+			tmpDir := TmpDir(GinkgoT(), "start-java")
+			logFile := TmpFile(GinkgoT(), tmpDir+"/watch-test/tomcat.log", "content")
 			outputChan := make(chan string)
 
 			go shell.ExecuteCommand(outputChan, func() (string, error) {
 				return Run(watchCmd).Passing(
 					"--run", "java -jar rating.jar",
-					"--dir", "/tmp/watch-test",
+					"--dir", tmpDir+"/watch-test",
 					// for testing purposes we handle file change events more frequently to avoid excessively long tests
 					"interval", "10",
 				)
@@ -95,7 +97,8 @@ var _ = Describe("Usage of ike watch command", func() {
 
 		It("should build and run java process only initially when changing file is excluded", func() {
 			// given
-			code := TmpFile(GinkgoT(), "/tmp/watch-test/rating.java", "content")
+			tmpDir := TmpDir(GinkgoT(), "build-run-java")
+			code := TmpFile(GinkgoT(), tmpDir+"/watch-test/rating.java", "content")
 			outputChan := make(chan string)
 			go shell.ExecuteCommand(outputChan, func() (string, error) {
 				return Run(watchCmd).Passing(
@@ -122,13 +125,14 @@ var _ = Describe("Usage of ike watch command", func() {
 		})
 
 		It("should ignore build if not defined and just re-run java process on file change", func() {
-			code := TmpFile(GinkgoT(), "/tmp/watch-test/rating.java", "content")
+			tmpDir := TmpDir(GinkgoT(), "ignore-build")
+			code := TmpFile(GinkgoT(), tmpDir+"/watch-test/rating.java", "content")
 
 			outputChan := make(chan string)
 			go shell.ExecuteCommand(outputChan, func() (string, error) {
 				return Run(watchCmd).Passing(
 					"--run", "java -jar rating.jar",
-					"--dir", "/tmp/watch-test",
+					"--dir", tmpDir+"/watch-test",
 					// for testing purposes we handle file change events more frequently to avoid excessively long tests
 					"--interval", "10",
 				)
@@ -149,14 +153,15 @@ var _ = Describe("Usage of ike watch command", func() {
   run: "java -jar config.jar"
   build: "mvn clean install"
 `)
-			code := TmpFile(GinkgoT(), "/tmp/watch-test/rating.java", "content")
+			tmpDir := TmpDir(GinkgoT(), "re-run-no-build")
+			code := TmpFile(GinkgoT(), tmpDir+"/watch-test/rating.java", "content")
 
 			outputChan := make(chan string)
 			go shell.ExecuteCommand(outputChan, func() (string, error) {
 				return Run(watchCmd).Passing(
 					"--config", configFile.Name(),
 					"--no-build",
-					"--dir", "/tmp/watch-test",
+					"--dir", tmpDir+"/watch-test",
 					// for testing purposes we handle file change events more frequently to avoid excessively long tests
 					"--interval", "10",
 				)

--- a/test/tmp_file.go
+++ b/test/tmp_file.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 )
@@ -29,7 +30,8 @@ var appFs = afero.NewOsFs()
 func TmpDir(t TestReporter, dir string) string {
 	fullPath := dir
 	if !path.IsAbs(dir) {
-		fullPath = fmt.Sprintf("%s/%s/%s", os.TempDir(), randomAlphaNumeric(), dir)
+		tmpDir := filepath.Clean(os.TempDir())
+		fullPath = fmt.Sprintf("%s/%s/%s", tmpDir, randomAlphaNumeric(), dir)
 	}
 
 	if err := appFs.MkdirAll(fullPath, os.ModePerm); err != nil {
@@ -48,7 +50,8 @@ func TmpDir(t TestReporter, dir string) string {
 func TmpFile(t TestReporter, filePath, content string) afero.File {
 	fullPath := filePath
 	if !path.IsAbs(filePath) {
-		fullPath = fmt.Sprintf("%s/%s/%s", os.TempDir(), randomAlphaNumeric(), filePath)
+		tmpDir := filepath.Clean(os.TempDir())
+		fullPath = fmt.Sprintf("%s/%s/%s", tmpDir, randomAlphaNumeric(), filePath)
 	}
 
 	if err := appFs.MkdirAll(path.Dir(fullPath), os.ModePerm); err != nil {


### PR DESCRIPTION
#### Short description of what this resolves:

It now works on MacOS \o/

#### Changes proposed in this pull request:


- fix: downloads os-specific operator-sdk
- fix: builds os-specific binaries (and linux for docker)
- fix: proper tmp dir for macOS


Fixes #184 