### PR TITLE
feat(template): externalize cloning of target resource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1080,6 +1080,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/evanphx/json-patch",
     "github.com/fsnotify/fsnotify",
     "github.com/go-cmd/cmd",
     "github.com/go-logr/logr",

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -98,13 +98,13 @@ func cloneDeployment(deployment *appsv1.Deployment, version string) (*appsv1.Dep
 		tpVersion = "0.101"
 	}
 
-	org, err := json.Marshal(deployment)
+	originalDeployment, err := json.Marshal(deployment)
 	if err != nil {
 		return nil, err
 	}
 
 	e := template.NewDefaultEngine()
-	modified, err := e.Run("telepresence", org, version, map[string]string{
+	modifiedDeployment, err := e.Run("telepresence", originalDeployment, version, map[string]string{
 		"TelepresenceVersion": tpVersion,
 	})
 	if err != nil {
@@ -112,7 +112,7 @@ func cloneDeployment(deployment *appsv1.Deployment, version string) (*appsv1.Dep
 	}
 
 	clone := appsv1.Deployment{}
-	err = json.Unmarshal(modified, &clone)
+	err = json.Unmarshal(modifiedDeployment, &clone)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -61,7 +61,7 @@ func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error { //nolin
 	}
 	err = ctx.Client.Create(ctx, deploymentClone)
 	if err != nil {
-		ctx.Log.Info("Failed to clone Deployment", "name", deploymentClone.Name)
+		ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)
 		ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentKind, Name: deploymentClone.Name, Action: model.ActionFailed})
 		return err
 	}

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 						Labels: map[string]string{
 							"version": "0.0.1",
 						},
+						CreationTimestamp: metav1.Now(),
 					},
 
 					Spec: appsv1.DeploymentSpec{
@@ -198,6 +199,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 						Labels: map[string]string{
 							"version": "0.0.1",
 						},
+						CreationTimestamp: metav1.Now(),
 					},
 
 					Spec: appsv1.DeploymentSpec{

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -70,6 +70,9 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 		BeforeEach(func() {
 			objects = []runtime.Object{
 				&appsv1.Deployment{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "Deployment",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-ref",
 						Namespace: "test",
@@ -144,6 +147,18 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
+		})
+
+		It("should update selector", func() {
+			ref := CreateTestRef()
+			mutatorErr := k8s.DeploymentMutator(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			deployment := appsv1.Deployment{}
+			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
+			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo("v1-test"))
 		})
 
 		It("should only mutate if Target is of kind Deployment", func() {

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -103,13 +103,13 @@ func cloneDeployment(deployment *appsv1.DeploymentConfig, version string) (*apps
 		tpVersion = "0.101"
 	}
 
-	org, err := json.Marshal(deployment)
+	originalDeployment, err := json.Marshal(deployment)
 	if err != nil {
 		return nil, err
 	}
 
 	e := template.NewDefaultEngine()
-	modified, err := e.Run("telepresence", org, version, map[string]string{
+	modifiedDeployment, err := e.Run("telepresence", originalDeployment, version, map[string]string{
 		"TelepresenceVersion": tpVersion,
 	})
 	if err != nil {
@@ -117,7 +117,7 @@ func cloneDeployment(deployment *appsv1.DeploymentConfig, version string) (*apps
 	}
 
 	clone := appsv1.DeploymentConfig{}
-	err = json.Unmarshal(modified, &clone)
+	err = json.Unmarshal(modifiedDeployment, &clone)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -1,14 +1,15 @@
 package openshift
 
 import (
+	"encoding/json"
 	"os"
 
 	"github.com/maistra/istio-workspace/pkg/apis"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/template"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,10 +59,14 @@ func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error { /
 	}
 	ctx.Log.Info("Found DeploymentConfig", "name", ref.Target.Name)
 
-	deploymentClone := cloneDeployment(deployment.DeepCopy(), ref.Target.GetNewVersion(ctx.Name))
+	deploymentClone, err := cloneDeployment(deployment.DeepCopy(), ref.Target.GetNewVersion(ctx.Name))
+	if err != nil {
+		ctx.Log.Info("Failed to clone DeploymentConfig", "name", deployment.Name)
+		return err
+	}
 	err = ctx.Client.Create(ctx, deploymentClone)
 	if err != nil {
-		ctx.Log.Info("Failed to clone DeploymentConfig", "name", deploymentClone.Name)
+		ctx.Log.Info("Failed to create cloned DeploymentConfig", "name", deploymentClone.Name)
 		ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentConfigKind, Name: deploymentClone.Name, Action: model.ActionFailed})
 		return err
 	}
@@ -92,43 +97,31 @@ func DeploymentConfigRevertor(ctx model.SessionContext, ref *model.Ref) error { 
 	return nil
 }
 
-func cloneDeployment(deployment *appsv1.DeploymentConfig, version string) *appsv1.DeploymentConfig {
-	deploymentClone := deployment.DeepCopy()
-	labelsClone := deploymentClone.Spec.Selector
-	labelsClone["telepresence"] = "test"
-	labelsClone["version-source"] = labelsClone["version"]
-	labelsClone["version"] = version
-	deploymentClone.SetName(deployment.GetName() + "-" + version)
-	deploymentClone.SetLabels(labelsClone)
-	deploymentClone.Spec.Selector = labelsClone
-	deploymentClone.Spec.Template.SetLabels(labelsClone)
-	deploymentClone.SetResourceVersion("")
-	deploymentClone.Spec.Replicas = 1
-
+func cloneDeployment(deployment *appsv1.DeploymentConfig, version string) (*appsv1.DeploymentConfig, error) {
 	tpVersion, found := os.LookupEnv("TELEPRESENCE_VERSION")
 	if !found {
 		tpVersion = "0.101"
 	}
 
-	container := deploymentClone.Spec.Template.Spec.Containers[0]
-	container.Image = "datawire/telepresence-k8s:" + tpVersion
+	org, err := json.Marshal(deployment)
+	if err != nil {
+		return nil, err
+	}
 
-	container.Env = append(container.Env, corev1.EnvVar{
-		Name: "TELEPRESENCE_CONTAINER_NAMESPACE",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				APIVersion: "v1",
-				FieldPath:  "metadata.namespace",
-			},
-		},
+	e := template.NewDefaultEngine()
+	modified, err := e.Run("telepresence", org, version, map[string]string{
+		"TelepresenceVersion": tpVersion,
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	// remove unneeded fields
-	container.LivenessProbe = nil
-	container.ReadinessProbe = nil
-
-	deploymentClone.Spec.Template.Spec.Containers[0] = container
-	return deploymentClone
+	clone := appsv1.DeploymentConfig{}
+	err = json.Unmarshal(modified, &clone)
+	if err != nil {
+		return nil, err
+	}
+	return &clone, nil
 }
 
 func getDeploymentConfig(ctx model.SessionContext, namespace, name string) (*appsv1.DeploymentConfig, error) { //nolint[:hugeParam]

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -86,10 +86,16 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 						Labels: map[string]string{
 							"version": "0.0.1",
 						},
+						CreationTimestamp: metav1.Now(),
 					},
 					Spec: appsv1.DeploymentConfigSpec{
 						Selector: map[string]string{"A": "A"},
 						Template: &v1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"version": "0.0.1",
+								},
+							},
 							Spec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
@@ -205,6 +211,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 						Labels: map[string]string{
 							"version": "0.0.1",
 						},
+						CreationTimestamp: metav1.Now(),
 					},
 					Spec: appsv1.DeploymentConfigSpec{
 						Selector: map[string]string{"A": "A"},

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,0 +1,265 @@
+package template
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+// NewDefaultEngine returns a new Engine with a predefined templates
+func NewDefaultEngine() *Engine {
+	patchs := []Patch{
+		Patch{
+			Name: "telepresence",
+			Template: []byte(`[
+				{{ if not (.Data.Has "/spec/template/metadata") }}
+				{"op": "add", "path": "/spec/template/metadata", "value": {}},
+				{{ end }}
+				{{ if not (.Data.Has "/spec/template/metadata/labels") }}
+				{"op": "add", "path": "/spec/template/metadata/labels", "value": {}},
+				{{ end }}
+				{{ if .Data.Has "/spec/template/metadata/labels/version" }}
+				{"op": "copy", "from": "/spec/template/metadata/labels/version", "path": "/spec/template/metadata/labels/version-source"},
+				{"op": "replace", "path": "/spec/template/metadata/labels/version", "value": "{{.NewVersion}}"},
+				{{ end }}
+				{{ if not (.Data.Has "/spec/template/metadata/labels/version") }}
+				{"op": "add", "path": "/spec/template/metadata/labels/version", "value": "{{.NewVersion}}"},
+				{{ end }}
+				{{ if not (.Data.Has "/spec/selector") }}
+				{"op": "add", "path": "/spec/selector", "value": {}},
+				{{ end }}
+				{{ if .Data.Equal "/metadata/kind" "Deployment" }}
+					{{ if not (.Data.Has "/spec/selector/matchLabels") }}
+					{"op": "add", "path": "/spec/selector/matchLabels", "value": {}},
+					{{ end }}
+					{{ if .Data.Has "/spec/selector/matchLabels/version" }}
+					{"op": "replace", "path": "/spec/selector/matchLabels/version", "value": "{{.NewVersion}}"},
+					{{ end }}
+					{{ if not (.Data.Has "/spec/selector/matchLabels/version") }}
+					{"op": "add", "path": "/spec/selector/matchLabels/version", "value": "{{.NewVersion}}"},
+					{{ end }}
+				{{ end }}
+				{{ if .Data.Equal "/metadata/kind" "DeploymentKind" }}
+					{{ if .Data.Has "/spec/selector/version" }}
+					{"op": "replace", "path": "/spec/selector/version", "value": "{{.NewVersion}}"},
+					{{ end }}
+					{{ if not (.Data.Has "/spec/selector/version") }}
+					{"op": "add", "path": "/spec/selector/version", "value": "{{.NewVersion}}"},
+					{{ end }}
+				{{ end }}
+				{{ if .Data.Has "/metadata/labels/version" }}
+				{"op": "replace", "path": "/metadata/labels/version", "value": "{{.NewVersion}}"},
+				{{ end }}
+				{"op": "replace", "path": "/metadata/name", "value": "{{.Data.Value "/metadata/name"}}-{{.NewVersion}}"},
+				{"op": "replace", "path": "/spec/template/spec/replicas", "value": "1"},
+
+				{"op": "add", "path": "/spec/template/metadata/labels/telepresence", "value": "test"},
+				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "datawire/telepresence-k8s:{{.Vars.TelepresenceVersion}}"},
+				{{ if not (.Data.Has "/spec/template/spec/containers/0/env") }}
+				{"op": "add", "path": "/spec/template/spec/containers/0/env", "value": []},
+				{{ end }}
+				{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
+					"name": "TELEPRESENCE_CONTAINER_NAMESPACE",
+					"valueFrom": {
+						"fieldRef": {
+							"apiVersion": "v1",
+							"fieldPath": "metadata.namespace"
+						}
+					}
+				}
+				},
+				{{ if .Data.Has "/spec/template/spec/containers/0/livenessProbe" }}
+				{"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"},
+				{{ end }}
+				{{ if .Data.Has "/spec/template/spec/containers/0/readinessProbe" }}
+				{"op": "remove", "path": "/spec/template/spec/containers/0/readinessProbe"},
+				{{ end }}
+
+					{{ template "basic-remove" . }}
+				]`),
+			Variables: map[string]string{
+				"TelepresenceVersion": "y",
+			},
+		},
+		Patch{
+			Name: "basic-remove",
+			Template: []byte(`
+				{{ if .Data.Has "/metadata/resourceVersion" }}
+				{"op": "remove", "path": "/metadata/resourceVersion"},
+				{{ end }}
+				{{ if .Data.Has "/metadata/generation" }}
+				{"op": "remove", "path": "/metadata/generation"},
+				{{ end }}
+				{{ if .Data.Has "/metadata/uid" }}
+				{"op": "remove", "path": "/metadata/uid"},
+				{{ end }}
+				{{ if .Data.Has "/metadata/creationTimestamp" }}
+				{"op": "remove", "path": "/metadata/creationTimestamp"}
+				{{ end }}
+			`),
+		},
+	}
+	return NewEngine(patchs)
+}
+
+// NewEngine constructs a new Engine with the given templates
+func NewEngine(patchs Patchs) *Engine {
+	return &Engine{patches: patchs}
+}
+
+func newJSON(data []byte) (JSON, error) {
+	t := JSON{}
+	err := json.Unmarshal(data, &t)
+	return t, err
+}
+
+// JSON is a parsed json structure with helper functions to access the data based on json paths.
+type JSON map[string]interface{}
+
+// Context contain the template context used during conversion. Holds template variables and data.
+type Context struct {
+	NewVersion string
+	Data       JSON
+	Vars       map[string]string
+}
+
+// Patch is a named JSON Patch and it's defined default variables.
+type Patch struct {
+	Name      string
+	Template  []byte
+	Variables map[string]string
+}
+
+// Patchs holds all known patch templates for a Engine
+type Patchs []Patch
+
+// Engine is a reusable instance with a configured set of patch templates
+type Engine struct {
+	patches Patchs
+}
+
+// Value returns the object value behind a json path, e.g. /spec/metadata/name
+func (t JSON) Value(path string) (interface{}, error) {
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("given path is not valid")
+	}
+	parts = parts[1:]
+	var level interface{} = t
+	for i, part := range parts {
+		var l interface{}
+		switch v := level.(type) {
+		case map[string]interface{}:
+			l = v[part]
+		case JSON:
+			l = v[part]
+		case []interface{}:
+			p, err := strconv.ParseInt(part, 10, 0)
+			if err != nil {
+				return nil, err
+			}
+			l = v[p]
+		}
+
+		switch v := l.(type) {
+		case map[string]interface{}, []interface{}:
+			level = v
+		default:
+			if i == len(parts)-1 {
+				return l, nil
+			}
+			return nil, nil
+		}
+	}
+	return level, nil
+}
+
+// Has is a check if the json contain a value behind a json path, e.g. /spec/metadata/name
+func (t JSON) Has(path string) bool {
+	v, err := t.Value(path)
+	if err != nil || v == nil {
+		return false
+	}
+	return true
+}
+
+// Equal checks if the values are the same
+func (t JSON) Equal(path string, compare interface{}) bool {
+	v, err := t.Value(path)
+	if err != nil || v == nil {
+		return false
+	}
+
+	return fmt.Sprint(v) == fmt.Sprint(compare)
+}
+
+// Run performs the template transformation of a given json structure
+func (e Engine) Run(name string, resource []byte, newVersion string, variables map[string]string) ([]byte, error) {
+	t, err := loadTemplate(e.patches)
+	if err != nil {
+		return nil, err
+	}
+
+	patchVariables := map[string]string{}
+	// Load default variables
+	defaultVariables := map[string]string{}
+	for _, p := range e.patches {
+		if p.Name == name {
+			defaultVariables = p.Variables
+		}
+	}
+	for k, v := range defaultVariables {
+		patchVariables[k] = v
+	}
+	for k, v := range variables {
+		patchVariables[k] = v
+	}
+
+	resourceData, err := newJSON(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	c := Context{
+		Data:       resourceData,
+		NewVersion: newVersion,
+		Vars:       patchVariables,
+	}
+
+	// Run Template
+	rawPatch := new(bytes.Buffer)
+	err = t.ExecuteTemplate(rawPatch, name, c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply patch
+	patch, err := jsonpatch.DecodePatch(rawPatch.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	modified, err := patch.ApplyIndent(resource, "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return modified, nil
+}
+
+func loadTemplate(patches Patchs) (*template.Template, error) {
+	var err error
+	t := template.New("workspace")
+	for _, p := range patches {
+		t, err = t.New(p.Name).Parse(string(p.Template))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -13,7 +13,7 @@ import (
 
 // NewDefaultEngine returns a new Engine with a predefined templates
 func NewDefaultEngine() *Engine {
-	patchs := []Patch{
+	patches := []Patch{
 		Patch{
 			Name: "telepresence",
 			Template: []byte(`[
@@ -104,12 +104,12 @@ func NewDefaultEngine() *Engine {
 			`),
 		},
 	}
-	return NewEngine(patchs)
+	return NewEngine(patches)
 }
 
 // NewEngine constructs a new Engine with the given templates
-func NewEngine(patchs Patchs) *Engine {
-	return &Engine{patches: patchs}
+func NewEngine(patches Patches) *Engine {
+	return &Engine{patches: patches}
 }
 
 // NewJSON constructs a JSON object from a json string
@@ -136,12 +136,12 @@ type Patch struct {
 	Variables map[string]string
 }
 
-// Patchs holds all known patch templates for a Engine
-type Patchs []Patch
+// Patches holds all known patch templates for a Engine
+type Patches []Patch
 
 // Engine is a reusable instance with a configured set of patch templates
 type Engine struct {
-	patches Patchs
+	patches Patches
 }
 
 // Value returns the object value behind a json path, e.g. /spec/metadata/name
@@ -253,7 +253,7 @@ func (e Engine) Run(name string, resource []byte, newVersion string, variables m
 	return modified, nil
 }
 
-func loadTemplate(patches Patchs) (*template.Template, error) {
+func loadTemplate(patches Patches) (*template.Template, error) {
 	var err error
 	t := template.New("workspace")
 	for _, p := range patches {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -33,7 +33,7 @@ func NewDefaultEngine() *Engine {
 				{{ if not (.Data.Has "/spec/selector") }}
 				{"op": "add", "path": "/spec/selector", "value": {}},
 				{{ end }}
-				{{ if .Data.Equal "/metadata/kind" "Deployment" }}
+				{{ if .Data.Equal "/kind" "Deployment" }}
 					{{ if not (.Data.Has "/spec/selector/matchLabels") }}
 					{"op": "add", "path": "/spec/selector/matchLabels", "value": {}},
 					{{ end }}
@@ -44,7 +44,7 @@ func NewDefaultEngine() *Engine {
 					{"op": "add", "path": "/spec/selector/matchLabels/version", "value": "{{.NewVersion}}"},
 					{{ end }}
 				{{ end }}
-				{{ if .Data.Equal "/metadata/kind" "DeploymentKind" }}
+				{{ if .Data.Equal "/kind" "DeploymentConfig" }}
 					{{ if .Data.Has "/spec/selector/version" }}
 					{"op": "replace", "path": "/spec/selector/version", "value": "{{.NewVersion}}"},
 					{{ end }}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -112,7 +112,8 @@ func NewEngine(patchs Patchs) *Engine {
 	return &Engine{patches: patchs}
 }
 
-func newJSON(data []byte) (JSON, error) {
+// NewJSON constructs a JSON object from a json string
+func NewJSON(data []byte) (JSON, error) {
 	t := JSON{}
 	err := json.Unmarshal(data, &t)
 	return t, err
@@ -220,7 +221,7 @@ func (e Engine) Run(name string, resource []byte, newVersion string, variables m
 		patchVariables[k] = v
 	}
 
-	resourceData, err := newJSON(resource)
+	resourceData, err := NewJSON(resource)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/template/template_suite_test.go
+++ b/pkg/template/template_suite_test.go
@@ -1,0 +1,24 @@
+package template_test
+
+import (
+	"testing"
+
+	. "github.com/maistra/istio-workspace/test"
+
+	"go.uber.org/goleak"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecWithJUnitReporter(t, "Template Suite")
+}
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Operations for template system", func() {
 		)
 
 		BeforeEach(func() {
-			tj, err = template.NewJSON([]byte(org))
+			tj, err = template.NewJSON([]byte(testDeployment))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -102,7 +102,7 @@ var _ = Describe("Operations for template system", func() {
 		It("happy, happy, basic DefaultEngine", func() {
 			e := template.NewDefaultEngine()
 
-			o, err := e.Run("telepresence", []byte(org), "1000", map[string]string{
+			o, err := e.Run("telepresence", []byte(testDeployment), "1000", map[string]string{
 				"TelepresenceVersion": "x",
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("Operations for template system", func() {
 	})
 })
 
-var org = `
+var testDeployment = `
 {
     "apiVersion": "extensions/v1beta1",
     "kind": "Deployment",

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,0 +1,162 @@
+package template
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTemplateJSONValue(t *testing.T) {
+	tj, err := newJSON([]byte(org))
+	if err != nil {
+		t.Error(err)
+	}
+	if !tj.Has("/metadata/creationTimestamp") {
+		t.Error("creationTimestamp not found")
+	}
+	if v, _ := tj.Value("/spec/replicas"); v.(float64) != 1 {
+		t.Error("replicas not found")
+	}
+
+	if v, _ := tj.Value("/metadata/labels/version"); v.(string) != "v1" {
+		t.Error("version not found")
+	}
+
+	if !tj.Equal("/metadata/labels/version", "v1") {
+		t.Error("version not equal")
+	}
+
+	if v, _ := tj.Value("/spec/template/spec/containers/0/env/0/value"); v.(string) != "productpage-v1" {
+		t.Error("env not found")
+	}
+}
+
+func TestX(t *testing.T) {
+
+	e := NewDefaultEngine()
+
+	modified, err := e.Run("telepresence", []byte(org), "1000", map[string]string{
+		"TelepresenceVersion": "x",
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Printf("Modified document: %s\n", modified)
+}
+
+var org = `
+{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1",
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\"}\n"
+        },
+        "creationTimestamp": "2019-07-13T08:46:46Z",
+        "generation": 1,
+        "labels": {
+            "app": "productpage",
+            "version": "v1"
+        },
+        "name": "productpage-v1",
+        "namespace": "bookinfo",
+        "resourceVersion": "638482",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/bookinfo/deployments/productpage-v1",
+        "uid": "bf2a3655-a54a-11e9-b309-482ae3045b54"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 1,
+        "revisionHistoryLimit": 10,
+        "selector": {
+                "app": "productpage",
+                "version": "v1"
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": 1,
+                "maxUnavailable": 1
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "annotations": {
+                    "kiali.io/runtimes": "go",
+                    "prometheus.io/path": "/metrics",
+                    "prometheus.io/port": "9080",
+                    "prometheus.io/scheme": "http",
+                    "prometheus.io/scrape": "true",
+                    "sidecar.istio.io/inject": "true"
+                },
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "productpage",
+                    "version": "v1"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "SERVICE_NAME",
+                                "value": "productpage-v1"
+                            },
+                            {
+                                "name": "HTTP_ADDR",
+                                "value": ":9080"
+                            },
+                            {
+                                "name": "SERVICE_CALL",
+                                "value": "http://reviews:9080/"
+                            }
+                        ],
+                        "image": "docker.io/aslakknutsen/istio-workspace-test:latest",
+                        "imagePullPolicy": "Always",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 9080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 1,
+                            "periodSeconds": 3,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "name": "productpage",
+                        "ports": [
+                            {
+                                "containerPort": 9080,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 9080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 1,
+                            "periodSeconds": 3,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    }
+}
+`

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Operations for template system", func() {
 			It("should get value in slice", func() {
 				v, err := tj.Value("/spec/template/spec/containers/0")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(v).ToNot(BeNil())
+				Expect(v).ToNot(BeEmpty())
 			})
 			It("should get value in child of slice", func() {
 				v, err := tj.Value("/spec/template/spec/containers/0/env/0/value")

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Operations for template system", func() {
 
 		Context("object validation", func() {
 			It("should fail on wrong Patch format", func() {
-				e := template.NewEngine(template.Patchs{template.Patch{
+				e := template.NewEngine(template.Patches{template.Patch{
 					Name:     "test",
 					Template: []byte("{"),
 				}})
@@ -121,7 +121,7 @@ var _ = Describe("Operations for template system", func() {
 			})
 
 			It("should fail on wrong Patch format", func() {
-				e := template.NewEngine(template.Patchs{template.Patch{
+				e := template.NewEngine(template.Patches{template.Patch{
 					Name:     "test",
 					Template: []byte("[]"),
 				}})
@@ -134,7 +134,7 @@ var _ = Describe("Operations for template system", func() {
 		Context("normal operations", func() {
 
 			It("should apply patch", func() {
-				e := template.NewEngine(template.Patchs{template.Patch{
+				e := template.NewEngine(template.Patches{template.Patch{
 					Name:      "test",
 					Template:  []byte(`[ {"op": "remove", "path": "/version"} ]`),
 					Variables: map[string]string{},
@@ -145,7 +145,7 @@ var _ = Describe("Operations for template system", func() {
 			})
 
 			It("should fail on bad patch", func() {
-				e := template.NewEngine(template.Patchs{template.Patch{
+				e := template.NewEngine(template.Patches{template.Patch{
 					Name:      "test",
 					Template:  []byte(`[ {"op": "remove", "path": "/test"} ]`),
 					Variables: map[string]string{},
@@ -159,7 +159,7 @@ var _ = Describe("Operations for template system", func() {
 		Context("variables", func() {
 
 			It("should use default values if non provided", func() {
-				e := template.NewEngine(template.Patchs{template.Patch{
+				e := template.NewEngine(template.Patches{template.Patch{
 					Name:     "test",
 					Template: []byte(`[ {"op": "replace", "path": "/version", "value": "{{.Vars.Version}}"} ]`),
 					Variables: map[string]string{
@@ -172,7 +172,7 @@ var _ = Describe("Operations for template system", func() {
 			})
 
 			It("should override with incomming is available", func() {
-				e := template.NewEngine(template.Patchs{template.Patch{
+				e := template.NewEngine(template.Patches{template.Patch{
 					Name:     "test",
 					Template: []byte(`[ {"op": "replace", "path": "/version", "value": "{{.Vars.Version}}"} ]`),
 					Variables: map[string]string{


### PR DESCRIPTION
Use Go Templates to generate JSON Patch(rfc6902) objects to apply
to the target resource during mutation.

fixes #202

- [x] Test template.JSON operations
- [x] Test template.Engine