### PR TITLE
fix(circleci): aligns golang version between jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults:
       sudo rm -rf /usr/local/go
       sudo circleci-install golang 1.12.7
   docker:
-    - image: &golang-img circleci/golang:1.12.6
+    - image: &golang-img circleci/golang:1.12.7
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   env-vars: &env-vars


### PR DESCRIPTION
It seems I missed the version bump in the last PR. Now both binary `build`, `e2e-tests`, and `release` are using the same go version 1.12.7