### PR TITLE
chore: bumps golang to latest 1.13.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ defaults:
     name: "Installs latest Golang"
     command: |
       sudo rm -rf /usr/local/go
-      sudo circleci-install golang 1.13.4
+      sudo circleci-install golang 1.13.5
   docker:
-    - image: &golang-img circleci/golang:1.13.4
+    - image: &golang-img circleci/golang:1.13.5
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   env-vars: &env-vars


### PR DESCRIPTION
#### Short description of what this resolves:

Updates golang runtime to latest `1.13.5`.

#### Changes proposed in this pull request:

- circleci golang version updated both in builder image and e2e test machine
