### PR TITLE
chore: golang bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,11 +142,11 @@ jobs:
           name: "Installs Openshift and k8s client tools"
           command: |
             cd ~
-            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.16/openshift-client-linux-4.1.16.tar.gz" -O "oc.tar.gz"
+            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-09-24-025718/openshift-client-linux-4.2.0-0.nightly-2019-09-24-025718.tar.gz" -O "oc.tar.gz"
             tar xzfv oc.tar.gz oc
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl && \
+            tar xzfv oc.tar.gz kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,10 +143,9 @@ jobs:
           command: |
             cd ~
             wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-09-24-025718/openshift-client-linux-4.2.0-0.nightly-2019-09-24-025718.tar.gz" -O "oc.tar.gz"
-            tar xzfv oc.tar.gz oc
+            tar xzfv oc.tar.gz
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"
-            tar xzfv oc.tar.gz kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ defaults:
     name: "Installs latest Golang"
     command: |
       sudo rm -rf /usr/local/go
-      sudo circleci-install golang 1.12.9
+      sudo circleci-install golang 1.13.1
   docker:
-    - image: &golang-img circleci/golang:1.12.9
+    - image: &golang-img circleci/golang:1.13.1
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   env-vars: &env-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       <<: *machine-conf
     environment:
       <<: *env-vars
+      IKE_CLUSTER_VERSION: 4
     steps:
       - checkout
       - run:

--- a/e2e/bash_completion_test.go
+++ b/e2e/bash_completion_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = XDescribe("Bash Completion Tests", func() {
+var _ = Describe("Bash Completion Tests", func() {
 
 	Context("basic completion", func() {
 

--- a/e2e/bash_completion_test.go
+++ b/e2e/bash_completion_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Bash Completion Tests", func() {
+var _ = XDescribe("Bash Completion Tests", func() {
 
 	Context("basic completion", func() {
 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -42,7 +42,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		tmpClusterDir = TmpDir(GinkgoT(), "/tmp/ike-e2e-tests/cluster-maistra-"+naming.RandName(16))
 		executeWithTimer(func() {
 			fmt.Printf("\nStarting up Openshift/Istio cluster in [%s]\n", tmpClusterDir)
-			projectDir := os.Getenv("PROJECT_DIR")
+			projectDir := testshell.GetProjectDir()
 			Expect(os.Setenv("IKE_CLUSTER_DIR", tmpClusterDir)).ToNot(HaveOccurred())
 			<-testshell.ExecuteInDir(projectDir, "make", "start-cluster").Done()
 		})

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -81,13 +81,13 @@ var _ = SynchronizedAfterSuite(func() {},
 			})
 		}
 
-		fmt.Printf("Don't forget to wipe out %s where test cluster sits\n", tmpClusterDir)
+		fmt.Printf("Don't forget to wipe out %s cluster directory!\n", tmpClusterDir)
 		fmt.Println("For example by using such command: ")
 		fmt.Printf("$ mount | grep openshift | cut -d' ' -f 3 | xargs -I {} sudo umount {} && sudo rm -rf %s", tmpClusterDir)
 	})
 
-var CompletionProject1 = "datawire-project-" + naming.RandName(16)
-var CompletionProject2 = "datawire-other-project-" + naming.RandName(16)
+var CompletionProject1 = "ike-autocompletion-test-" + naming.RandName(16)
+var CompletionProject2 = "ike-autocompletion-test-" + naming.RandName(16)
 
 func createProjectsForCompletionTests() {
 	LoginAsTestPowerUser()

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -1,6 +1,8 @@
 package infra
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -49,8 +51,22 @@ func ClientVersion() int {
 	return 3
 }
 
-// Events returns all events which occurred for a given namespace
-func Events(ns string) {
+// GetEvents returns all events which occurred for a given namespace
+func GetEvents(ns string) {
 	state := shell.Execute("oc get events -n " + ns)
 	<-state.Done()
+}
+
+// DumpTelepresenceLog dumps telepresence log if exists
+func DumpTelepresenceLog(dir string) {
+	fh, err := os.Open(dir + string(os.PathSeparator)+ "telepresence.log")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_, err = io.Copy(os.Stdout, fh)
+	if err != nil {
+		fmt.Println(err)
+	}
 }

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/maistra/istio-workspace/test/shell"
@@ -35,6 +36,10 @@ func LoginAsTestPowerUser() {
 }
 
 func ClientVersion() int {
+	if version, found := os.LookupEnv("IKE_CLUSTER_VERSION"); found {
+		result, _ := strconv.ParseInt(version, 0, 0)
+		return int(result)
+	}
 	version := shell.Execute("oc version")
 	<-version.Done()
 	v := strings.Join(version.Status().Stdout, " ")

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -38,7 +38,7 @@ func ClientVersion() int {
 	version := shell.Execute("oc version")
 	<-version.Done()
 	v := strings.Join(version.Status().Stdout, " ")
-	if strings.Contains(v, "GitVersion:\"v4.") {
+	if strings.Contains(v, "Server Version: 4.") {
 		return 4
 	}
 	return 3

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -11,13 +11,13 @@ import (
 
 // LoadIstio calls make load-istio target and waits until operator sets up the mesh
 func LoadIstio() {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	<-shell.ExecuteInDir(projectDir, "make", "load-istio").Done()
 }
 
 // BuildOperator builds istio-workspace operator and pushes it to specified registry
 func BuildOperator() (registry string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	_, registry = setDockerEnvForOperatorBuild()
 	LoginAsTestPowerUser()
 	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
@@ -27,7 +27,7 @@ func BuildOperator() (registry string) {
 
 // DeployLocalOperator deploys istio-workspace operator into specified namespace
 func DeployLocalOperator(namespace string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	gomega.Expect(projectDir).To(gomega.Not(gomega.BeEmpty()))
 	LoginAsTestPowerUser()
 

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -22,7 +22,7 @@ func OriginalServerCodeIn(tmpDir string) {
 
 // BuildTestService builds istio-workspace-test service and pushes it to specified registry
 func BuildTestService(namespace string) (registry string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	registry = setDockerEnvForTestServiceBuild(namespace)
 
 	LoginAsTestPowerUser()
@@ -33,7 +33,7 @@ func BuildTestService(namespace string) (registry string) {
 
 // BuildTestServicePreparedImage builds istio-workspace-test-prepared service and pushes it to specified registry
 func BuildTestServicePreparedImage(namespace string) (registry string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	registry = setDockerEnvForTestServiceBuild(namespace)
 
 	LoginAsTestPowerUser()
@@ -44,7 +44,7 @@ func BuildTestServicePreparedImage(namespace string) (registry string) {
 
 // DeployTestScenario deploys a test scenario into the specified namespace
 func DeployTestScenario(scenario, namespace string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	setDockerEnvForTestServiceDeploy(namespace)
 
 	LoginAsTestPowerUser()

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -249,7 +249,7 @@ func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
 	Eventually(call(productPageURL, map[string]string{
 		"Host":         GetGatewayHost(namespace),
 		"x-test-suite": "smoke"}),
-		3*time.Minute, 1*time.Second).Should(ContainSubstring("PublisherA"))
+		5*time.Minute, 1*time.Second).Should(ContainSubstring("PublisherA"))
 
 	// then modify the service
 	modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
@@ -259,12 +259,12 @@ func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
 	Eventually(call(productPageURL, map[string]string{
 		"Host":         GetGatewayHost(namespace),
 		"x-test-suite": "smoke"}),
-		3*time.Minute, 1*time.Second).Should(ContainSubstring("Publisher Ike"))
+		5*time.Minute, 1*time.Second).Should(ContainSubstring("Publisher Ike"))
 
 	// but also check if prod is intact
 	Eventually(call(productPageURL, map[string]string{
 		"Host": GetGatewayHost(namespace)}),
-		3*time.Minute, 1*time.Second).ShouldNot(And(ContainSubstring("PublisherA"), ContainSubstring("Publisher Ike")))
+		5*time.Minute, 1*time.Second).ShouldNot(And(ContainSubstring("PublisherA"), ContainSubstring("Publisher Ike")))
 
 	stopFailed := ikeWithWatch.Stop()
 	Expect(stopFailed).ToNot(HaveOccurred())

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -99,92 +99,94 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			cleanupNamespace(namespace)
 		})
 
-		Context("scenario-1-basic-deployment", func() {
+		Describe("k8s deployment", func() {
+
 			BeforeEach(func() {
 				scenario = "scenario-1"
 			})
 
-			It("should watch for changes in ratings service and serve it", func() {
-				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+			Context("basic deployment modifications", func() {
+				It("should watch for changes in ratings service and serve it", func() {
+					verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+				})
+
+				It("should watch for changes in ratings service in specified namespace and serve it", func() {
+					verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+				})
 			})
 
-			It("should watch for changes in ratings service in specified namespace and serve it", func() {
-				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+			Context("deployment create/delete operations", func() {
+				var registry string
+
+				JustBeforeEach(func() {
+					BuildTestServicePreparedImage(namespace)
+					registry = GetDockerRegistryInternal()
+				})
+
+				It("should watch for changes in ratings service and serve it", func() {
+					productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
+
+					Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+					Eventually(call(productPageURL, map[string]string{
+						"Host": GetGatewayHost(namespace)}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
+
+					// switch to different namespace - so we also test -n parameter of $ ike
+					<-testshell.Execute("oc project default").Done()
+
+					// when we start ike to create
+					ikeWithCreate := testshell.ExecuteInDir(tmpDir, "ike", "create",
+						"--deployment", "ratings-v1",
+						"-n", namespace,
+						"--route", "header:x-test-suite=smoke",
+						"--image", registry+"/"+namespace+"/istio-workspace-test-prepared:latest",
+						"-s", "test-session",
+					)
+					Eventually(ikeWithCreate.Done(), 1*time.Minute).Should(BeClosed())
+
+					// ensure the new service is running
+					Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+					// check original response
+					Eventually(call(productPageURL, map[string]string{
+						"Host":         GetGatewayHost(namespace),
+						"x-test-suite": "smoke"}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("prepared-image"), Not(ContainSubstring("ratings-v1"))))
+
+					// but also check if prod is intact
+					Eventually(call(productPageURL, map[string]string{}), 3*time.Minute, 1*time.Second).
+						ShouldNot(ContainSubstring("prepared-image"))
+
+					// when we start ike to delete
+					ikeWithDelete := testshell.ExecuteInDir(tmpDir, "ike", "delete",
+						"--deployment", "ratings-v1",
+						"-n", namespace,
+						"-s", "test-session",
+					)
+					Eventually(ikeWithDelete.Done(), 1*time.Minute).Should(BeClosed())
+
+					// check original response
+					Eventually(call(productPageURL, map[string]string{
+						"Host":         GetGatewayHost(namespace),
+						"x-test-suite": "smoke"}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
+
+					// but also check if prod is intact
+					Eventually(call(productPageURL, map[string]string{
+						"Host": GetGatewayHost(namespace)}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
+				})
+
 			})
+
 		})
 
-		Context("scenario-1-basic-deployment create/delete", func() {
-			var registry string
-			BeforeEach(func() {
-				scenario = "scenario-1"
-			})
-			JustBeforeEach(func() {
-				BuildTestServicePreparedImage(namespace)
-				registry = GetDockerRegistryInternal()
-			})
-
-			It("should watch for changes in ratings service and serve it", func() {
-				productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
-
-				Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
-
-				Eventually(call(productPageURL, map[string]string{
-					"Host": GetGatewayHost(namespace)}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
-
-				// switch to different namespace - so we also test -n parameter of $ ike
-				<-testshell.Execute("oc project default").Done()
-
-				// when we start ike to create
-				ikeWithCreate := testshell.ExecuteInDir(tmpDir, "ike", "create",
-					"--deployment", "ratings-v1",
-					"-n", namespace,
-					"--route", "header:x-test-suite=smoke",
-					"--image", registry+"/"+namespace+"/istio-workspace-test-prepared:latest",
-					"-s", "test-session",
-				)
-				Eventually(ikeWithCreate.Done(), 1*time.Minute).Should(BeClosed())
-
-				// ensure the new service is running
-				Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
-
-				// check original response
-				Eventually(call(productPageURL, map[string]string{
-					"Host":         GetGatewayHost(namespace),
-					"x-test-suite": "smoke"}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("prepared-image"), Not(ContainSubstring("ratings-v1"))))
-
-				// but also check if prod is intact
-				Eventually(call(productPageURL, map[string]string{}), 3*time.Minute, 1*time.Second).
-					ShouldNot(ContainSubstring("prepared-image"))
-
-				// when we start ike to delete
-				ikeWithDelete := testshell.ExecuteInDir(tmpDir, "ike", "delete",
-					"--deployment", "ratings-v1",
-					"-n", namespace,
-					"-s", "test-session",
-				)
-				Eventually(ikeWithDelete.Done(), 1*time.Minute).Should(BeClosed())
-
-				// check original response
-				Eventually(call(productPageURL, map[string]string{
-					"Host":         GetGatewayHost(namespace),
-					"x-test-suite": "smoke"}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
-
-				// but also check if prod is intact
-				Eventually(call(productPageURL, map[string]string{
-					"Host": GetGatewayHost(namespace)}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
-			})
-
-		})
-
-		Context("scenario-2-basic-deploymentconfig", func() {
+		Context("openshift deploymentconfig modifications", func() {
 			BeforeEach(func() {
 				scenario = "scenario-2"
 			})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 				scenario = "scenario-2"
 			})
 
-			FIt("should watch for changes in ratings service in specified namespace and serve it", func() {
+			It("should watch for changes in ratings service in specified namespace and serve it", func() {
 				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
 			})
 		})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 				scenario = "scenario-2"
 			})
 
-			It("should watch for changes in ratings service in specified namespace and serve it", func() {
+			FIt("should watch for changes in ratings service in specified namespace and serve it", func() {
 				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
 			})
 		})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -94,7 +94,8 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 					StateOf(namespace, pod)
 					printBanner()
 				}
-				Events(namespace)
+				GetEvents(namespace)
+				DumpTelepresenceLog(tmpDir)
 			}
 			cleanupNamespace(namespace)
 		})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -223,7 +223,7 @@ func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
 
 	Eventually(call(productPageURL, map[string]string{
 		"Host": GetGatewayHost(namespace)}),
-		3*time.Minute, 1*time.Second).Should(ContainSubstring("ratings-v1"))
+		5*time.Minute, 1*time.Second).Should(ContainSubstring("ratings-v1"))
 
 	// switch to different namespace - so we also test -n parameter of $ ike
 	<-testshell.Execute("oc project default").Done()

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -53,8 +53,9 @@ func main() {
 	http.HandleFunc("/", NewBasic(c, log))
 	err := http.ListenAndServe(adr, nil)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err, "failed initializing")
 	}
+	log.Info("Started serving basic test service")
 }
 
 func parseURL(value string) ([]*url.URL, error) {

--- a/test/shell/funcs.go
+++ b/test/shell/funcs.go
@@ -40,3 +40,11 @@ func ExecuteInDir(dir, name string, args ...string) *gocmd.Cmd {
 	}
 	return command
 }
+
+func GetProjectDir() string {
+	projectDir, found := os.LookupEnv("PROJECT_DIR")
+	if !found {
+		return "."
+	}
+	return projectDir
+}


### PR DESCRIPTION
I would suggest "rebase" instead of "squash merge" - didn't want to open two different PRs for these small changes.

#### Changes in this PR

- bumps circleci golang version to 1.13.1
- reorganizes e2e smoke tests to avoid duplication of scenario name definition