### PR TITLE
feat: test infra enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
       - save_cache:
           key: golang-deps-cache-{{ checksum "Gopkg.lock" }}
           paths:
-            - ./vendor
-            - {{ .Environment.GOPATH }}/bin
+            - "./vendor"
+            - "{{ .Environment.GOPATH }}/bin"
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed (local)
   e2e_tests_local:
@@ -103,8 +103,8 @@ jobs:
       - save_cache:
           key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
-            - ./vendor
-            - {{ .Environment.GOPATH }}/bin
+            - "./vendor"
+            - "{{ .Environment.GOPATH }}/bin"
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
@@ -167,8 +167,8 @@ jobs:
       - save_cache:
           key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
-            - ./vendor
-            - {{ .Environment.GOPATH }}/bin
+            - "./vendor"
+            - "{{ .Environment.GOPATH }}/bin"
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,7 @@ jobs:
       - save_cache:
           key: golang-deps-cache-{{ checksum "Gopkg.lock" }}
           paths:
-            - "./vendor"
-            - "{{ .Environment.GOPATH }}/bin"
+            - ./vendor
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed (local)
   e2e_tests_local:
@@ -103,8 +102,7 @@ jobs:
       - save_cache:
           key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
-            - "./vendor"
-            - "{{ .Environment.GOPATH }}/bin"
+            - ./vendor
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
@@ -167,8 +165,7 @@ jobs:
       - save_cache:
           key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
-            - "./vendor"
-            - "{{ .Environment.GOPATH }}/bin"
+            - ./vendor
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           key: golang-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
-            - $GOPATH/bin
+            - ${{ .Environment.GOPATH }}/bin
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed (local)
   e2e_tests_local:
@@ -104,7 +104,7 @@ jobs:
           key: golang-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
-            - $GOPATH/bin
+            - ${{ .Environment.GOPATH }}/bin
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,11 +142,11 @@ jobs:
           name: "Installs Openshift and k8s client tools"
           command: |
             cd ~
-            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.16/openshift-client-linux-4.1.16.tar.gz" -O "oc.tar.gz"
+            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-09-24-025718/openshift-client-linux-4.2.0-0.nightly-2019-09-24-025718.tar.gz" -O "oc.tar.gz"
             tar xzfv oc.tar.gz oc
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl && \
+            tar xzfv oc.tar.gz kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,10 +143,9 @@ jobs:
           command: |
             cd ~
             wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-09-24-025718/openshift-client-linux-4.2.0-0.nightly-2019-09-24-025718.tar.gz" -O "oc.tar.gz"
-            tar xzfv oc.tar.gz oc
+            tar xzfv oc.tar.gz
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"
-            tar xzfv oc.tar.gz kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - golang-cache-{{ checksum "Gopkg.lock" }}
+            - golang-deps-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs the build"
           command: make build-ci
       - save_cache:
-          key: golang-cache-{{ checksum "Gopkg.lock" }}
+          key: golang-deps-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
-            - ${{ .Environment.GOPATH }}/bin
+            - {{ .Environment.GOPATH }}/bin
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed (local)
   e2e_tests_local:
@@ -96,15 +96,15 @@ jobs:
           command: ./scripts/openshift/deploy-istio.sh
       - restore_cache:
           keys:
-            - golang-e2e-cache-{{ checksum "Gopkg.lock" }}
+            - golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs end-to-end tests"
           command: TELEPRESENCE_VERSION=$(telepresence --version) make deps test-e2e
       - save_cache:
-          key: golang-e2e-cache-{{ checksum "Gopkg.lock" }}
+          key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
-            - ${{ .Environment.GOPATH }}/bin
+            - {{ .Environment.GOPATH }}/bin
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
@@ -153,7 +153,7 @@ jobs:
             echo "Installed kubectl\n$(kubectl version)\n"
       - restore_cache:
           keys:
-            - vendor-e2e-cache-{{ checksum "Gopkg.lock" }}
+            - golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs end-to-end tests"
           command: |
@@ -165,9 +165,10 @@ jobs:
             IKE_CLUSTER_ADDRESS=$QE_CLUSTER_ADDRESS \
             make deps test-e2e
       - save_cache:
-          key: vendor-e2e-cache-{{ checksum "Gopkg.lock" }}
+          key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
+            - {{ .Environment.GOPATH }}/bin
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ defaults:
     name: "Installs latest Golang"
     command: |
       sudo rm -rf /usr/local/go
-      sudo circleci-install golang 1.12.9
+      sudo circleci-install golang 1.13.1
   docker:
-    - image: &golang-img circleci/golang:1.12.9
+    - image: &golang-img circleci/golang:1.13.1
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   env-vars: &env-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       <<: *machine-conf
     environment:
       <<: *env-vars
+      IKE_CLUSTER_VERSION: 4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - vendor-cache-{{ checksum "Gopkg.lock" }}
+            - golang-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs the build"
           command: make build-ci
       - save_cache:
-          key: vendor-cache-{{ checksum "Gopkg.lock" }}
+          key: golang-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
+            - $GOPATH/bin
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed (local)
   e2e_tests_local:
@@ -95,14 +96,15 @@ jobs:
           command: ./scripts/openshift/deploy-istio.sh
       - restore_cache:
           keys:
-            - vendor-e2e-cache-{{ checksum "Gopkg.lock" }}
+            - golang-e2e-cache-{{ checksum "Gopkg.lock" }}
       - run:
           name: "Runs end-to-end tests"
           command: TELEPRESENCE_VERSION=$(telepresence --version) make deps test-e2e
       - save_cache:
-          key: vendor-e2e-cache-{{ checksum "Gopkg.lock" }}
+          key: golang-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
+            - $GOPATH/bin
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,6 @@ issues:
 
 service:
   project-path: github.com/maistra/istio-workspace
-  golangci-lint-version: 1.19.x # Locks the version to avoid newly introduces linters
+  golangci-lint-version: 1.19.1 # Locks the version to avoid newly introduces linters
   prepare:
     - make lint-prepare

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ linters-settings:
       - commentFormatting # https://github.com/go-critic/go-critic/issues/755
   unused:
     check-exported: true
+  gocognit:
+    min-complexity: 16
 
 linters:
   enable-all: true
@@ -74,6 +76,6 @@ issues:
 
 service:
   project-path: github.com/maistra/istio-workspace
-  golangci-lint-version: 1.17.x # Locks the version to avoid newly introduces linters
+  golangci-lint-version: 1.19.x # Locks the version to avoid newly introduces linters
   prepare:
     - make lint-prepare

--- a/Makefile
+++ b/Makefile
@@ -128,14 +128,18 @@ $(BINARY_DIR)/$(TEST_BINARY_NAME): $(BINARY_DIR) $(SRCS)
 
 ##@ Setup
 
-.PHONY: tools
-tools: ## Installs required go tools
-	$(call header,"Installing required tools")
+.PHONY: install-dep
+install-dep:
 	go get -u github.com/golang/dep/cmd/dep
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
+.PHONY: tools
+tools: install-dep ## Installs required go tools
+	$(call header,"Installing required tools")
+	GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.19.1
 	go get -u golang.org/x/tools/cmd/goimports
-	go get -u github.com/onsi/ginkgo/ginkgo
-	go get -u github.com/go-bindata/go-bindata/...
+	$(eval GINKGO_VERSION:=$(shell dep status -f='{{if eq .ProjectRoot "github.com/onsi/ginkgo"}}{{.Version}}{{end}}'))
+	GO111MODULE=on go get -u github.com/onsi/ginkgo/ginkgo@$(GINKGO_VERSION)
+	GO111MODULE=on go get -u github.com/go-bindata/go-bindata/...@v3.1.2
 
 EXECUTABLES:=dep golangci-lint goimports ginkgo go-bindata
 CHECK:=$(foreach exec,$(EXECUTABLES),\

--- a/e2e/bash_completion_test.go
+++ b/e2e/bash_completion_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = XDescribe("Bash Completion Tests", func() {
+var _ = Describe("Bash Completion Tests", func() {
 
 	Context("basic completion", func() {
 

--- a/e2e/bash_completion_test.go
+++ b/e2e/bash_completion_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Bash Completion Tests", func() {
+var _ = XDescribe("Bash Completion Tests", func() {
 
 	Context("basic completion", func() {
 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -42,7 +42,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		tmpClusterDir = TmpDir(GinkgoT(), "/tmp/ike-e2e-tests/cluster-maistra-"+naming.RandName(16))
 		executeWithTimer(func() {
 			fmt.Printf("\nStarting up Openshift/Istio cluster in [%s]\n", tmpClusterDir)
-			projectDir := os.Getenv("PROJECT_DIR")
+			projectDir := testshell.GetProjectDir()
 			Expect(os.Setenv("IKE_CLUSTER_DIR", tmpClusterDir)).ToNot(HaveOccurred())
 			<-testshell.ExecuteInDir(projectDir, "make", "start-cluster").Done()
 		})

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -81,13 +81,13 @@ var _ = SynchronizedAfterSuite(func() {},
 			})
 		}
 
-		fmt.Printf("Don't forget to wipe out %s where test cluster sits\n", tmpClusterDir)
+		fmt.Printf("Don't forget to wipe out %s cluster directory!\n", tmpClusterDir)
 		fmt.Println("For example by using such command: ")
 		fmt.Printf("$ mount | grep openshift | cut -d' ' -f 3 | xargs -I {} sudo umount {} && sudo rm -rf %s", tmpClusterDir)
 	})
 
-var CompletionProject1 = "datawire-project-" + naming.RandName(16)
-var CompletionProject2 = "datawire-other-project-" + naming.RandName(16)
+var CompletionProject1 = "ike-autocompletion-test-" + naming.RandName(16)
+var CompletionProject2 = "ike-autocompletion-test-" + naming.RandName(16)
 
 func createProjectsForCompletionTests() {
 	LoginAsTestPowerUser()

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -39,15 +39,20 @@ func LoginAsTestPowerUser() {
 
 func ClientVersion() int {
 	if version, found := os.LookupEnv("IKE_CLUSTER_VERSION"); found {
-		result, _ := strconv.ParseInt(version, 0, 0)
-		return int(result)
+		result, err := strconv.Atoi(version)
+		if err != nil {
+			fmt.Printf("failed parsing int value of IKE_CLUSTER_VERSION='%s'. reason: %s", version, err.Error())
+		} else {
+			return result
+		}
 	}
 	version := shell.Execute("oc version")
 	<-version.Done()
 	v := strings.Join(version.Status().Stdout, " ")
-	if strings.Contains(v, "Server Version: 4.") {
+	if strings.Contains(v, "Server Version: 4.") || strings.Contains(v, "GitVersion:\"v4.") {
 		return 4
 	}
+	// Fallback to 3.x version (default local test setup right now)
 	return 3
 }
 

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/maistra/istio-workspace/test/shell"
@@ -35,10 +36,14 @@ func LoginAsTestPowerUser() {
 }
 
 func ClientVersion() int {
+	if version, found := os.LookupEnv("IKE_CLUSTER_VERSION"); found {
+		result, _ := strconv.ParseInt(version, 0, 0)
+		return int(result)
+	}
 	version := shell.Execute("oc version")
 	<-version.Done()
 	v := strings.Join(version.Status().Stdout, " ")
-	if strings.Contains(v, "GitVersion:\"v4.") {
+	if strings.Contains(v, "Server Version: 4.") {
 		return 4
 	}
 	return 3

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -1,6 +1,8 @@
 package infra
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -49,8 +51,22 @@ func ClientVersion() int {
 	return 3
 }
 
-// Events returns all events which occurred for a given namespace
-func Events(ns string) {
+// GetEvents returns all events which occurred for a given namespace
+func GetEvents(ns string) {
 	state := shell.Execute("oc get events -n " + ns)
 	<-state.Done()
+}
+
+// DumpTelepresenceLog dumps telepresence log if exists
+func DumpTelepresenceLog(dir string) {
+	fh, err := os.Open(dir + string(os.PathSeparator) + "telepresence.log")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_, err = io.Copy(os.Stdout, fh)
+	if err != nil {
+		fmt.Println(err)
+	}
 }

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -11,13 +11,13 @@ import (
 
 // LoadIstio calls make load-istio target and waits until operator sets up the mesh
 func LoadIstio() {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	<-shell.ExecuteInDir(projectDir, "make", "load-istio").Done()
 }
 
 // BuildOperator builds istio-workspace operator and pushes it to specified registry
 func BuildOperator() (registry string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	_, registry = setDockerEnvForOperatorBuild()
 	LoginAsTestPowerUser()
 	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
@@ -27,7 +27,7 @@ func BuildOperator() (registry string) {
 
 // DeployLocalOperator deploys istio-workspace operator into specified namespace
 func DeployLocalOperator(namespace string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	gomega.Expect(projectDir).To(gomega.Not(gomega.BeEmpty()))
 	LoginAsTestPowerUser()
 

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -22,7 +22,7 @@ func OriginalServerCodeIn(tmpDir string) {
 
 // BuildTestService builds istio-workspace-test service and pushes it to specified registry
 func BuildTestService(namespace string) (registry string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	registry = setDockerEnvForTestServiceBuild(namespace)
 
 	LoginAsTestPowerUser()
@@ -33,7 +33,7 @@ func BuildTestService(namespace string) (registry string) {
 
 // BuildTestServicePreparedImage builds istio-workspace-test-prepared service and pushes it to specified registry
 func BuildTestServicePreparedImage(namespace string) (registry string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	registry = setDockerEnvForTestServiceBuild(namespace)
 
 	LoginAsTestPowerUser()
@@ -44,7 +44,7 @@ func BuildTestServicePreparedImage(namespace string) (registry string) {
 
 // DeployTestScenario deploys a test scenario into the specified namespace
 func DeployTestScenario(scenario, namespace string) {
-	projectDir := os.Getenv("PROJECT_DIR")
+	projectDir := shell.GetProjectDir()
 	setDockerEnvForTestServiceDeploy(namespace)
 
 	LoginAsTestPowerUser()

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -99,92 +99,94 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			cleanupNamespace(namespace)
 		})
 
-		Context("scenario-1-basic-deployment", func() {
+		Describe("k8s deployment", func() {
+
 			BeforeEach(func() {
 				scenario = "scenario-1"
 			})
 
-			It("should watch for changes in ratings service and serve it", func() {
-				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+			Context("basic deployment modifications", func() {
+				It("should watch for changes in ratings service and serve it", func() {
+					verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+				})
+
+				It("should watch for changes in ratings service in specified namespace and serve it", func() {
+					verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+				})
 			})
 
-			It("should watch for changes in ratings service in specified namespace and serve it", func() {
-				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
+			Context("deployment create/delete operations", func() {
+				var registry string
+
+				JustBeforeEach(func() {
+					BuildTestServicePreparedImage(namespace)
+					registry = GetDockerRegistryInternal()
+				})
+
+				It("should watch for changes in ratings service and serve it", func() {
+					productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
+
+					Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+					Eventually(call(productPageURL, map[string]string{
+						"Host": GetGatewayHost(namespace)}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
+
+					// switch to different namespace - so we also test -n parameter of $ ike
+					<-testshell.Execute("oc project default").Done()
+
+					// when we start ike to create
+					ikeWithCreate := testshell.ExecuteInDir(tmpDir, "ike", "create",
+						"--deployment", "ratings-v1",
+						"-n", namespace,
+						"--route", "header:x-test-suite=smoke",
+						"--image", registry+"/"+namespace+"/istio-workspace-test-prepared:latest",
+						"-s", "test-session",
+					)
+					Eventually(ikeWithCreate.Done(), 1*time.Minute).Should(BeClosed())
+
+					// ensure the new service is running
+					Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+					// check original response
+					Eventually(call(productPageURL, map[string]string{
+						"Host":         GetGatewayHost(namespace),
+						"x-test-suite": "smoke"}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("prepared-image"), Not(ContainSubstring("ratings-v1"))))
+
+					// but also check if prod is intact
+					Eventually(call(productPageURL, map[string]string{}), 3*time.Minute, 1*time.Second).
+						ShouldNot(ContainSubstring("prepared-image"))
+
+					// when we start ike to delete
+					ikeWithDelete := testshell.ExecuteInDir(tmpDir, "ike", "delete",
+						"--deployment", "ratings-v1",
+						"-n", namespace,
+						"-s", "test-session",
+					)
+					Eventually(ikeWithDelete.Done(), 1*time.Minute).Should(BeClosed())
+
+					// check original response
+					Eventually(call(productPageURL, map[string]string{
+						"Host":         GetGatewayHost(namespace),
+						"x-test-suite": "smoke"}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
+
+					// but also check if prod is intact
+					Eventually(call(productPageURL, map[string]string{
+						"Host": GetGatewayHost(namespace)}),
+						3*time.Minute, 1*time.Second).
+						Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
+				})
+
 			})
+
 		})
 
-		Context("scenario-1-basic-deployment create/delete", func() {
-			var registry string
-			BeforeEach(func() {
-				scenario = "scenario-1"
-			})
-			JustBeforeEach(func() {
-				BuildTestServicePreparedImage(namespace)
-				registry = GetDockerRegistryInternal()
-			})
-
-			It("should watch for changes in ratings service and serve it", func() {
-				productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
-
-				Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
-
-				Eventually(call(productPageURL, map[string]string{
-					"Host": GetGatewayHost(namespace)}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
-
-				// switch to different namespace - so we also test -n parameter of $ ike
-				<-testshell.Execute("oc project default").Done()
-
-				// when we start ike to create
-				ikeWithCreate := testshell.ExecuteInDir(tmpDir, "ike", "create",
-					"--deployment", "ratings-v1",
-					"-n", namespace,
-					"--route", "header:x-test-suite=smoke",
-					"--image", registry+"/"+namespace+"/istio-workspace-test-prepared:latest",
-					"-s", "test-session",
-				)
-				Eventually(ikeWithCreate.Done(), 1*time.Minute).Should(BeClosed())
-
-				// ensure the new service is running
-				Eventually(AllPodsReady(namespace), 5*time.Minute, 5*time.Second).Should(BeTrue())
-
-				// check original response
-				Eventually(call(productPageURL, map[string]string{
-					"Host":         GetGatewayHost(namespace),
-					"x-test-suite": "smoke"}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("prepared-image"), Not(ContainSubstring("ratings-v1"))))
-
-				// but also check if prod is intact
-				Eventually(call(productPageURL, map[string]string{}), 3*time.Minute, 1*time.Second).
-					ShouldNot(ContainSubstring("prepared-image"))
-
-				// when we start ike to delete
-				ikeWithDelete := testshell.ExecuteInDir(tmpDir, "ike", "delete",
-					"--deployment", "ratings-v1",
-					"-n", namespace,
-					"-s", "test-session",
-				)
-				Eventually(ikeWithDelete.Done(), 1*time.Minute).Should(BeClosed())
-
-				// check original response
-				Eventually(call(productPageURL, map[string]string{
-					"Host":         GetGatewayHost(namespace),
-					"x-test-suite": "smoke"}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
-
-				// but also check if prod is intact
-				Eventually(call(productPageURL, map[string]string{
-					"Host": GetGatewayHost(namespace)}),
-					3*time.Minute, 1*time.Second).
-					Should(And(ContainSubstring("ratings-v1"), Not(ContainSubstring("prepared-image"))))
-			})
-
-		})
-
-		Context("scenario-2-basic-deploymentconfig", func() {
+		Context("openshift deploymentconfig modifications", func() {
 			BeforeEach(func() {
 				scenario = "scenario-2"
 			})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 				scenario = "scenario-2"
 			})
 
-			FIt("should watch for changes in ratings service in specified namespace and serve it", func() {
+			It("should watch for changes in ratings service in specified namespace and serve it", func() {
 				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
 			})
 		})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -187,7 +187,10 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 
 		})
 
-		Context("openshift deploymentconfig modifications", func() {
+		// Telepresence fails on picking up oc/openshift cluster due to /apis being secured.
+		// Thus it treats cluster as vanilla k8s and expects Deployment, not DeploymentConfig to appear
+		// Enable when https://github.com/telepresenceio/telepresence/issues/1139 is fixed
+		XContext("openshift deploymentconfig", func() {
 			BeforeEach(func() {
 				scenario = "scenario-2"
 			})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 				scenario = "scenario-2"
 			})
 
-			It("should watch for changes in ratings service in specified namespace and serve it", func() {
+			FIt("should watch for changes in ratings service in specified namespace and serve it", func() {
 				verifyThatResponseMatchesModifiedService(tmpDir, namespace)
 			})
 		})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -94,7 +94,8 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 					StateOf(namespace, pod)
 					printBanner()
 				}
-				Events(namespace)
+				GetEvents(namespace)
+				DumpTelepresenceLog(tmpDir)
 			}
 			cleanupNamespace(namespace)
 		})

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -53,8 +53,9 @@ func main() {
 	http.HandleFunc("/", NewBasic(c, log))
 	err := http.ListenAndServe(adr, nil)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err, "failed initializing")
 	}
+	log.Info("Started serving basic test service")
 }
 
 func parseURL(value string) ([]*url.URL, error) {

--- a/test/shell/funcs.go
+++ b/test/shell/funcs.go
@@ -40,3 +40,11 @@ func ExecuteInDir(dir, name string, args ...string) *gocmd.Cmd {
 	}
 	return command
 }
+
+func GetProjectDir() string {
+	projectDir, found := os.LookupEnv("PROJECT_DIR")
+	if !found {
+		return "."
+	}
+	return projectDir
+}


### PR DESCRIPTION
#### Changes proposed in this pull request:

- bumps golang to 1.13.1
- reorganizes e2e tests to avoid duplication of scenario name definition
- adds simple logging to test service
- obtains project dir using a func (removes duplication)
- aligns ocp cli with remote cluster 
- defines cluster version using env var (IKE_CLUSTER_VERSION)
- dumps telepresence log after test failure

**IMPORTANT** This PR disables dc tests until telepresenceio/telepresence/issues/1139 is fixed

