### PR TITLE
fix: uses username defined by IKE_CLUSTER_USER instead of oc whoami

### DIFF
--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -18,9 +18,11 @@ func UpdateSecurityConstraintsFor(namespace string) {
 		"oc adm policy add-scc-to-user privileged -z default -n "+namespace)
 }
 
+var user = "admin" //nolint[:goconst]
+var pwd = "admin"  //nolint[:goconst]
+
 func LoginAsTestPowerUser() {
-	user := "admin" //nolint[:goconst]
-	pwd := "admin"  //nolint[:goconst]
+
 	if ikeUser, found := os.LookupEnv("IKE_CLUSTER_USER"); found {
 		user = ikeUser
 	}

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -20,7 +20,7 @@ func BuildOperator() (registry string) {
 	projectDir := shell.GetProjectDir()
 	_, registry = setDockerEnvForOperatorBuild()
 	LoginAsTestPowerUser()
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
+	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u " + user + " -p $(oc whoami -t) "+registry).Done()
 	<-shell.ExecuteInDir(projectDir, "make", "docker-build").Done()
 	return
 }

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -20,7 +20,7 @@ func BuildOperator() (registry string) {
 	projectDir := shell.GetProjectDir()
 	_, registry = setDockerEnvForOperatorBuild()
 	LoginAsTestPowerUser()
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u " + user + " -p $(oc whoami -t) "+registry).Done()
+	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u "+user+" -p $(oc whoami -t) "+registry).Done()
 	<-shell.ExecuteInDir(projectDir, "make", "docker-build").Done()
 	return
 }

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -39,7 +39,7 @@ func BuildTestServicePreparedImage(callerName, namespace string) (registry strin
 	os.Setenv("IKE_TEST_PREPARED_NAME", callerName)
 
 	LoginAsTestPowerUser()
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u " + user + " -p $(oc whoami -t) "+registry).Done()
+	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u "+user+" -p $(oc whoami -t) "+registry).Done()
 	<-shell.ExecuteInDir(projectDir, "make", "docker-build-test-prepared", "docker-push-test-prepared").Done()
 	return
 }

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -26,7 +26,7 @@ func BuildTestService(namespace string) (registry string) {
 	registry = setDockerEnvForTestServiceBuild(namespace)
 
 	LoginAsTestPowerUser()
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u " + user + " -p $(oc whoami -t) "+registry).Done()
+	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u "+user+" -p $(oc whoami -t) "+registry).Done()
 	<-shell.ExecuteInDir(projectDir, "make", "docker-build-test", "docker-push-test").Done()
 	return
 }

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -26,7 +26,7 @@ func BuildTestService(namespace string) (registry string) {
 	registry = setDockerEnvForTestServiceBuild(namespace)
 
 	LoginAsTestPowerUser()
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
+	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u " + user + " -p $(oc whoami -t) "+registry).Done()
 	<-shell.ExecuteInDir(projectDir, "make", "docker-build-test", "docker-push-test").Done()
 	return
 }
@@ -39,7 +39,7 @@ func BuildTestServicePreparedImage(callerName, namespace string) (registry strin
 	os.Setenv("IKE_TEST_PREPARED_NAME", callerName)
 
 	LoginAsTestPowerUser()
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u $(oc whoami) -p $(oc whoami -t) "+registry).Done()
+	<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u " + user + " -p $(oc whoami -t) "+registry).Done()
 	<-shell.ExecuteInDir(projectDir, "make", "docker-build-test-prepared", "docker-push-test-prepared").Done()
 	return
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Using user defined by `IKE_CLUSTER_USER` variable rather than `oc whoami` command. Latter can retur `kube:admin` which won't work as login to internal docker registry .

