### PR TITLE
feat(strategy): support setting up a route for a prepared image

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -21,8 +21,50 @@ func NewDefaultEngine() *Engine {
 
 	patches := []Patch{
 		{
+			Name: "preparedimage",
+			Template: []byte(`[
+					{{ template "basic-version" . }}
+
+				{"op": "replace", "path": "/spec/template/spec/replicas", "value": "1"},
+				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "{{.Vars.image}}"},
+
+					{{ template "basic-remove" . }}
+				]`),
+			Variables: map[string]string{
+				"image": "",
+			},
+		},
+		{
 			Name: "telepresence",
 			Template: []byte(`[
+					{{ template "basic-version" . }}
+
+				{"op": "replace", "path": "/spec/template/spec/replicas", "value": "1"},
+
+				{"op": "add", "path": "/spec/template/metadata/labels/telepresence", "value": "test"},
+				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "datawire/telepresence-k8s:{{.Vars.Version}}"},
+				{{ if not (.Data.Has "/spec/template/spec/containers/0/env") }}
+				{"op": "add", "path": "/spec/template/spec/containers/0/env", "value": []},
+				{{ end }}
+				{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
+					"name": "TELEPRESENCE_CONTAINER_NAMESPACE",
+					"valueFrom": {
+						"fieldRef": {
+							"apiVersion": "v1",
+							"fieldPath": "metadata.namespace"
+						}
+					}
+				}
+				},
+					{{ template "basic-remove" . }}
+				]`),
+			Variables: map[string]string{
+				"Version": tpVersion,
+			},
+		},
+		{
+			Name: "basic-version",
+			Template: []byte(`
 				{{ if not (.Data.Has "/spec/template/metadata") }}
 				{"op": "add", "path": "/spec/template/metadata", "value": {}},
 				{{ end }}
@@ -62,39 +104,17 @@ func NewDefaultEngine() *Engine {
 				{"op": "replace", "path": "/metadata/labels/version", "value": "{{.NewVersion}}"},
 				{{ end }}
 				{"op": "replace", "path": "/metadata/name", "value": "{{.Data.Value "/metadata/name"}}-{{.NewVersion}}"},
-				{"op": "replace", "path": "/spec/template/spec/replicas", "value": "1"},
-
-				{"op": "add", "path": "/spec/template/metadata/labels/telepresence", "value": "test"},
-				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "datawire/telepresence-k8s:{{.Vars.Version}}"},
-				{{ if not (.Data.Has "/spec/template/spec/containers/0/env") }}
-				{"op": "add", "path": "/spec/template/spec/containers/0/env", "value": []},
-				{{ end }}
-				{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
-					"name": "TELEPRESENCE_CONTAINER_NAMESPACE",
-					"valueFrom": {
-						"fieldRef": {
-							"apiVersion": "v1",
-							"fieldPath": "metadata.namespace"
-						}
-					}
-				}
-				},
+			`),
+		},
+		{
+			Name: "basic-remove",
+			Template: []byte(`
 				{{ if .Data.Has "/spec/template/spec/containers/0/livenessProbe" }}
 				{"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"},
 				{{ end }}
 				{{ if .Data.Has "/spec/template/spec/containers/0/readinessProbe" }}
 				{"op": "remove", "path": "/spec/template/spec/containers/0/readinessProbe"},
 				{{ end }}
-
-					{{ template "basic-remove" . }}
-				]`),
-			Variables: map[string]string{
-				"Version": tpVersion,
-			},
-		},
-		{
-			Name: "basic-remove",
-			Template: []byte(`
 				{{ if .Data.Has "/metadata/resourceVersion" }}
 				{"op": "remove", "path": "/metadata/resourceVersion"},
 				{{ end }}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -21,14 +21,14 @@ func NewDefaultEngine() *Engine {
 
 	patches := []Patch{
 		{
-			Name: "preparedimage",
+			Name: "prepared-image",
 			Template: []byte(`[
-					{{ template "basic-version" . }}
+					{{ template "_basic-version" . }}
 
 				{"op": "replace", "path": "/spec/template/spec/replicas", "value": "1"},
 				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "{{.Vars.image}}"},
 
-					{{ template "basic-remove" . }}
+					{{ template "_basic-remove" . }}
 				]`),
 			Variables: map[string]string{
 				"image": "",
@@ -37,12 +37,12 @@ func NewDefaultEngine() *Engine {
 		{
 			Name: "telepresence",
 			Template: []byte(`[
-					{{ template "basic-version" . }}
+					{{ template "_basic-version" . }}
 
 				{"op": "replace", "path": "/spec/template/spec/replicas", "value": "1"},
 
 				{"op": "add", "path": "/spec/template/metadata/labels/telepresence", "value": "test"},
-				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "datawire/telepresence-k8s:{{.Vars.Version}}"},
+				{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "datawire/telepresence-k8s:{{.Vars.version}}"},
 				{{ if not (.Data.Has "/spec/template/spec/containers/0/env") }}
 				{"op": "add", "path": "/spec/template/spec/containers/0/env", "value": []},
 				{{ end }}
@@ -56,14 +56,14 @@ func NewDefaultEngine() *Engine {
 					}
 				}
 				},
-					{{ template "basic-remove" . }}
+					{{ template "_basic-remove" . }}
 				]`),
 			Variables: map[string]string{
-				"Version": tpVersion,
+				"version": tpVersion,
 			},
 		},
 		{
-			Name: "basic-version",
+			Name: "_basic-version",
 			Template: []byte(`
 				{{ if not (.Data.Has "/spec/template/metadata") }}
 				{"op": "add", "path": "/spec/template/metadata", "value": {}},
@@ -107,7 +107,7 @@ func NewDefaultEngine() *Engine {
 			`),
 		},
 		{
-			Name: "basic-remove",
+			Name: "_basic-remove",
 			Template: []byte(`
 				{{ if .Data.Has "/spec/template/spec/containers/0/livenessProbe" }}
 				{"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"},

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -104,10 +104,11 @@ var _ = Describe("Operations for template system", func() {
 				e := template.NewDefaultEngine()
 
 				o, err := e.Run("telepresence", []byte(testDeployment), "1000", map[string]string{
-					"Version": "x",
+					"version": "x-x-v",
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(o)).To(ContainSubstring("1000"))
+				Expect(string(o)).To(ContainSubstring("x-x-v"))
 			})
 		})
 
@@ -115,7 +116,7 @@ var _ = Describe("Operations for template system", func() {
 			It("happy, happy, basic DefaultEngine", func() {
 				e := template.NewDefaultEngine()
 
-				o, err := e.Run("preparedimage", []byte(testDeployment), "1000", map[string]string{
+				o, err := e.Run("prepared-image", []byte(testDeployment), "1000", map[string]string{
 					"image": "maistra.org/test-image:test",
 				})
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -99,14 +99,29 @@ var _ = Describe("Operations for template system", func() {
 
 	Context("engine", func() {
 
-		It("happy, happy, basic DefaultEngine", func() {
-			e := template.NewDefaultEngine()
+		Context("telepresence", func() {
+			It("happy, happy, basic DefaultEngine", func() {
+				e := template.NewDefaultEngine()
 
-			o, err := e.Run("telepresence", []byte(testDeployment), "1000", map[string]string{
-				"TelepresenceVersion": "x",
+				o, err := e.Run("telepresence", []byte(testDeployment), "1000", map[string]string{
+					"Version": "x",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(o)).To(ContainSubstring("1000"))
 			})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(o)).To(ContainSubstring("1000"))
+		})
+
+		Context("preparedimage", func() {
+			It("happy, happy, basic DefaultEngine", func() {
+				e := template.NewDefaultEngine()
+
+				o, err := e.Run("preparedimage", []byte(testDeployment), "1000", map[string]string{
+					"image": "maistra.org/test-image:test",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(o)).To(ContainSubstring("1000"))
+				Expect(string(o)).To(ContainSubstring("maistra.org/test-image:test"))
+			})
 		})
 
 		Context("object validation", func() {


### PR DESCRIPTION
```
refs:
  - name: x
    strategy: preparedimage
    args:
      image: x/x:x
```

fixes #238