### PR TITLE
chore: enables deployment config e2e tests

### DIFF
--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -211,10 +211,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 
 		})
 
-		// Telepresence fails on picking up oc/openshift cluster due to /apis being secured.
-		// Thus it treats cluster as vanilla k8s and expects Deployment, not DeploymentConfig to appear
-		// Enable when https://github.com/telepresenceio/telepresence/issues/1139 is fixed
-		XContext("openshift deploymentconfig", func() {
+		Context("openshift deploymentconfig", func() {
 
 			BeforeEach(func() {
 				scenario = "scenario-2"


### PR DESCRIPTION
Telepresence has been released with a patch so let's enable problematic `DeploymentConfig` tests back.