### PR TITLE
feat: introduces ENV_FILE var to overwrite variables used in tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -311,6 +311,14 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:f5b9328966ccea0970b1d15075698eff0ddb3e75889560aad2e9f76b289b536a"
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:5e349fd839ecbd417975da64c8b69764d78859c5cf9817460b4fb763852eb44e"
   name = "github.com/json-iterator/go"
   packages = ["."]
@@ -1227,6 +1235,7 @@
     "github.com/google/go-github/github",
     "github.com/google/shlex",
     "github.com/hashicorp/go-multierror",
+    "github.com/joho/godotenv",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,6 +91,10 @@ required = [
   version = "=1.11.0"
 
 [[constraint]]
+  name = "github.com/joho/godotenv"
+  version = "=v1.3.0"
+
+[[constraint]]
   name = "go.uber.org/goleak"
   branch = "master"
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,6 @@ test/cmd/test-service/html.go: test/cmd/test-service/assets/index.html
 .PHONY: compile-test-service
 compile-test-service: test/cmd/test-service/html.go $(BINARY_DIR)/$(TEST_BINARY_NAME)
 
-
 ##@ Setup
 
 .PHONY: install-dep

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -33,7 +33,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	if envFile, found := os.LookupEnv("ENV_FILE"); found {
-		if err := godotenv.Load( testshell.GetProjectDir() + string(os.PathSeparator) + envFile); err != nil {
+		if err := godotenv.Load(testshell.GetProjectDir() + string(os.PathSeparator) + envFile); err != nil {
 			Fail(err.Error())
 		}
 	}

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/maistra/istio-workspace/test"
 	testshell "github.com/maistra/istio-workspace/test/shell"
 
+	"github.com/joho/godotenv"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -30,6 +31,12 @@ var tmpPath = NewTmpPath()
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	rand.Seed(time.Now().UTC().UnixNano())
+
+	if envFile, found := os.LookupEnv("ENV_FILE"); found {
+		if err := godotenv.Load( testshell.GetProjectDir() + string(os.PathSeparator) + envFile); err != nil {
+			Fail(err.Error())
+		}
+	}
 
 	ClientVersion()
 


### PR DESCRIPTION
#### Short description of what this resolves:

When `ENV_FILE` is set, variables defined in that file will overwrite any other settings (including existing system settings). This way one can have files used for testing against different clusters and swap them easily.

#### Changes proposed in this pull request:

- loads env file before e2e suite starts

