### PR TITLE
fix(e2e): add to the members array instead of replacing it

### DIFF
--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -52,7 +52,7 @@ func DeployTestScenario(scenario, namespace string) {
 	LoginAsTestPowerUser()
 	if ClientVersion() == 4 {
 		<-shell.ExecuteInDir(".", "bash", "-c",
-			`oc -n `+GetIstioNamespace()+` patch --type='json' smmr default -p '[{"op": "add", "path": "/spec/members", "value":["'"`+namespace+`"'"]}]'`).Done()
+			`oc -n `+GetIstioNamespace()+` patch --type='json' smmr default -p '[{"op": "add", "path": "/spec/members/-", "value":"`+namespace+`"}]'`).Done()
 		gomega.Eventually(func() string {
 			return GetProjectLabels(namespace)
 		}, 1*time.Minute).Should(gomega.ContainSubstring("maistra.io/member-of"))


### PR DESCRIPTION
To avoid unregistering other already registered members we should
add to the members' array, not just replace it with our new value.
