### PR TITLE
chore(make): gopath fix + self-install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults:
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   env-vars: &env-vars
-    GOPATH: $HOME/.go_workspace
+    GOPATH: ~/.go_workspace
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults:
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   env-vars: &env-vars
-    GOPATH: ~/.go_workspace
+    GOPATH: /home/circleci/.go_workspace
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,7 @@ jobs:
             - vendor-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs the build"
-          command: |
-            make tools && \
-            make build-ci
+          command: make build-ci
       - save_cache:
           key: vendor-cache-{{ checksum "Gopkg.lock" }}
           paths:
@@ -81,7 +79,7 @@ jobs:
             - vendor-e2e-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs end-to-end tests"
-          command: TELEPRESENCE_VERSION=$(telepresence --version) make tools deps test-e2e
+          command: TELEPRESENCE_VERSION=$(telepresence --version) make deps test-e2e
       - save_cache:
           key: vendor-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
@@ -107,9 +105,6 @@ jobs:
             sudo apt-get install pandoc
       - run:
           <<: *golang-install
-      - run:
-          name: "Installs Golang project prerequisites"
-          command: make tools
       - run:
           name: "Push it!"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed
   e2e_tests:
-    working_directory: $HOME/.go_workspace/src/github.com/maistra/istio-workspace
+    working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
       <<: *machine-conf
     environment:
@@ -92,7 +92,7 @@ jobs:
             - ./vendor
 
   release:
-    working_directory: $HOME/.go_workspace/src/github.com/maistra/istio-workspace
+    working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
       <<: *machine-conf
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ defaults:
       sudo circleci-install golang 1.12.7
   docker:
     - image: &golang-img circleci/golang:1.12.6
+  machine-conf: &machine-conf
+    image: ubuntu-1604:201903-01
+  env-vars: &env-vars
+    GOPATH: $HOME/.go_workspace
 
 version: 2.1
 jobs:
@@ -30,9 +34,11 @@ jobs:
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed
   e2e_tests:
-    working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
+    working_directory: $HOME/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
-      image: ubuntu-1604:201903-01
+      <<: *machine-conf
+    environment:
+      <<: *env-vars
     steps:
       - checkout
       - run:
@@ -86,9 +92,11 @@ jobs:
             - ./vendor
 
   release:
-    working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
+    working_directory: $HOME/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
-      image: ubuntu-1604:201903-01
+      <<: *machine-conf
+    environment:
+      <<: *env-vars
     steps:
       - checkout
       - run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,4 +60,4 @@ issues:
 service:
   project-path: github.com/maistra/istio-workspace
   prepare:
-    - make tools deps codegen
+    - make deps codegen

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - make tools deps codegen
+    - make deps codegen
 builds:
 - env:
   - CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ GROUP_VERSIONS:="istio:v1alpha1"
 .PHONY: codegen
 codegen: $(CUR_DIR)/bin/operator-sdk $(CUR_DIR)/$(ASSETS) ## Generates operator-sdk code and bundles packages using go-bindata
 	$(call header,"Generates operator-sdk code")
-	GOPATH=$(shell echo ${GOPATH} | rev | cut -d':' -f 2 | rev) $(CUR_DIR)/bin/operator-sdk generate k8s
+	GOPATH=$(shell echo ${GOPATH} | rev | cut -d':' -f 1 | rev) $(CUR_DIR)/bin/operator-sdk generate k8s
 	$(call header,"Generates clientset code")
-	GOPATH=$(shell echo ${GOPATH} | rev | cut -d':' -f 2 | rev) ./vendor/k8s.io/code-generator/generate-groups.sh client \
+	GOPATH=$(shell echo ${GOPATH} | rev | cut -d':' -f 1 | rev) ./vendor/k8s.io/code-generator/generate-groups.sh client \
 		$(PACKAGE_NAME)/pkg/client \
 		$(PACKAGE_NAME)/pkg/apis \
 		$(GROUP_VERSIONS)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ ASSET_SRCS=$(shell find ./deploy/istio-workspace -name "*.yaml")
 
 TELEPRESENCE_VERSION?=$(shell telepresence --version)
 
+# Determine this makefile's path.
+# Be sure to place this BEFORE `include` directives, if any.
+THIS_MAKEFILE:=$(lastword $(MAKEFILE_LIST))
+
 # Call this function with $(call header,"Your message") to see underscored green text
 define header =
 @echo -e "\n\e[92m\e[4m\e[1m$(1)\e[0m\n"
@@ -48,7 +52,7 @@ clean: ## Removes build artifacts
 	rm -rf $(BINARY_DIR) $(CUR_DIR)/bin/
 
 .PHONY: deps
-deps: ## Fetches all dependencies
+deps: check-tools ## Fetches all dependencies
 	$(call header,"Fetching dependencies")
 	dep ensure -v
 
@@ -122,6 +126,14 @@ tools: ## Installs required go tools
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/onsi/ginkgo/ginkgo
 	go get -u github.com/go-bindata/go-bindata/...
+
+EXECUTABLES:=dep golangci-lint goimports ginkgo go-bindata
+CHECK:=$(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $(exec) 2>/dev/null),,"install"))
+.PHONY: check-tools
+check-tools:
+	$(call header,"Checking required tools")
+	@$(if $(strip $(CHECK)),$(MAKE) -f $(THIS_MAKEFILE) tools,echo "'$(EXECUTABLES)' are installed")
 
 OPERATOR_OS=linux-gnu
 ifeq ($(OS), Darwin)

--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ Assuming that you have all the https://golang.org/doc/install[Golang prerequisit
 $ git clone https://github.com/maistra/istio-workspace $GOPATH/src/github.com/maistra/istio-workspace
 ----
 
-then run `make tools` which will take care of installing all the tools mentioned below:
+We rely on following tools:
 
 * https://golang.github.io/dep/[`dep`] for dependency management
 * https://github.com/golangci/golangci-lint[`golang-ci`] linter
@@ -46,8 +46,9 @@ then run `make tools` which will take care of installing all the tools mentioned
 * https://godoc.org/golang.org/x/tools/cmd/goimports[`goimports`] for formatting
 * https://github.com/operator-framework/operator-sdk[`operator-sdk`] for code generation
 
-From now on you are ready to hack. Run `make help` to see what targets are available, but you will use
-`make build` and `make test` most often.
+but from now on you are ready to hack - invoking `make` will check if those binaries are available and install if there are some missing.
+
+Run `make help` to see what targets are available, but you will use `make` most often.
 
 NOTE: Have a look how https://github.com/moovweb/gvm[Go Version Manager] can help you simplifying configuration
 and management of different versions of Go.

--- a/docs/modules/ROOT/pages/contribution_guide.adoc
+++ b/docs/modules/ROOT/pages/contribution_guide.adoc
@@ -37,13 +37,17 @@ $ git clone https://github.com/maistra/istio-workspace $GOPATH/src/github.com/ma
 TIP: Have a look how link:https://github.com/moovweb/gvm[Go Version Manager] can help you simplifying configuration
 and management of different versions of Go.
 
-then run `make tools` which will take care of installing all the tools mentioned below:
+We rely on following tools:
 
-* link:https://golang.github.io/dep/[`dep`] for dependency management
-* link:https://github.com/golangci/golangci-lint[`golang-ci`] linter
-* link:https://github.com/onsi/ginkgo[`ginkgo`] for testing
-* link:https://godoc.org/golang.org/x/tools/cmd/goimports[`goimports`] for formatting
-* link:https://github.com/operator-framework/operator-sdk[`operator-sdk`] for code generation
+* https://golang.github.io/dep/[`dep`] for dependency management
+* https://github.com/golangci/golangci-lint[`golang-ci`] linter
+* https://github.com/onsi/ginkgo[`ginkgo`] for testing
+* https://godoc.org/golang.org/x/tools/cmd/goimports[`goimports`] for formatting
+* https://github.com/operator-framework/operator-sdk[`operator-sdk`] for code generation
+
+but from now on you are ready to hack - invoking `make` will check if those binaries are available and install if there are some missing.
+
+Run `make help` to see what targets are available, but you will use `make` most often.
 
 === Coding
 


### PR DESCRIPTION
#### Short description of what this resolves:

Improves make to always check the presence of required binaries (e.g. `dep`) and assumes that GOPATH has always the first part required and then additional workspaces are added afterward.

#### Changes proposed in this pull request:

- assumes `GOPATH` is appended with custom workspaces
- self-installing binaries - no need to call `make tools`
