### PR TITLE
fix(github): minor typos in gh templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 <!--
-Thanks for interest in istio-workspace and apologies for making your experience not yet as awesome as we strive for.  
+Thanks for your interest in istio-workspace and apologies for making your experience not yet as awesome as we strive for.  
 
-Please follow template provided below to report a bug you have encountered and we will make sure to improve it.
+Please follow the template provided below to report a bug you have encountered and we will make sure to improve it.
 
 YOU CAN DELETE THIS TEXT BEFORE SUBMITTING THE ISSUE
 -->
@@ -30,7 +30,7 @@ Tell us briefly what the problem is about.
 
 ##### Additional Information
 
-Anything relevant to help us resolving the problem. For example:
+Anything relevant to help us resolve the problem. For example:
 
   * which version of k8s/openshift you are using
     * output from `kubectl version` or `oc version` accordingly
@@ -38,7 +38,7 @@ Anything relevant to help us resolving the problem. For example:
   * console log or any other relevant information from additional tools such as browser developer tools
   * operator logs (from the cluster)
 
-For long outputs such as stacktraces please use HTML5 `<details>`
+For long outputs such as stack traces please use HTML5 `<details>`
 
 ```
 <details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
 <!-- 
-Many thanks for contributing to istio-workspace! Together we can make the cloud development world better.
+Many thanks for contributing to istio-workspace! Together we can make the cloud development better.
 
 Please tell us what this PR brings following the template we provided. 
-And don't forget to link to the issue (or create one if there is none).
+Also don't forget to link to the issue (or create one if there is none).
 
 If you are still working on the change please but you would like our early feedback, please mark this pull request as draft
+
+You can learn more about "Draft PRs" here https://github.blog/2019-02-14-introducing-draft-pull-requests/
 
 YOU CAN DELETE THIS COMMENT :)
 -->
@@ -17,6 +19,5 @@ YOU CAN DELETE THIS COMMENT :)
 -
 -
 -
-
 
 Fixes #


### PR DESCRIPTION
### Short description of what this resolves:

There were minor typos in our `.github` templates. 

#### Changes proposed in this pull request:

- Typos in bug-report
- Link to Draft PR GH blog in the PR template

Part of #13