### PR TITLE
chore(circle): circle cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - ./vendor
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) installed (local)
-  e2e_tests_local:
+  e2e_tests_local_openshift_3:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
       <<: *machine-conf
@@ -103,7 +103,7 @@ jobs:
           paths:
             - ./vendor
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
-  e2e_tests_remote:
+  e2e_tests_remote_openshift_4:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
       <<: *machine-conf
@@ -211,8 +211,8 @@ workflows:
       - build
   circleci_e2e_tests:
     jobs:
-      - e2e_tests_local
-      - e2e_tests_remote
+      - e2e_tests_local_openshift_3
+      - e2e_tests_remote_openshift_4
   circleci_release:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           name: "Installs Openshift and k8s client tools"
           command: |
             cd ~
-            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.8/openshift-client-linux-4.2.8.tar.gz" -O "oc.tar.gz"
+            wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.3.2/openshift-client-linux-4.3.2.tar.gz" -O "oc.tar.gz"
             tar xzfv oc.tar.gz
             sudo mv $PWD/oc /usr/local/bin/
             echo "Installed oc\n$(oc version)\n"


### PR DESCRIPTION
- renames e2e jobs to have openshift version in them
- aligns `oc` client version with the remote cluster