### PR TITLE
fix: handles error coming from root cmd

### DIFF
--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -25,7 +25,8 @@ func main() {
 	// Logs to os.Stderr, where all structured logging should go
 	// When running outside of k8s cluster it will use development
 	// mode so the log is not in JSON, but plain text format
-	logf.SetLogger(log.CreateClusterAwareLogger())
+	logger := log.CreateClusterAwareLogger()
+	logf.SetLogger(logger)
 
 	// Setting random seed e.g. for session name generator
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -41,5 +42,7 @@ func main() {
 
 	cmd.VisitAll(rootCmd, completion.AddFlagCompletion)
 
-	_ = rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		logger.Error(err, "failed executing command")
+	}
 }

--- a/test/shell/funcs.go
+++ b/test/shell/funcs.go
@@ -35,6 +35,8 @@ func ExecuteInDir(dir, name string, args ...string) *gocmd.Cmd {
 	commandString := command.Name + " " + strings.Join(command.Args, " ")
 	if !strings.Contains(commandString, "oc login") {
 		fmt.Printf("executing: [%s]\n", commandString)
+	} else {
+		fmt.Println("executing [oc login .....]")
 	}
 	return command
 }


### PR DESCRIPTION
I guess we shouldn't swallow error thrown from `root` command :) Seems like left-over from some initial spike.