### PR TITLE
fix(test): proper namespaces in cli completion test

### DIFF
--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -97,7 +97,7 @@ func createProjectsForCompletionTests() {
 		DeployHelloWorldCmd("my-datawire-deployment", CompletionProject1),
 		NewProjectCmd(CompletionProject2),
 		DeployHelloWorldCmd("other-1-datawire-deployment", CompletionProject2),
-		DeployHelloWorldCmd("other-2-datawire-deployment", CompletionProject1),
+		DeployHelloWorldCmd("other-2-datawire-deployment", CompletionProject2),
 	)
 }
 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -94,10 +94,10 @@ func createProjectsForCompletionTests() {
 	LoginAsTestPowerUser()
 	testshell.ExecuteAll(
 		NewProjectCmd(CompletionProject1),
-		DeployHelloWorldCmd("my-datawire-deployment"),
+		DeployHelloWorldCmd("my-datawire-deployment", CompletionProject1),
 		NewProjectCmd(CompletionProject2),
-		DeployHelloWorldCmd("other-1-datawire-deployment"),
-		DeployHelloWorldCmd("other-2-datawire-deployment"),
+		DeployHelloWorldCmd("other-1-datawire-deployment", CompletionProject2),
+		DeployHelloWorldCmd("other-2-datawire-deployment", CompletionProject1),
 	)
 }
 

--- a/e2e/infra/deployment.go
+++ b/e2e/infra/deployment.go
@@ -47,11 +47,15 @@ func CreateNewApp(name string) {
 		"oc", "new-app",
 		"--docker-image", "datawire/hello-world",
 		"--name", name,
+		"--namespace", name,
 		"--allow-missing-images",
 	).Done()
 	shell.ExecuteAll("oc expose svc/"+name, "oc status")
 }
 
-func DeployHelloWorldCmd(name string) string {
-	return "oc new-app --docker-image datawire/hello-world --name " + name + " --allow-missing-images"
+func DeployHelloWorldCmd(name, ns string) string {
+	return "oc new-app --docker-image datawire/hello-world " +
+		"--name " + name + " " +
+		"--namespace " + ns + " " +
+		"--allow-missing-images"
 }


### PR DESCRIPTION
#### Short description of what this resolves:

On 4.x cluster we currently deploy datawire/helloworld based apps for CLI completion tests to `default` namespace. This is wrong and confusing.

#### Changes proposed in this pull request:

- deploys apps to ns created for that purpose
