### PR TITLE
chore(lint): removes unnecessary new line

### DIFF
--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -22,7 +22,6 @@ var user = "admin" //nolint[:goconst]
 var pwd = "admin"  //nolint[:goconst]
 
 func LoginAsTestPowerUser() {
-
 	if ikeUser, found := os.LookupEnv("IKE_CLUSTER_USER"); found {
 		user = ikeUser
 	}


### PR DESCRIPTION
Not sure why it's not failing on `master` build, but locally, having the same version of `golangci-lint` version I was getting this:

```
golangci-lint run
e2e/infra/cluster_operations.go:24: unnecessary leading newline (whitespace)
func LoginAsTestPowerUser() {

make: *** [Makefile:71: lint] Error 1
```