### PR TITLE
feat(circleci): adds changelog integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,13 +175,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Sets up Quay.io"
-          command: |
-            mkdir -p ~/.docker && chmod 0700 ~/.docker
-            touch ~/.docker/config.json && chmod 0600 ~/.docker/config.json
-            echo $QUAY_AUTH_JSON > ~/.docker/config.json
-            docker login quay.io
-      - run:
           name: "Installs release tools prerequisites"
           command: |
             gem install asciidoctor
@@ -189,12 +182,25 @@ jobs:
       - run:
           <<: *golang-install
       - run:
+          name: "Installs GitHub Changelog Generator"
+          command: |
+            ghc_dir=$(curl -sL http://git.io/install-ghc | bash -s -- --path-only)
+            sudo mv $ghc_dir/ghc /usr/local/bin/
+      - run:
+          name: "Sets up Quay.io"
+          command: |
+            mkdir -p ~/.docker && chmod 0700 ~/.docker
+            touch ~/.docker/config.json && chmod 0600 ~/.docker/config.json
+            echo $QUAY_AUTH_JSON > ~/.docker/config.json
+            docker login quay.io
+      - run:
           name: "Push it!"
           command: |
             make deps docker-build docker-push-versioned
       - run:
           name: "Release it!"
           command: |
+            ghc generate -r maistra/istio-workspace --format adoc >> docs/modules/ROOT/pages/release_notes/${CIRCLE_TAG}.adoc
             asciidoctor -b docbook -a leveloffset=+1 -o - docs/modules/ROOT/pages/release_notes/${CIRCLE_TAG}.adoc | pandoc --atx-headers --wrap=preserve -t markdown_strict -f docbook - 1> converted-release-notes.md
             curl -sL https://git.io/goreleaser | bash -s -- release --rm-dist --release-notes=converted-release-notes.md
 


### PR DESCRIPTION
#### Short description of what this resolves:

Adds https://github.com/bartoszmajsak/github-changelog-generator as part of `release` job. This will fetch all the PRs since the last release and append it to prepared release notes (some highlights we put in `docs/modules/ROOT/pages/release_notes/VERSION.adoc` as part of release process).

Here's how it looks like https://gist.github.com/bartoszmajsak/a079f411bac1df8b2c560561b3cf7318

#### Changes proposed in this pull request:

- updates `circleci` job to run `ghc` tool to generate release notes for `goreleaser`

Fixes #161 
