### PR TITLE
chore: introduces lint-prepare target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,4 +62,4 @@ service:
   project-path: github.com/maistra/istio-workspace
   golangci-lint-version: 1.17.x # Locks the version to avoid newly introduces linters
   prepare:
-    - make deps codegen
+    - make lint-prepare

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,15 +47,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:13c005cd1497b291d3aaf711086e94f6046efb7f104db33208bff268f0187213"
+  digest = "1:f8657a34251b97c1b5fcfd6f460410ea7354439682602235fc0fa0af7b1b7a29"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
     "log",
   ]
   pruneopts = "NT"
-  revision = "6ac3b8eb89d325e5c750d77f344a6870464d03c3"
-  version = "v2.9.6"
+  revision = "f48aa74d360eda838561e6db9d36c6538398343f"
+  version = "v2.10.0"
 
 [[projects]]
   digest = "1:448bf60e9dce6d5fd9dfa8fd9eb9a23163424ff4e4f142456405781e942e3998"
@@ -98,28 +98,28 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
+  digest = "1:3758c86e787dfe5792a23430f34636106a16da914446724399c9c12f121a225d"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
   pruneopts = "NT"
-  revision = "a105a905c5e6ad147f08504784917f3e178e0ba5"
-  version = "v0.19.2"
+  revision = "ed123515f087412cd7ef02e49b0b0a5e6a79a360"
+  version = "v0.19.3"
 
 [[projects]]
   digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
   pruneopts = "NT"
-  revision = "2903bfd4bfbaf188694f1edf731f2725a8fa344f"
-  version = "v0.19.2"
+  revision = "82f31475a8f7a12bc26962f6e26ceade8ea6f66a"
+  version = "v0.19.3"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f04cb7797917efbe9d9efd509a311f28930a9ee7ef1e047d01808d64ded53554"
+  digest = "1:7fc0908f885357d71c0fa50bb2333eb63ff6f9402584e7f8ac13f5cdf6e967d5"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "NT"
-  revision = "bdfd7e07daecc404d77868a88b2364d0aed0ee5a"
+  revision = "2223ab324566e4ace63ab69b9c8fff1b81a40eeb"
+  version = "v0.19.3"
 
 [[projects]]
   digest = "1:b318f36b1725220c1580b27504b8ee9d33a2a8e2db58f28c176edf6f0d1b7fb2"
@@ -319,8 +319,7 @@
   version = "v1.8.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5abd2595ba85b83e66f26ac8e89605dd334f0bfe3c455c1bf25a6a176a4fe836"
+  digest = "1:5181790e1f11c6b9cb42c70c5b902926c5e696b1e71bc24d4f82e6862ab3d078"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
@@ -328,7 +327,8 @@
     "jwriter",
   ]
   pruneopts = "NT"
-  revision = "b2ccc519800e761ac8000b95e5d57c80a897ff9e"
+  revision = "1b2b06f5f209fea48ff5922d8bfb2b9ed5d8f00b"
+  version = "v0.7.0"
 
 [[projects]]
   digest = "1:ea1db000388d88b31db7531c83016bef0d6db0d908a07794bfc36aca16fbf935"
@@ -609,7 +609,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f82ba53ff318249f82e7efa709f68e93bfcbf899c252bd66739b66f4b0fce202"
+  digest = "1:0a93ab1b9f6515272587680f1743cc02f3b140b59f29b34816844856bc9c1e2b"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -622,11 +622,11 @@
     "ssh/terminal",
   ]
   pruneopts = "NT"
-  revision = "9756ffdc24725223350eb3266ffb92590d28f278"
+  revision = "227b76d455e791cb042b03e633e2f7fbcfdf74a5"
 
 [[projects]]
   branch = "master"
-  digest = "1:cbba042a4d23f68bb83a73bbb300468378269b258b42e69b2627136e3084f151"
+  digest = "1:56fff8568bf7b339064e82f62bb910896274a8c86a5f1ef6edb4fb27c3010839"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -640,7 +640,7 @@
     "idna",
   ]
   pruneopts = "NT"
-  revision = "ba9fcec4b297b415637633c5a6e8fa592e4a16c3"
+  revision = "a7b16738d86b947dd0fadb08ca2c2342b51958b6"
 
 [[projects]]
   branch = "master"
@@ -655,14 +655,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c1e99da0f6c35f9c94fdf728c3527995bf224383d2a58065398877b5666acb6e"
+  digest = "1:9bc2f13aa9664a5d949cbf5d12b9efa8654695cdb499bdefe719e9a68108b493"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NT"
-  revision = "9109b7679e13aa34a54834cfb4949cac4b96e576"
+  revision = "bc967efca4b87fb45e946a3ea4cb891883404fd0"
 
 [[projects]]
   digest = "1:348fa8283a7c60b5b71ce04d27b37f7c0fce552d4d0b463b5b3ebbd1840d3f1a"
@@ -712,7 +712,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4b28967703490659ada4b5f4bb54fb7f6796f4e81cf4c0837d4101e7a9b0f7e2"
+  digest = "1:48df021f91ddba944975b3200417f9c9cfc067a504b8a982ff1bd91a60e05dc4"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -729,7 +729,7 @@
     "internal/semver",
   ]
   pruneopts = "NT"
-  revision = "afe7f8212f0d48598f7ba258eba2127cbfb7c3e9"
+  revision = "44811c0174895e13ada67eafee7eeeaa2be78022"
 
 [[projects]]
   digest = "1:8392b5c29adedc5f85c66b48bb53b6c49dd91d8540f3cad5d43ef7277946718f"
@@ -1029,7 +1029,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:337538b222999931b26bfcd46d88ce12a888d83028b9f261ebb7e91717b5e3ce"
+  digest = "1:6052f05eb0fa1de1923ba3cb87c5c3f983e67333a7deb5b2cb0dc33c1d0f41e2"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1042,7 +1042,7 @@
     "types",
   ]
   pruneopts = "NT"
-  revision = "a874a240740c2ae854082ec73d46c5efcedd2149"
+  revision = "ebc107f98eab922ef99d645781b87caca01f4f48"
 
 [[projects]]
   digest = "1:f4ba96b662d53fd1d18907c661cc429108e3522b92cb678db5fc1e5e1d2af7a7"
@@ -1064,7 +1064,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8ce127d755418ce5f27f1e9178656b7484c5f8794a874c3f9345011dc881852b"
+  digest = "1:7020da1852b3532e7c0ac43e68efb85b37c39661e3b866e9bc9aa5f8ea6c493c"
   name = "k8s.io/utils"
   packages = [
     "buffer",
@@ -1072,7 +1072,7 @@
     "trace",
   ]
   pruneopts = "NT"
-  revision = "3a4a5477acf81b48e20870a3b9dc743f63c66730"
+  revision = "3d4f5b7dea0b7c63c77d7fb1f0ee433ad8d54667"
 
 [[projects]]
   digest = "1:cc7d4dda9f8c970af917d6767e64db45a9826698a0bb24fb10f564903f0634ba"

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,11 @@ format: ## Removes unneeded imports and formats source code
 	$(call header,"Formatting code")
 	goimports -l -w ./pkg/ ./cmd/ ./version/ ./test/ ./e2e/
 
+.PHONY: lint-prepare
+lint-prepare: deps codegen
+
 .PHONY: lint
-lint: deps ## Concurrently runs a whole bunch of static analysis tools
+lint: lint-prepare ## Concurrently runs a whole bunch of static analysis tools
 	$(call header,"Running a whole bunch of static analysis tools")
 	golangci-lint run
 


### PR DESCRIPTION
I was preparing golang template repo for future projects and wanted to re-use a bunch of stuff we are having here. Thus I thought having `lint-prepare` target (so some abstraction one can customize) would be helpful. It is used by GolangCI.

