### PR TITLE
feat: aligns telepresence version used by client and cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,6 @@ jobs:
       - run:
           name: "Runs end-to-end tests"
           command: |
-            TELEPRESENCE_VERSION=$(telepresence --version) \
             IKE_CLUSTER_USER=$QE_IKE_CLUSTER_USER \
             IKE_CLUSTER_PWD=$QE_IKE_CLUSTER_PWD \
             IKE_CLUSTER_HOST=$QE_IKE_CLUSTER_HOST \

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/maistra/istio-workspace/pkg/telepresence"
+
 	"github.com/maistra/istio-workspace/pkg/cmd/internal/build"
 
 	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
@@ -21,8 +23,6 @@ import (
 
 var log = logf.Log.WithName("develop")
 
-const telepresenceBin = "telepresence"
-
 var DefaultExclusions = []string{"*.log", ".git/"}
 
 // NewCmd creates instance of "develop" Cobra Command with flags and execution logic defined
@@ -32,8 +32,8 @@ func NewCmd() *cobra.Command {
 		Short:        "Starts the development flow",
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
-			if !shell.BinaryExists(telepresenceBin, "Head over to https://www.telepresence.io/reference/install for installation instructions.\n") {
-				return fmt.Errorf("unable to find %s on your $PATH", telepresenceBin)
+			if !telepresence.BinaryAvailable() {
+				return fmt.Errorf("unable to find %s on your $PATH", telepresence.BinaryName)
 			}
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
@@ -59,7 +59,7 @@ func NewCmd() *cobra.Command {
 			arguments := parseArguments(cmd)
 
 			go func() {
-				tp := gocmd.NewCmdOptions(shell.StreamOutput, telepresenceBin, arguments...)
+				tp := gocmd.NewCmdOptions(shell.StreamOutput, telepresence.BinaryName, arguments...)
 				shell.RedirectStreams(tp, cmd.OutOrStdout(), cmd.OutOrStderr(), done)
 				shell.ShutdownHook(tp, done)
 				shell.Start(tp, done)

--- a/pkg/cmd/internal/session/session_func.go
+++ b/pkg/cmd/internal/session/session_func.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"github.com/maistra/istio-workspace/pkg/internal/session"
+	"github.com/maistra/istio-workspace/pkg/telepresence"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -35,9 +36,11 @@ func RemoveSessions(cmd *cobra.Command) (session.State, func(), error) {
 	return session.RemoveHandler(options)
 }
 
+const telepresenceStrategy = "telepresence"
+
 // ToOptions converts between FlagSet to a Handler Options
 func ToOptions(flags *pflag.FlagSet) (session.Options, error) {
-	strategy := "telepresence"
+	strategy := telepresenceStrategy
 	strategyArgs := map[string]string{}
 
 	n, err := flags.GetString("namespace")
@@ -64,6 +67,10 @@ func ToOptions(flags *pflag.FlagSet) (session.Options, error) {
 	if i != "" {
 		strategy = "prepared-image"
 		strategyArgs["image"] = i
+	}
+
+	if strategy == telepresenceStrategy {
+		strategyArgs["version"] = telepresence.GetVersion()
 	}
 
 	return session.Options{

--- a/pkg/cmd/internal/session/session_suite_test.go
+++ b/pkg/cmd/internal/session/session_suite_test.go
@@ -1,0 +1,31 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/maistra/istio-workspace/test/shell"
+
+	"github.com/onsi/gomega/gexec"
+	"go.uber.org/goleak"
+
+	. "github.com/maistra/istio-workspace/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDevelopCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecWithJUnitReporter(t, "Session Internal Logic Suite")
+}
+
+var _ = BeforeSuite(shell.StubShellCommands)
+
+var _ = AfterSuite(func() {
+	CleanUpTmpFiles(GinkgoT())
+	gexec.CleanupBuildArtifacts()
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/pkg/telepresence/telepresence_suite_test.go
+++ b/pkg/telepresence/telepresence_suite_test.go
@@ -1,0 +1,28 @@
+package telepresence_test
+
+import (
+	"testing"
+
+	"github.com/maistra/istio-workspace/test/shell"
+
+	"go.uber.org/goleak"
+
+	. "github.com/maistra/istio-workspace/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTelepresenceWrapper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecWithJUnitReporter(t, "Telepresence Wrapper Suite")
+}
+
+var _ = BeforeSuite(shell.StubShellCommands)
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/maistra/istio-workspace/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})

--- a/pkg/telepresence/wrapper.go
+++ b/pkg/telepresence/wrapper.go
@@ -1,0 +1,46 @@
+package telepresence
+
+import (
+	"os"
+	"strings"
+
+	"github.com/maistra/istio-workspace/pkg/shell"
+
+	gocmd "github.com/go-cmd/cmd"
+)
+
+const (
+	BinaryName                 = "telepresence"
+	DefaultTelepresenceVersion = "0.101"
+)
+
+// GetVersion checks which version of telepresence should be used or is available on the path
+// TELEPRESENCE_VERSION env variable is checked and if is defined takes precedence.
+// If the binary is present on the $PATH then its version is used.
+// If all above fails we return telepresence.DefaultTelepresenceVersion
+func GetVersion() string {
+	tpVersion, found := os.LookupEnv("TELEPRESENCE_VERSION")
+	if !found && BinaryAvailable() {
+		done := make(chan gocmd.Status, 1)
+		defer close(done)
+
+		go func() {
+			tp := gocmd.NewCmdOptions(shell.BufferAndStreamOutput, "telepresence", "--version")
+			shell.RedirectStreams(tp, os.Stdout, os.Stderr, done)
+			shell.Start(tp, done)
+		}()
+
+		finalStatus := <-done
+		tpVersion = strings.Join(finalStatus.Stdout, " ")
+	}
+
+	if tpVersion == "" {
+		tpVersion = DefaultTelepresenceVersion
+	}
+	return tpVersion
+}
+
+// BinaryAvailable checks if telepresence binary is available on the path
+func BinaryAvailable() bool {
+	return shell.BinaryExists(BinaryName, "Head over to https://www.telepresence.io/reference/install for installation instructions.\n")
+}

--- a/pkg/telepresence/wrapper_test.go
+++ b/pkg/telepresence/wrapper_test.go
@@ -1,0 +1,72 @@
+package telepresence_test
+
+import (
+	"os"
+	"path"
+
+	"github.com/maistra/istio-workspace/test/shell"
+
+	"github.com/maistra/istio-workspace/pkg/telepresence"
+	. "github.com/maistra/istio-workspace/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("telepresence commands wrapper", func() {
+
+	Context("telepresence not available", func() {
+
+		tmpPath := NewTmpPath()
+		BeforeEach(func() {
+			tmpPath.SetPath()
+		})
+		AfterEach(tmpPath.Restore)
+
+		It("should fail when telepresence is not on $PATH", func() {
+			Expect(telepresence.BinaryAvailable()).To(BeFalse())
+		})
+
+		It("should return default version when no env nor telepresence binary available", func() {
+			version := telepresence.GetVersion()
+			Expect(version).To(Equal(telepresence.DefaultTelepresenceVersion))
+		})
+
+	})
+
+	Context("telepresence available", func() {
+
+		It("should retrieve version from TELEPRESENCE_VERSION env variable when defined", func() {
+			// given
+			currentTpVersion := os.Getenv("TELEPRESENCE_VERSION")
+			defer func() {
+				if currentTpVersion != "" {
+					_ = os.Setenv("TELEPRESENCE_VERSION", currentTpVersion)
+				} else {
+					_ = os.Unsetenv("TELEPRESENCE_VERSION")
+				}
+			}()
+			_ = os.Setenv("TELEPRESENCE_VERSION", "0.123")
+
+			// when
+			version := telepresence.GetVersion()
+
+			// then
+			Expect(version).To(Equal("0.123"))
+		})
+
+		It("should retrieve version from telepresence binary", func() {
+			tmpPath := NewTmpPath()
+			tmpPath.SetPath(path.Dir(shell.TpVersionBin))
+			defer tmpPath.Restore()
+
+			// when
+			version := telepresence.GetVersion()
+
+			// then
+			Expect(version).To(Equal("0.234"))
+		})
+
+	})
+
+})

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -8,15 +8,11 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/maistra/istio-workspace/pkg/telepresence"
-
 	jsonpatch "github.com/evanphx/json-patch"
 )
 
 // NewDefaultEngine returns a new Engine with a predefined templates
 func NewDefaultEngine() *Engine {
-	tpVersion := telepresence.GetVersion()
-
 	patches := []Patch{
 		{
 			Name: "prepared-image",
@@ -57,7 +53,7 @@ func NewDefaultEngine() *Engine {
 					{{ template "_basic-remove" . }}
 				]`),
 			Variables: map[string]string{
-				"version": tpVersion,
+				"version": "",
 			},
 		},
 		{

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -4,20 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/maistra/istio-workspace/pkg/telepresence"
 
 	jsonpatch "github.com/evanphx/json-patch"
 )
 
 // NewDefaultEngine returns a new Engine with a predefined templates
 func NewDefaultEngine() *Engine {
-	tpVersion, found := os.LookupEnv("TELEPRESENCE_VERSION")
-	if !found {
-		tpVersion = "0.101"
-	}
+	tpVersion := telepresence.GetVersion()
 
 	patches := []Patch{
 		{

--- a/test/echo/main.go
+++ b/test/echo/main.go
@@ -9,12 +9,19 @@ import (
 	"time"
 )
 
-// SleepMs indicates for how the program should sleep before he gets terminated
+// SleepMs indicates for how long the program should sleep before he gets terminated
 // The value is in milliseconds or "infinite" which will result in endless loop
 var SleepMs string
 
+// Echo if specified as build flag will be the output of the command
+var Echo string
+
 func main() {
-	fmt.Println(os.Args)
+	if Echo != "" {
+		fmt.Println(Echo)
+	} else {
+		fmt.Println(os.Args)
+	}
 	if SleepMs != "" {
 		if SleepMs == "infinite" {
 			infiniteLoop()

--- a/test/echo/main.go
+++ b/test/echo/main.go
@@ -22,6 +22,7 @@ func main() {
 	} else {
 		fmt.Println(os.Args)
 	}
+
 	if SleepMs != "" {
 		if SleepMs == "infinite" {
 			infiniteLoop()

--- a/test/shell/test_setup.go
+++ b/test/shell/test_setup.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	MvnBin     string
-	TpBin      string
-	TpSleepBin string
-	JavaBin    string
+	MvnBin       string
+	TpBin        string
+	TpSleepBin   string
+	TpVersionBin string
+	JavaBin      string
 )
 
 func StubShellCommands() {
@@ -24,6 +25,7 @@ func StubShellCommands() {
 	_ = buildBinary("github.com/maistra/istio-workspace/test/echo", "ike",
 		"-ldflags", "-w -X main.SleepMs=50")
 	TpBin = buildBinary("github.com/maistra/istio-workspace/test/echo", "telepresence")
+	TpVersionBin = buildBinary("github.com/maistra/istio-workspace/test/echo", "telepresence", "-ldflags", "-w -X main.Echo=0.234")
 	TpSleepBin = buildBinary("github.com/maistra/istio-workspace/test/echo",
 		"telepresence", "-ldflags", "-w -X main.SleepMs=50")
 }


### PR DESCRIPTION
### Short description of what this resolves:

Sends the telepresence version used by the client (i.e. `ike develop`) to the server so the proper version of the image is used. Otherwise, if there's a mismatch, the command will fail highlighting this problem. This happens in the current implementation when we have hardcoded default and we don't send `TELEPRESENCE_VERSION` environment variable in the target deployment.

#### Changes proposed in this pull request:

- checks version of telepresence using binary telepresence version resolution works as follows now:
  - `TELEPRESENCE_VERSION` env var takes precedence
  - if telepresence binary is available on the path then it will call `telepresence --version`
  - otherwise, we return hardcoded default version (last resort)
- introduces telepresence wrapper exposing functionalities used across the
pkgs
- tests tp version passed from the client by not setting env var for 4.x cluster e2e tests on CircleCI

Fixes #284 
