### PR TITLE
fix(operator): mutate route if subset is missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           name: "Installs Openshift and k8s client tools"
           command: |
             cd ~
-            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.5/openshift-install-linux-4.2.5.tar.gz" -O "oc.tar.gz"
+            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.5/openshift-client-linux-4.2.5.tar.gz" -O "oc.tar.gz"
             tar xzfv oc.tar.gz
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           name: "Installs Openshift and k8s client tools"
           command: |
             cd ~
-            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-09-24-025718/openshift-client-linux-4.2.0-0.nightly-2019-09-24-025718.tar.gz" -O "oc.tar.gz"
+            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.5/openshift-install-linux-4.2.5.tar.gz" -O "oc.tar.gz"
             tar xzfv oc.tar.gz
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -108,8 +108,8 @@ func mutateVirtualService(ctx model.SessionContext, sourceResource model.Located
 	}
 	removeOtherRoutes := func(http v1alpha3.HTTPRoute, host, subset string) v1alpha3.HTTPRoute {
 		for i, r := range http.Route {
-			if !((r.Destination.Host == host && r.Destination.Subset == subset) ||
-				(r.Destination.Host == host && r.Destination.Subset == "")) {
+			if !((r.Destination != nil && r.Destination.Host == host && r.Destination.Subset == subset) ||
+				(r.Destination != nil && r.Destination.Host == host && r.Destination.Subset == "")) {
 				http.Route = append(http.Route[:i], http.Route[i+1:]...)
 			}
 		}

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -97,8 +97,10 @@ func mutateVirtualService(ctx model.SessionContext, sourceResource model.Located
 		routes := []*v1alpha3.HTTPRoute{}
 		for _, h := range vs.Spec.Http {
 			for _, r := range h.Route {
-				if r.Destination.Host == host && r.Destination.Subset == subset {
-					routes = append(routes, h)
+				if r.Destination != nil && r.Destination.Host == host {
+					if r.Destination.Subset == "" || r.Destination.Subset == subset {
+						routes = append(routes, h)
+					}
 				}
 			}
 		}
@@ -106,7 +108,8 @@ func mutateVirtualService(ctx model.SessionContext, sourceResource model.Located
 	}
 	removeOtherRoutes := func(http v1alpha3.HTTPRoute, host, subset string) v1alpha3.HTTPRoute {
 		for i, r := range http.Route {
-			if !(r.Destination.Host == host && r.Destination.Subset == subset) {
+			if !((r.Destination.Host == host && r.Destination.Subset == subset) ||
+				(r.Destination.Host == host && r.Destination.Subset == "")) {
 				http.Route = append(http.Route[:i], http.Route[i+1:]...)
 			}
 		}

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -161,6 +161,23 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 
 					Expect(GetMutatedRoute(mutatedVirtualService, targetV6Host, targetV6Subset).Redirect).To(BeNil())
 				})
+
+				It("route missing", func() {
+					_, err = mutateVirtualService(
+						ctx,
+						model.NewLocatedResource("Deployment", "miss-v5", map[string]string{"version": "v5"}),
+						virtualService)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("route not found"))
+				})
+				It("route missing version", func() {
+					_, err = mutateVirtualService(
+						ctx,
+						model.NewLocatedResource("Deployment", "details-v10", map[string]string{"version": "v10"}),
+						virtualService)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("route not found"))
+				})
 			})
 		})
 

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -51,6 +51,9 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 					targetV5              = model.NewLocatedResource("Deployment", "details-v5", map[string]string{"version": "v5"})
 					targetV5Host          = "details"
 					targetV5Subset        = "v5-vs-test"
+					targetV6              = model.NewLocatedResource("Deployment", "x-v5", map[string]string{"version": "v5"})
+					targetV6Host          = "x"
+					targetV6Subset        = "v5-vs-test"
 				)
 
 				BeforeEach(func() {
@@ -151,6 +154,12 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Redirect).To(BeNil())
+				})
+				It("include destinations with no subset", func() {
+					mutatedVirtualService, err = mutateVirtualService(ctx, targetV6, virtualService)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(GetMutatedRoute(mutatedVirtualService, targetV6Host, targetV6Subset).Redirect).To(BeNil())
 				})
 			})
 		})


### PR DESCRIPTION
If a mutation does not occur the original route will be hit and end up
round-robin between different versions.

fixes #307
