### PR TITLE
test(e2e): verifies production route

### DIFF
--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -91,43 +91,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			})
 
 			It("should watch for changes in ratings service and serve it", func() {
-				Eventually(AllPodsNotInState(namespace, "Running"), 3*time.Minute, 2*time.Second).
-					Should(ContainSubstring("No resources found"))
-
-				Eventually(func() (string, error) {
-					return GetBody("http://istio-ingressgateway-istio-system.127.0.0.1.nip.io/productpage")
-				}, 3*time.Minute, 1*time.Second).Should(ContainSubstring("ratings-v1"))
-
-				// given we have details code locally
-				CreateFile(tmpDir+"/ratings.rb", DetailsRuby)
-
-				// when we start ike with watch
-				ikeWithWatch := testshell.ExecuteInDir(tmpDir, "ike", "develop",
-					"--deployment", "ratings-v1",
-					"--port", "9080",
-					"--watch",
-					"--run", "ruby ratings.rb 9080",
-					"--route", "header:x-test-suite=smoke",
-				)
-
-				// ensure the new service is running
-				Eventually(AllPodsNotInState(namespace, "Running"), 3*time.Minute, 2*time.Second).
-					Should(ContainSubstring("No resources found"))
-
-				// and modify the service
-				modifiedDetails := strings.Replace(DetailsRuby, "PublisherA", "Publisher Ike", 1)
-				CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
-
-				// then
-				Eventually(func() (string, error) {
-					fmt.Printf("[%s] checking...\n", time.Now().Format("2006-01-02 15:04:05.001"))
-					return GetBodyWithHeaders("http://istio-ingressgateway-istio-system.127.0.0.1.nip.io/productpage", map[string]string{"x-test-suite": "smoke"})
-				}, 3*time.Minute, 1*time.Second).Should(ContainSubstring("Publisher Ike"))
-
-				stopFailed := ikeWithWatch.Stop()
-				Expect(stopFailed).ToNot(HaveOccurred())
-
-				Eventually(ikeWithWatch.Done(), 1*time.Minute).Should(BeClosed())
+				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
 			})
 
 			It("should watch for changes in ratings service in specified namespace and serve it", func() {
@@ -148,11 +112,13 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 })
 
 func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
+	productPageURL := "http://istio-ingressgateway-istio-system.127.0.0.1.nip.io/productpage"
+
 	Eventually(AllPodsNotInState(namespace, "Running"), 3*time.Minute, 2*time.Second).
 		Should(ContainSubstring("No resources found"))
 
 	Eventually(func() (string, error) {
-		return GetBody("http://istio-ingressgateway-istio-system.127.0.0.1.nip.io/productpage")
+		return GetBody(productPageURL)
 	}, 3*time.Minute, 1*time.Second).Should(ContainSubstring("ratings-v1"))
 
 	// switch to different namespace
@@ -180,16 +146,22 @@ func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
 	modifiedDetails := strings.Replace(DetailsRuby, "PublisherA", "Publisher Ike", 1)
 	CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-	// then
-	Eventually(func() (string, error) {
-		fmt.Printf("[%s] checking...\n", time.Now().Format("2006-01-02 15:04:05.001"))
-		return GetBodyWithHeaders("http://istio-ingressgateway-istio-system.127.0.0.1.nip.io/productpage", map[string]string{"x-test-suite": "smoke"})
-	}, 3*time.Minute, 1*time.Second).Should(ContainSubstring("Publisher Ike"))
+	// then check modified route
+	Eventually(verifyRoute(productPageURL, map[string]string{"x-test-suite": "smoke"}), 3*time.Minute, 1*time.Second).Should(ContainSubstring("Publisher Ike"))
+	// but also check if prod is intact
+	Eventually(verifyRoute(productPageURL, map[string]string{}), 3*time.Minute, 1*time.Second).Should(ContainSubstring("PublisherA"))
 
 	stopFailed := ikeWithWatch.Stop()
 	Expect(stopFailed).ToNot(HaveOccurred())
 
 	Eventually(ikeWithWatch.Done(), 1*time.Minute).Should(BeClosed())
+}
+
+func verifyRoute(rawUrl string, headers map[string]string) func() (string, error) {
+	return func() (string, error) {
+		fmt.Printf("[%s] Checking [%s] with headers [%s]...\n", time.Now().Format("2006-01-02 15:04:05.001"), rawUrl, headers)
+		return GetBodyWithHeaders(rawUrl, headers)
+	}
 }
 
 func callGetOn(name string) func() (string, error) {

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -159,7 +159,7 @@ func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
 	Eventually(ikeWithWatch.Done(), 1*time.Minute).Should(BeClosed())
 }
 
-func call(routeURL string, headers map[string]string) func() (string, error) {
+func call(routeURL string, headers map[string]string) func() (string, error) { //nolint[:unparam]
 	return func() (string, error) {
 		fmt.Printf("[%s] Checking [%s] with headers [%s]...\n", time.Now().Format("2006-01-02 15:04:05.001"), routeURL, headers)
 		return GetBodyWithHeaders(routeURL, headers)


### PR DESCRIPTION
#### Short description of what this resolves:

Our e2e tests covered only happy path so far (calling modified service with expected header). We missed verification of official prod route as well as the response from the service prior to modification in developer's route.

#### Changes proposed in this pull request:

- Checks production route
- Checks dev route prior to applying changes
- Minor test code cleanups

Fixes #143
