### PR TITLE
feat: introduces env var handling for tests

### DIFF
--- a/pkg/cmd/develop/develop_test.go
+++ b/pkg/cmd/develop/develop_test.go
@@ -39,10 +39,10 @@ var _ = Describe("Usage of ike develop command", func() {
 		AfterEach(tmpPath.Restore)
 
 		It("should fail invoking develop cmd when telepresence binary is not on $PATH", func() {
-			oldPath := os.Getenv("PATH")
-			_ = os.Setenv("PATH", "")
+			envVars := TemporaryEnvVars()
+			envVars.Set("PATH", "")
 			defer func() {
-				_ = os.Setenv("PATH", oldPath)
+				envVars.Restore()
 			}()
 
 			_, err := ValidateArgumentsOf(developCmd).Passing("-r", "./test.sh", "-d", "hello-world")
@@ -162,16 +162,13 @@ var _ = Describe("Usage of ike develop command", func() {
 
 			Context("with ENV port variable", func() {
 
-				var oldEnv string
+				envVars := TemporaryEnvVars()
 
 				BeforeEach(func() {
-					oldEnv = os.Getenv("IKE_DEVELOP_PORT")
-					_ = os.Setenv("IKE_DEVELOP_PORT", "4321")
+					envVars.Set("IKE_DEVELOP_PORT", "4321")
 				})
 
-				AfterEach(func() {
-					_ = os.Setenv("IKE_DEVELOP_PORT", oldEnv)
-				})
+				AfterEach(envVars.Restore)
 
 				It("should use environment variable over config file", func() {
 					_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name())

--- a/pkg/cmd/develop/develop_test.go
+++ b/pkg/cmd/develop/develop_test.go
@@ -39,11 +39,8 @@ var _ = Describe("Usage of ike develop command", func() {
 		AfterEach(tmpPath.Restore)
 
 		It("should fail invoking develop cmd when telepresence binary is not on $PATH", func() {
-			envVars := TemporaryEnvVars()
-			envVars.Set("PATH", "")
-			defer func() {
-				envVars.Restore()
-			}()
+			restore := TemporaryEnvVars("PATH", "")
+			defer restore()
 
 			_, err := ValidateArgumentsOf(developCmd).Passing("-r", "./test.sh", "-d", "hello-world")
 
@@ -162,13 +159,13 @@ var _ = Describe("Usage of ike develop command", func() {
 
 			Context("with ENV port variable", func() {
 
-				envVars := TemporaryEnvVars()
-
+				var restoreEnvVars func()
 				BeforeEach(func() {
-					envVars.Set("IKE_DEVELOP_PORT", "4321")
+					restoreEnvVars = TemporaryEnvVars("IKE_DEVELOP_PORT", "4321")
 				})
-
-				AfterEach(envVars.Restore)
+				AfterEach(func() {
+					restoreEnvVars()
+				})
 
 				It("should use environment variable over config file", func() {
 					_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name())

--- a/pkg/cmd/internal/session/session_func_test.go
+++ b/pkg/cmd/internal/session/session_func_test.go
@@ -14,13 +14,13 @@ import (
 
 var _ = Describe("Usage of session func", func() {
 
-	envVars := test.TemporaryEnvVars()
-
+	var restoreEnvVars func()
 	BeforeEach(func() {
-		envVars.Set("TELEPRESENCE_VERSION", "0.123")
+		restoreEnvVars = test.TemporaryEnvVars("TELEPRESENCE_VERSION", "0.123")
 	})
-
-	AfterEach(envVars.Restore)
+	AfterEach(func() {
+		restoreEnvVars()
+	})
 
 	Context("checking required command arguments", func() {
 

--- a/pkg/cmd/internal/session/session_func_test.go
+++ b/pkg/cmd/internal/session/session_func_test.go
@@ -1,10 +1,9 @@
 package internal_test
 
 import (
-	"os"
-
 	"github.com/maistra/istio-workspace/pkg/cmd/develop"
 	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
+	"github.com/maistra/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,19 +14,13 @@ import (
 
 var _ = Describe("Usage of session func", func() {
 
-	currentTpVersion := os.Getenv("TELEPRESENCE_VERSION")
+	envVars := test.TemporaryEnvVars()
 
 	BeforeEach(func() {
-		_ = os.Setenv("TELEPRESENCE_VERSION", "0.123")
+		envVars.Set("TELEPRESENCE_VERSION", "0.123")
 	})
 
-	AfterEach(func() {
-		if currentTpVersion != "" {
-			_ = os.Setenv("TELEPRESENCE_VERSION", currentTpVersion)
-		} else {
-			_ = os.Unsetenv("TELEPRESENCE_VERSION")
-		}
-	})
+	AfterEach(envVars.Restore)
 
 	Context("checking required command arguments", func() {
 

--- a/pkg/openshift/parser/template_test.go
+++ b/pkg/openshift/parser/template_test.go
@@ -1,8 +1,7 @@
 package parser_test
 
 import (
-	"os"
-
+	"github.com/maistra/istio-workspace/test"
 	"github.com/maistra/istio-workspace/version"
 
 	. "github.com/maistra/istio-workspace/pkg/openshift/parser"
@@ -66,22 +65,15 @@ var _ = Describe("template processing", func() {
 
 			It("should process operator template", func() {
 				// given
-				newEnvs := map[string]string{
+				envVars := test.TemporaryEnvVars()
+				envVars.SetAll(map[string]string{
 					"IKE_DOCKER_REGISTRY":   "quay.io",
 					"IKE_DOCKER_REPOSITORY": "istio-workspace",
 					"IKE_IMAGE_NAME":        "ike-cli",
 					"IKE_IMAGE_TAG":         "latest",
-				}
-
-				oldEnvs := map[string]string{}
-				for k, v := range newEnvs {
-					oldEnvs[os.Getenv(k)] = v
-					_ = os.Setenv(k, v)
-				}
+				})
 				defer func() {
-					for k, v := range oldEnvs {
-						_ = os.Setenv(k, v)
-					}
+					envVars.Restore()
 				}()
 
 				var yaml []byte

--- a/pkg/openshift/parser/template_test.go
+++ b/pkg/openshift/parser/template_test.go
@@ -65,16 +65,11 @@ var _ = Describe("template processing", func() {
 
 			It("should process operator template", func() {
 				// given
-				envVars := test.TemporaryEnvVars()
-				envVars.SetAll(map[string]string{
-					"IKE_DOCKER_REGISTRY":   "quay.io",
-					"IKE_DOCKER_REPOSITORY": "istio-workspace",
-					"IKE_IMAGE_NAME":        "ike-cli",
-					"IKE_IMAGE_TAG":         "latest",
-				})
-				defer func() {
-					envVars.Restore()
-				}()
+				restoreEnvVars := test.TemporaryEnvVars("IKE_DOCKER_REGISTRY", "quay.io",
+					"IKE_DOCKER_REPOSITORY", "istio-workspace",
+					"IKE_IMAGE_NAME", "ike-cli",
+					"IKE_IMAGE_TAG", "latest")
+				defer restoreEnvVars()
 
 				var yaml []byte
 

--- a/pkg/telepresence/wrapper_test.go
+++ b/pkg/telepresence/wrapper_test.go
@@ -1,7 +1,6 @@
 package telepresence_test
 
 import (
-	"os"
 	"path"
 
 	"github.com/maistra/istio-workspace/test/shell"
@@ -39,15 +38,11 @@ var _ = Describe("telepresence commands wrapper", func() {
 
 		It("should retrieve version from TELEPRESENCE_VERSION env variable when defined", func() {
 			// given
-			currentTpVersion := os.Getenv("TELEPRESENCE_VERSION")
+			envVars := TemporaryEnvVars()
+			envVars.Set("TELEPRESENCE_VERSION", "0.123")
 			defer func() {
-				if currentTpVersion != "" {
-					_ = os.Setenv("TELEPRESENCE_VERSION", currentTpVersion)
-				} else {
-					_ = os.Unsetenv("TELEPRESENCE_VERSION")
-				}
+				envVars.Restore()
 			}()
-			_ = os.Setenv("TELEPRESENCE_VERSION", "0.123")
 
 			// when
 			version, err := telepresence.GetVersion()

--- a/pkg/telepresence/wrapper_test.go
+++ b/pkg/telepresence/wrapper_test.go
@@ -38,11 +38,8 @@ var _ = Describe("telepresence commands wrapper", func() {
 
 		It("should retrieve version from TELEPRESENCE_VERSION env variable when defined", func() {
 			// given
-			envVars := TemporaryEnvVars()
-			envVars.Set("TELEPRESENCE_VERSION", "0.123")
-			defer func() {
-				envVars.Restore()
-			}()
+			restoreEnvVars := TemporaryEnvVars("TELEPRESENCE_VERSION", "0.123")
+			defer restoreEnvVars()
 
 			// when
 			version, err := telepresence.GetVersion()

--- a/test/os_env.go
+++ b/test/os_env.go
@@ -1,0 +1,38 @@
+package test
+
+import "os"
+
+type EnvVars struct {
+	originalEnvs map[string]string
+}
+
+func TemporaryEnvVars() *EnvVars {
+	return &EnvVars{
+		originalEnvs: map[string]string{},
+	}
+}
+
+func (env *EnvVars) SetAll(envVars map[string]string) {
+	for k, v := range envVars {
+		env.Set(k, v)
+	}
+}
+
+func (env *EnvVars) Set(key, value string) {
+	env.originalEnvs[key] = os.Getenv(key)
+	if value != "" {
+		_ = os.Setenv(key, value)
+	} else {
+		_ = os.Unsetenv(key)
+	}
+}
+
+func (env *EnvVars) Restore() {
+	for k, v := range env.originalEnvs {
+		if v != "" {
+			_ = os.Setenv(k, v)
+		} else {
+			_ = os.Unsetenv(k)
+		}
+	}
+}

--- a/test/os_env.go
+++ b/test/os_env.go
@@ -2,37 +2,33 @@ package test
 
 import "os"
 
-type EnvVars struct {
-	originalEnvs map[string]string
-}
-
-func TemporaryEnvVars() *EnvVars {
-	return &EnvVars{
-		originalEnvs: map[string]string{},
+func TemporaryEnvVars(keyValues ...string) func() {
+	if len(keyValues)%2 != 0 {
+		panic("you should supply even amount of key-value arguments")
 	}
-}
 
-func (env *EnvVars) SetAll(envVars map[string]string) {
-	for k, v := range envVars {
-		env.Set(k, v)
+	vars := map[string]string{}
+	for i := 0; i < len(keyValues); i += 2 {
+		vars[keyValues[i]] = keyValues[i+1]
 	}
-}
+	originalEnvs := map[string]string{}
 
-func (env *EnvVars) Set(key, value string) {
-	env.originalEnvs[key] = os.Getenv(key)
-	if value != "" {
-		_ = os.Setenv(key, value)
-	} else {
-		_ = os.Unsetenv(key)
-	}
-}
-
-func (env *EnvVars) Restore() {
-	for k, v := range env.originalEnvs {
-		if v != "" {
-			_ = os.Setenv(k, v)
+	for key, value := range vars {
+		originalEnvs[key] = os.Getenv(key)
+		if value != "" {
+			_ = os.Setenv(key, value)
 		} else {
-			_ = os.Unsetenv(k)
+			_ = os.Unsetenv(key)
+		}
+	}
+
+	return func() {
+		for k, v := range originalEnvs {
+			if v != "" {
+				_ = os.Setenv(k, v)
+			} else {
+				_ = os.Unsetenv(k)
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Simplifies overwriting and restoring environment variables in tests.

Now you can simply do:

```golang
It("should process operator template", func() {
	// given
	envVars := test.TemporaryEnvVars()
	envVars.SetAll(map[string]string{
		"IKE_DOCKER_REGISTRY":   "quay.io",
		"IKE_DOCKER_REPOSITORY": "istio-workspace",
		"IKE_IMAGE_NAME":        "ike-cli",
		"IKE_IMAGE_TAG":         "latest",
	})
	defer func() {
		envVars.Restore()
	}()

	// ...
})
```

or by using ginkgo hooks:

```golang
envVars := TemporaryEnvVars()

BeforeEach(func() {
	envVars.Set("IKE_DEVELOP_PORT", "4321")
})

AfterEach(envVars.Restore)
```
