### PR TITLE
fix(deps): locks openshift api on commit hash

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,8 @@ required = [
 
 [[constraint]]
   name = "github.com/openshift/api"
-  version = "=v3.9.0"
+  # v3.9.0 (which was a tag on that commit) does not exist anymore
+  revision = "0d921e363e951d89f583292c60d013c318df64dc"
 
 [[constraint]]
   name = "github.com/go-cmd/cmd"


### PR DESCRIPTION
`v3.9.0` tag has disappeared from `openshift/api` repo. Locking it down to the commit hash instead.
