### PR TITLE
feat: logs version when starting the operator

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -49,7 +49,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 			shouldPrintVersion, _ := cmd.Flags().GetBool("version")
 			if shouldPrintVersion {
-				version.PrintVersion()
+				version.LogVersion()
 			} else {
 				fmt.Print(cmd.UsageString())
 			}

--- a/pkg/cmd/serve/serve.go
+++ b/pkg/cmd/serve/serve.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/maistra/istio-workspace/pkg/cmd/version"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -97,6 +99,7 @@ func startOperator(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 	}
 
 	log.Info("Starting the operator.")
+	version.LogVersion()
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -21,13 +21,13 @@ func NewCmd() *cobra.Command {
 		Long:         "All software has versions. This is Ike's",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
-			PrintVersion()
+			LogVersion()
 			return nil
 		},
 	}
 }
 
-func PrintVersion() {
+func LogVersion() {
 	log.Info(fmt.Sprintf("Ike Version: %s", version.Version))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))


### PR DESCRIPTION
#### Short description of what this resolves:

Logs version of the operator in the container logs.

I'm mostly using `k9s` to fiddle around, so I thought it will make my life a bit easier - I know instantly which version I'm running against (especially when using `latest` as image tag)

#### Changes proposed in this pull request:

- logs version when starting operator
- renames `PrintVersion` to `LogVersion`
