### PR TITLE
feat(github): introduces label sync action

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,52 @@
+- name: Epic
+  color: 3E4B9E
+- name: component/ci
+  color: e575b2
+  description: "Component: CI Integraton"
+- name: component/cli
+  color: e575b2
+  description: "Component: CLI tooling"
+- name: component/docs
+  color: e575b2
+  description: "Component: Documentation"
+- name: component/ide
+  color: e575b2
+  description: "Component: IDE Integration"
+- name: component/operator
+  color: e575b2
+  description: "Component: Operator service"
+- name: dependencies
+  color: 21ceff
+  description: "Dependabot: Pull requests that update a dependency file"
+- name: docker
+  color: 21ceff
+  description: "Dependabot: Pull requests that update Docker code"
+- name: external/collaboration
+  color: 9596db
+  description: "External: outreach/patching/"
+- name: go
+  color: 21ceff
+  description: "Dependabot: Pull requests that update Go code"
+- name: internal/infra
+  color: e8e540
+  description: "Internal: related to project build / setup / release"
+- name: internal/test-infra
+  color: e8e540
+  description: "Internal: related to project testing"
+- name: kind/bug
+  color: "008672"
+  description: "Kind: Not working as expected"
+- name: kind/enhancement
+  color: "008672"
+  description: "Kind: New feature or request"
+- name: reason/breaking-changes
+  color: 8e0b30
+  description: "Reason: dependency update with compatibility issues"
+- name: skip-changelog
+  color: e5950b
+  description: "Command: used by changelog generator"
+- name: spike
+  color: 9d09bf
+  description: "related to discovery of stuff"
+- name: upstream
+  color: 1fddb7

--- a/.github/workflows/update_labels.yml
+++ b/.github/workflows/update_labels.yml
@@ -1,0 +1,19 @@
+name: Update Labels
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/labels.yml'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: .github/labels.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Short description of what this resolves:

Manages github labels as code.

#### Changes proposed in this pull request:

- current actions dumped to yaml file
- github action to be triggered on push on master branch to sync changes

Fixes #13
