### PR TITLE
chore(linter): disables gofmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,5 +60,6 @@ issues:
 
 service:
   project-path: github.com/maistra/istio-workspace
+  golangci-lint-version: 1.17.x # Locks the version to avoid newly introduces linters
   prepare:
     - make deps codegen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
   disable:
     - gochecknoinits # k8s/istio generated APIs are using init()
     - gochecknoglobals # TODO discuss
+    - gofmt # We use goimports and when using them both leads to contradicting errors
 
 run:
   deadline: 10m

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -17,6 +17,7 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"github.com/maistra/istio-workspace/pkg/cmd/develop"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -1,22 +1,22 @@
 package main
 
 import (
-	"math/rand"
-	"time"
 
-	"github.com/maistra/istio-workspace/pkg/cmd/completion"
 
 	"github.com/maistra/istio-workspace/pkg/cmd/install"
 	"github.com/maistra/istio-workspace/pkg/cmd/serve"
+	"math/rand"
+	"time"
 	"github.com/maistra/istio-workspace/pkg/cmd/version"
 
-	"github.com/maistra/istio-workspace/pkg/cmd/develop"
+	"github.com/maistra/istio-workspace/pkg/cmd/completion"
 
 	"github.com/maistra/istio-workspace/pkg/cmd/watch"
 
 	"github.com/maistra/istio-workspace/pkg/cmd"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/maistra/istio-workspace/pkg/cmd/develop"
 )
 
 func main() {

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -1,22 +1,17 @@
 package main
 
 import (
-
-
-	"github.com/maistra/istio-workspace/pkg/cmd/install"
-	"github.com/maistra/istio-workspace/pkg/cmd/serve"
 	"math/rand"
 	"time"
-	"github.com/maistra/istio-workspace/pkg/cmd/version"
-
-	"github.com/maistra/istio-workspace/pkg/cmd/completion"
-
-	"github.com/maistra/istio-workspace/pkg/cmd/watch"
 
 	"github.com/maistra/istio-workspace/pkg/cmd"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/maistra/istio-workspace/pkg/cmd/completion"
 	"github.com/maistra/istio-workspace/pkg/cmd/develop"
+	"github.com/maistra/istio-workspace/pkg/cmd/install"
+	"github.com/maistra/istio-workspace/pkg/cmd/serve"
+	"github.com/maistra/istio-workspace/pkg/cmd/version"
+	"github.com/maistra/istio-workspace/pkg/cmd/watch"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 


### PR DESCRIPTION
#### Short description of what this resolves:

Disables `gofmt` linter as it overlaps with `goimports` which we use as `make format`.

#### Changes proposed in this pull request:

- removes gofmt from linters
- locks the version of golangci-lint (service) to avoid newly introduces linters

Fixes #93