### PR TITLE
fix: cleans up linter usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters-settings:
     disabled-checks:
       - wrapperFunc
       - commentFormatting # https://github.com/go-critic/go-critic/issues/755
+      - hugeParam # seems to be premature optimization based on https://github.com/Maistra/istio-workspace/pull/378#discussion_r392208906
   unused:
     check-exported: true
   gocognit:

--- a/e2e/http_funcs.go
+++ b/e2e/http_funcs.go
@@ -14,7 +14,7 @@ func GetBody(rawURL string, cookies ...*http.Cookie) (string, error) {
 	for _, c := range cookies {
 		req.AddCookie(c)
 	}
-	resp, err := http.DefaultClient.Do(req) //nolint[:gosec]
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec //reason test code
 	if err != nil {
 		return "", err
 	}
@@ -35,7 +35,7 @@ func GetBodyWithHeaders(rawURL string, headers map[string]string) (string, error
 	for k, v := range headers {
 		req.Header[k] = []string{v}
 	}
-	resp, err := http.DefaultClient.Do(req) //nolint[:gosec]
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec //reason cmd required by cobra
 	if err != nil {
 		return "", err
 	}

--- a/e2e/infra/cluster_operations.go
+++ b/e2e/infra/cluster_operations.go
@@ -18,8 +18,10 @@ func UpdateSecurityConstraintsFor(namespace string) {
 		"oc adm policy add-scc-to-user privileged -z default -n "+namespace)
 }
 
-var user = "admin" //nolint[:goconst]
-var pwd = "admin"  //nolint[:goconst]
+var (
+	user = "admin"
+	pwd  = "admin"
+)
 
 func LoginAsTestPowerUser() {
 	if ikeUser, found := os.LookupEnv("IKE_CLUSTER_USER"); found {

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -33,7 +33,9 @@ func PushOperatorImage(namespace string) {
 
 	setDockerEnvForLocalOperatorBuild(namespace)
 	_ = os.Setenv("IKE_IMAGE_NAME", "istio-workspace")
-	<-shell.ExecuteInDir(".", "bash", "-c", "docker tag $IKE_DOCKER_REGISTRY/istio-workspace-operator/$IKE_IMAGE_NAME:$IKE_IMAGE_TAG $IKE_DOCKER_REGISTRY/"+namespace+"/$IKE_IMAGE_NAME:$IKE_IMAGE_TAG").Done() //nolint[:lll]
+	<-shell.ExecuteInDir(".", "bash", "-c",
+		"docker tag $IKE_DOCKER_REGISTRY/istio-workspace-operator/$IKE_IMAGE_NAME:$IKE_IMAGE_TAG "+
+			"$IKE_DOCKER_REGISTRY/"+namespace+"/$IKE_IMAGE_NAME:$IKE_IMAGE_TAG").Done()
 	<-shell.ExecuteInDir(".", "bash", "-c", "docker push $IKE_DOCKER_REGISTRY/"+namespace+"/$IKE_IMAGE_NAME:$IKE_IMAGE_TAG").Done()
 
 	setDockerEnvForLocalOperatorDeploy(namespace)

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -300,7 +300,7 @@ func verifyThatResponseMatchesModifiedService(tmpDir, namespace string) {
 	Eventually(ikeWithWatch.Done(), 1*time.Minute).Should(BeClosed())
 }
 
-func call(routeURL string, headers map[string]string) func() (string, error) { //nolint[:unparam]
+func call(routeURL string, headers map[string]string) func() (string, error) {
 	return func() (string, error) {
 		fmt.Printf("[%s] Checking [%s] with headers [%s]...\n", time.Now().Format("2006-01-02 15:04:05.001"), routeURL, headers)
 		return GetBodyWithHeaders(routeURL, headers)

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 		Example:      eg,
 		SilenceUsage: true,
 		ValidArgs:    []string{"bash", "zsh"},
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":
 				return cmd.Root().GenBashCompletion(os.Stdout)

--- a/pkg/cmd/config/cmd_test.go
+++ b/pkg/cmd/config/cmd_test.go
@@ -138,10 +138,10 @@ func NewTestCmd() *cobra.Command {
 		Use:          "test",
 		Short:        "Test of configuration",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error {
 			value, _ := cmd.Flags().GetString("arg")
 			cmd.Println(expectedOutput, ":", value)
 			return nil

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -16,10 +16,10 @@ func NewCmd() *cobra.Command {
 		Use:          "create",
 		Short:        "Creates a new Session",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error {
 			_, _, err := internal.Sessions(cmd)
 			return err
 		},

--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -16,10 +16,10 @@ func NewCmd() *cobra.Command {
 		Use:          "delete",
 		Short:        "Deletes an existing Session",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error {
 			_, remove, err := internal.RemoveSessions(cmd)
 			if err == nil {
 				remove()

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -32,13 +32,13 @@ func NewCmd() *cobra.Command {
 		Use:          "develop",
 		Short:        "Starts the development flow",
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !telepresence.BinaryAvailable() {
 				return fmt.Errorf("unable to find %s on your $PATH", telepresence.BinaryName)
 			}
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error {
 			dir, err := os.Getwd()
 			if err != nil {
 				return err

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -128,7 +128,7 @@ type applier struct {
 	d parser.DecodeFunc
 }
 
-func newApplier(namespace string) (*applier, error) { //nolint[:golint]
+func newApplier(namespace string) (*applier, error) {
 	client, err := dynclient.NewDefaultDynamicClient(namespace)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -45,7 +45,7 @@ Environment variables you can override:{{range tplParams}}
 	return installCmd
 }
 
-func installOperator(cmd *cobra.Command, args []string) error { //nolint:unparam,gocyclo
+func installOperator(cmd *cobra.Command, args []string) error { //nolint:unparam,gocyclo //reason args required by cobra, cyclo can be skipped in sake of readability
 	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return err

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -45,7 +45,7 @@ Environment variables you can override:{{range tplParams}}
 	return installCmd
 }
 
-func installOperator(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+func installOperator(cmd *cobra.Command, args []string) error { //nolint:unparam
 	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return err

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -45,7 +45,7 @@ Environment variables you can override:{{range tplParams}}
 	return installCmd
 }
 
-func installOperator(cmd *cobra.Command, args []string) error { //nolint:unparam
+func installOperator(cmd *cobra.Command, args []string) error { //nolint:unparam,gocyclo
 	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return err

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 		Use:                    "ike",
 		Short:                  "ike lets you safely develop and test on prod without a sweat",
 		BashCompletionFunction: completion.BashCompletionFunc,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if v.Released() {
 				go func() {
 					latestRelease, _ := version.LatestRelease()
@@ -46,7 +46,7 @@ func NewCmd() *cobra.Command {
 			}
 			return config.SetupConfigSources(loadConfigFileName(cmd))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error {
 			shouldPrintVersion, _ := cmd.Flags().GetBool("version")
 			if shouldPrintVersion {
 				version.LogVersion()

--- a/pkg/cmd/serve/serve.go
+++ b/pkg/cmd/serve/serve.go
@@ -41,7 +41,7 @@ func NewCmd() *cobra.Command {
 	return serveCmd
 }
 
-func startOperator(cmd *cobra.Command, args []string) error { //nolint:unparam
+func startOperator(cmd *cobra.Command, args []string) error { //nolint:unparam //reason cmd required by cobra
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		log.Error(err, "Failed to get watch namespace")

--- a/pkg/cmd/serve/serve.go
+++ b/pkg/cmd/serve/serve.go
@@ -41,7 +41,7 @@ func NewCmd() *cobra.Command {
 	return serveCmd
 }
 
-func startOperator(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+func startOperator(cmd *cobra.Command, args []string) error { //nolint:unparam
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		log.Error(err, "Failed to get watch namespace")

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -20,7 +20,7 @@ func NewCmd() *cobra.Command {
 		Short:        "Prints the version number of ike cli",
 		Long:         "All software has versions. This is Ike's",
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint:unparam
+		RunE: func(cmd *cobra.Command, args []string) error {
 			LogVersion()
 			return nil
 		},

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -20,7 +20,7 @@ func NewCmd() *cobra.Command {
 		Short:        "Prints the version number of ike cli",
 		Long:         "All software has versions. This is Ike's",
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:unparam
 			LogVersion()
 			return nil
 		},

--- a/pkg/controller/session/model_convert.go
+++ b/pkg/controller/session/model_convert.go
@@ -16,7 +16,7 @@ const (
 )
 
 // ConvertModelRefToAPIStatus appends/replaces the Ref in the provided Session.Status.Ref list
-func ConvertModelRefToAPIStatus(ref model.Ref, session *istiov1alpha1.Session) { //nolint[:hugeParam]
+func ConvertModelRefToAPIStatus(ref model.Ref, session *istiov1alpha1.Session) {
 	statusRef := &istiov1alpha1.RefStatus{Ref: istiov1alpha1.Ref{Name: ref.Name, Strategy: ref.Strategy, Args: ref.Args}}
 	for _, t := range ref.Targets {
 		target := t
@@ -49,7 +49,7 @@ func ConvertModelRefToAPIStatus(ref model.Ref, session *istiov1alpha1.Session) {
 }
 
 // ConvertAPIStatusesToModelRefs creates a List of Refs based on the Session.Status.Refs list
-func ConvertAPIStatusesToModelRefs(session istiov1alpha1.Session) []*model.Ref { //nolint[:hugeParam]
+func ConvertAPIStatusesToModelRefs(session istiov1alpha1.Session) []*model.Ref {
 	refs := []*model.Ref{}
 	for _, statusRef := range session.Status.Refs {
 		r := &model.Ref{Name: statusRef.Name, Strategy: statusRef.Strategy, Args: statusRef.Args}
@@ -60,7 +60,7 @@ func ConvertAPIStatusesToModelRefs(session istiov1alpha1.Session) []*model.Ref {
 }
 
 // ConvertAPIStatusToModelRef fills the ResourceStatus of a Ref based on the Session.Status.Refs with the same name
-func ConvertAPIStatusToModelRef(session istiov1alpha1.Session, ref *model.Ref) { //nolint[:hugeParam]
+func ConvertAPIStatusToModelRef(session istiov1alpha1.Session, ref *model.Ref) {
 	for _, statusRef := range session.Status.Refs {
 		if statusRef.Name == ref.Name {
 			for _, statusTarget := range statusRef.Targets {
@@ -99,7 +99,7 @@ func ConvertAPIRouteToModelRoute(session *istiov1alpha1.Session) model.Route {
 }
 
 // RefUpdated check if a Ref has been updated compared to current status
-func RefUpdated(session istiov1alpha1.Session, ref model.Ref) bool { //nolint[:hugeParam]
+func RefUpdated(session istiov1alpha1.Session, ref model.Ref) bool {
 	for _, statusRef := range session.Status.Refs {
 		if statusRef.Name == ref.Name {
 			if statusRef.Strategy != ref.Strategy || !reflect.DeepEqual(statusRef.Args, ref.Args) {

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -165,7 +165,7 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileSession) deleteRemovedRefs(ctx model.SessionContext, session *istiov1alpha1.Session, refs []*model.Ref) { //nolint[:hugeParam]
+func (r *ReconcileSession) deleteRemovedRefs(ctx model.SessionContext, session *istiov1alpha1.Session, refs []*model.Ref) {
 	for _, ref := range refs {
 		found := false
 		for _, r := range session.Spec.Refs {
@@ -182,7 +182,7 @@ func (r *ReconcileSession) deleteRemovedRefs(ctx model.SessionContext, session *
 	}
 }
 
-func (r *ReconcileSession) deleteAllRefs(ctx model.SessionContext, session *istiov1alpha1.Session, refs []*model.Ref) { //nolint[:hugeParam]
+func (r *ReconcileSession) deleteAllRefs(ctx model.SessionContext, session *istiov1alpha1.Session, refs []*model.Ref) {
 	for _, ref := range refs {
 		if err := r.delete(ctx, session, ref); err != nil {
 			ctx.Log.Error(err, "Failed to delete session ref", "ref", ref)
@@ -190,7 +190,7 @@ func (r *ReconcileSession) deleteAllRefs(ctx model.SessionContext, session *isti
 	}
 }
 
-func (r *ReconcileSession) delete(ctx model.SessionContext, session *istiov1alpha1.Session, ref *model.Ref) error { //nolint[:hugeParam]
+func (r *ReconcileSession) delete(ctx model.SessionContext, session *istiov1alpha1.Session, ref *model.Ref) error {
 	ctx.Log.Info("Remove ref", "name", ref.Name)
 
 	ConvertAPIStatusToModelRef(*session, ref)
@@ -204,7 +204,7 @@ func (r *ReconcileSession) delete(ctx model.SessionContext, session *istiov1alph
 	return ctx.Client.Status().Update(ctx, session)
 }
 
-func (r *ReconcileSession) syncAllRefs(ctx model.SessionContext, session *istiov1alpha1.Session) error { //nolint[:hugeParam]
+func (r *ReconcileSession) syncAllRefs(ctx model.SessionContext, session *istiov1alpha1.Session) error {
 	for _, specRef := range session.Spec.Refs {
 		ctx.Log.Info("Add ref", "name", specRef)
 		ref := ConvertAPIRefToModelRef(specRef)
@@ -216,7 +216,7 @@ func (r *ReconcileSession) syncAllRefs(ctx model.SessionContext, session *istiov
 	return nil
 }
 
-func (r *ReconcileSession) sync(ctx model.SessionContext, session *istiov1alpha1.Session, ref *model.Ref) error { //nolint[:hugeParam]
+func (r *ReconcileSession) sync(ctx model.SessionContext, session *istiov1alpha1.Session, ref *model.Ref) error {
 	// if ref has changed, delete first
 	if RefUpdated(*session, *ref) {
 		err := r.delete(ctx, session, ref)

--- a/pkg/controller/session/session_controller_test.go
+++ b/pkg/controller/session/session_controller_test.go
@@ -439,17 +439,17 @@ var _ = Describe("Basic session manipulation", func() {
 })
 
 // notFound Action for Locator tracker
-func notFoundTestLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func notFoundTestLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	return false
 }
 
 // found Action for Locator tracker
-func foundTestLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func foundTestLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	return true
 }
 
 // found Action for Locator tracker
-func foundTestLocatorTarget(names ...string) func(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func foundTestLocatorTarget(names ...string) func(ctx model.SessionContext, ref *model.Ref) bool {
 	return func(ctx model.SessionContext, ref *model.Ref) bool {
 		for _, name := range names {
 			ref.AddTargetResource(model.NewLocatedResource("test", name, map[string]string{}))
@@ -459,7 +459,7 @@ func foundTestLocatorTarget(names ...string) func(ctx model.SessionContext, ref 
 }
 
 // noOp Action for Mutator/Revertor trackers
-func noOp(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func noOp(ctx model.SessionContext, ref *model.Ref) error {
 	return nil
 }
 
@@ -468,13 +468,13 @@ type trackedLocator struct {
 	Action    model.Locator
 }
 
-func (t *trackedLocator) Do(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func (t *trackedLocator) Do(ctx model.SessionContext, ref *model.Ref) bool {
 	t.WasCalled = true
 	return t.Action(ctx, ref)
 }
 
 // addResource Action for mutator tracker
-func addResourceStatus(status model.ResourceStatus) func(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func addResourceStatus(status model.ResourceStatus) func(ctx model.SessionContext, ref *model.Ref) error {
 	return func(ctx model.SessionContext, ref *model.Ref) error {
 		ref.AddResourceStatus(status)
 		return nil
@@ -486,13 +486,13 @@ type trackedMutator struct {
 	Action    model.Mutator
 }
 
-func (t *trackedMutator) Do(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func (t *trackedMutator) Do(ctx model.SessionContext, ref *model.Ref) error {
 	t.WasCalled = true
 	return t.Action(ctx, ref)
 }
 
 // removeResource Action for revertor tracker
-func removeResourceStatus(kind, name string) func(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func removeResourceStatus(kind, name string) func(ctx model.SessionContext, ref *model.Ref) error { //nolint[:unparam] kind is always receiving 'test' so far
 	return func(ctx model.SessionContext, ref *model.Ref) error {
 		ref.RemoveResourceStatus(model.ResourceStatus{Kind: kind, Name: name})
 		return nil
@@ -504,7 +504,7 @@ type trackedRevertor struct {
 	Action    model.Revertor
 }
 
-func (t *trackedRevertor) Do(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func (t *trackedRevertor) Do(ctx model.SessionContext, ref *model.Ref) error {
 	t.WasCalled = true
 	return t.Action(ctx, ref)
 }

--- a/pkg/controller/session/session_controller_test.go
+++ b/pkg/controller/session/session_controller_test.go
@@ -492,7 +492,7 @@ func (t *trackedMutator) Do(ctx model.SessionContext, ref *model.Ref) error {
 }
 
 // removeResource Action for revertor tracker
-func removeResourceStatus(kind, name string) func(ctx model.SessionContext, ref *model.Ref) error { //nolint[:unparam] kind is always receiving 'test' so far
+func removeResourceStatus(kind, name string) func(ctx model.SessionContext, ref *model.Ref) error { //nolint:unparam kind is always receiving 'test' so far
 	return func(ctx model.SessionContext, ref *model.Ref) error {
 		ref.RemoveResourceStatus(model.ResourceStatus{Kind: kind, Name: name})
 		return nil

--- a/pkg/controller/session/session_controller_test.go
+++ b/pkg/controller/session/session_controller_test.go
@@ -492,7 +492,7 @@ func (t *trackedMutator) Do(ctx model.SessionContext, ref *model.Ref) error {
 }
 
 // removeResource Action for revertor tracker
-func removeResourceStatus(kind, name string) func(ctx model.SessionContext, ref *model.Ref) error { //nolint:unparam kind is always receiving 'test' so far
+func removeResourceStatus(kind, name string) func(ctx model.SessionContext, ref *model.Ref) error { //nolint:unparam //reason kind is always receiving 'test' so far
 	return func(ctx model.SessionContext, ref *model.Ref) error {
 		ref.RemoveResourceStatus(model.ResourceStatus{Kind: kind, Name: name})
 		return nil

--- a/pkg/internal/session/session.go
+++ b/pkg/internal/session/session.go
@@ -38,7 +38,7 @@ type State struct {
 type Handler func(opts Options) (State, func(), error)
 
 // Offline is a empty Handler doing nothing. Used for testing
-func Offline(opts Options) (State, func(), error) { //nolint[:hugeParam]
+func Offline(opts Options) (State, func(), error) {
 	return State{DeploymentName: opts.DeploymentName}, func() {}, nil
 }
 
@@ -52,7 +52,7 @@ type handler struct {
 // Rely on the following flags:
 //  * namespace - the name of the target namespace where deployment is defined
 //  * session - the name of the session
-func RemoveHandler(opts Options) (State, func(), error) { //nolint[:hugeParam]
+func RemoveHandler(opts Options) (State, func(), error) {
 	client, err := DefaultClient(opts.NamespaceName)
 
 	if err != nil {
@@ -73,7 +73,7 @@ func RemoveHandler(opts Options) (State, func(), error) { //nolint[:hugeParam]
 //  * deployment - the name of the target deployment and will update the flag with the new deployment name
 //  * session - the name of the session
 //  * route - the definition of traffic routing
-func CreateOrJoinHandler(opts Options) (State, func(), error) { //nolint[:hugeParam]
+func CreateOrJoinHandler(opts Options) (State, func(), error) {
 	sessionName := getOrCreateSessionName(opts.SessionName)
 	opts.SessionName = sessionName
 

--- a/pkg/internal/session/session_client.go
+++ b/pkg/internal/session/session_client.go
@@ -14,7 +14,7 @@ type client struct {
 }
 
 // NewClient creates client to handle Session resources based on passed config
-func NewClient(c versioned.Interface, namespace string) (*client, error) { //nolint[:golint] otherwise golint complains about "exported func returns unexported type *sessionName.client, which can be annoying to use"
+func NewClient(c versioned.Interface, namespace string) (*client, error) { //nolint:golint otherwise golint complains about "exported func returns unexported type *sessionName.client, which can be annoying to use"
 	return &client{namespace: namespace, Interface: c}, nil
 }
 
@@ -24,7 +24,7 @@ var defaultClient *client
 // The instance is created lazily only once and shared among all the callers
 // While resolving configuration we look for .kube/config file unless KUBECONFIG env variable is set
 // If namespace parameter is empty default one from the current context is used
-func DefaultClient(namespace string) (*client, error) { //nolint[:golint] otherwise golint complains about "exported func returns unexported type *sessionName.client, which can be annoying to use"
+func DefaultClient(namespace string) (*client, error) { //nolint:golint otherwise golint complains about "exported func returns unexported type *sessionName.client, which can be annoying to use"
 	if defaultClient == nil {
 		kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			clientcmd.NewDefaultClientConfigLoadingRules(),

--- a/pkg/internal/session/session_client.go
+++ b/pkg/internal/session/session_client.go
@@ -14,7 +14,7 @@ type client struct {
 }
 
 // NewClient creates client to handle Session resources based on passed config
-func NewClient(c versioned.Interface, namespace string) (*client, error) { //nolint:golint otherwise golint complains about "exported func returns unexported type *sessionName.client, which can be annoying to use"
+func NewClient(c versioned.Interface, namespace string) (*client, error) { //nolint:golint //reason otherwise it complaint about annoying client type to use
 	return &client{namespace: namespace, Interface: c}, nil
 }
 
@@ -24,7 +24,7 @@ var defaultClient *client
 // The instance is created lazily only once and shared among all the callers
 // While resolving configuration we look for .kube/config file unless KUBECONFIG env variable is set
 // If namespace parameter is empty default one from the current context is used
-func DefaultClient(namespace string) (*client, error) { //nolint:golint otherwise golint complains about "exported func returns unexported type *sessionName.client, which can be annoying to use"
+func DefaultClient(namespace string) (*client, error) { //nolint:golint //reason otherwise it complaint about annoying client type to use
 	if defaultClient == nil {
 		kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			clientcmd.NewDefaultClientConfigLoadingRules(),

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -107,7 +107,7 @@ func getDestinationRulesByHost(ctx model.SessionContext, namespace, hostName str
 
 	destinationRules := istionetwork.DestinationRuleList{}
 	err := ctx.Client.List(ctx, &destinationRules, client.InNamespace(namespace))
-	for _, dr := range destinationRules.Items { //nolint[:rangeValCopy]
+	for _, dr := range destinationRules.Items { //nolint:rangeValCopy
 		if dr.Spec.Host == hostName {
 			match := dr
 			matches = append(matches, &match)

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -23,7 +23,7 @@ var _ model.Revertor = DestinationRuleRevertor
 
 // DestinationRuleMutator creates destination rule mutator which is responsible for alternating the traffic for development
 // of the forked service
-func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
 	if len(ref.GetResourceStatus(DestinationRuleKind)) > 0 {
 		return nil
 	}
@@ -35,11 +35,7 @@ func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error { //
 		}
 		for _, dr := range drs {
 			ctx.Log.Info("Found DestinationRule", "name", dr.GetName())
-			mutatedDr, err := mutateDestinationRule(*dr, ref.GetNewVersion(ctx.Name))
-			if err != nil {
-				ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: dr.GetName(), Action: model.ActionFailed})
-				ctx.Log.Error(err, "failed to mutate DestinationRule", "name", dr.GetName())
-			}
+			mutatedDr := mutateDestinationRule(*dr, ref.GetNewVersion(ctx.Name))
 			err = ctx.Client.Update(ctx, &mutatedDr)
 			if err != nil {
 				ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: dr.GetName(), Action: model.ActionFailed})
@@ -53,7 +49,7 @@ func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error { //
 }
 
 // DestinationRuleRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects
-func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	resources := ref.GetResourceStatus(DestinationRuleKind)
 
 	for _, resource := range resources {
@@ -67,11 +63,7 @@ func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error { /
 		}
 
 		ctx.Log.Info("Found DestinationRule", "name", resource.Name)
-		mutatedDr, err := revertDestinationRule(*dr, ref.GetNewVersion(ctx.Name))
-		if err != nil {
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: resource.Name, Action: model.ActionFailed})
-			break
-		}
+		mutatedDr := revertDestinationRule(*dr, ref.GetNewVersion(ctx.Name))
 		err = ctx.Client.Update(ctx, &mutatedDr)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: resource.Name, Action: model.ActionFailed})
@@ -84,33 +76,33 @@ func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error { /
 	return nil
 }
 
-func mutateDestinationRule(dr istionetwork.DestinationRule, name string) (istionetwork.DestinationRule, error) { //nolint[:hugeParam]
+func mutateDestinationRule(dr istionetwork.DestinationRule, name string) istionetwork.DestinationRule {
 	dr.Spec.Subsets = append(dr.Spec.Subsets, &v1alpha3.Subset{
 		Name: name,
 		Labels: map[string]string{
 			"version": name,
 		},
 	})
-	return dr, nil
+	return dr
 }
 
-func revertDestinationRule(dr istionetwork.DestinationRule, name string) (istionetwork.DestinationRule, error) { //nolint[:hugeParam]
+func revertDestinationRule(dr istionetwork.DestinationRule, name string) istionetwork.DestinationRule {
 	for i := 0; i < len(dr.Spec.Subsets); i++ {
 		if strings.Contains(dr.Spec.Subsets[i].Name, name) {
 			dr.Spec.Subsets = append(dr.Spec.Subsets[:i], dr.Spec.Subsets[i+1:]...)
 			break
 		}
 	}
-	return dr, nil
+	return dr
 }
 
-func getDestinationRule(ctx model.SessionContext, namespace, name string) (*istionetwork.DestinationRule, error) { //nolint[:hugeParam]
+func getDestinationRule(ctx model.SessionContext, namespace, name string) (*istionetwork.DestinationRule, error) {
 	destinationRule := istionetwork.DestinationRule{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &destinationRule)
 	return &destinationRule, err
 }
 
-func getDestinationRulesByHost(ctx model.SessionContext, namespace, hostName string) ([]*istionetwork.DestinationRule, error) { //nolint[:hugeParam]
+func getDestinationRulesByHost(ctx model.SessionContext, namespace, hostName string) ([]*istionetwork.DestinationRule, error) {
 	matches := []*istionetwork.DestinationRule{}
 
 	destinationRules := istionetwork.DestinationRuleList{}

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -107,7 +107,7 @@ func getDestinationRulesByHost(ctx model.SessionContext, namespace, hostName str
 
 	destinationRules := istionetwork.DestinationRuleList{}
 	err := ctx.Client.List(ctx, &destinationRules, client.InNamespace(namespace))
-	for _, dr := range destinationRules.Items { //nolint:rangeValCopy
+	for _, dr := range destinationRules.Items { //nolint:gocritic //reason for readability
 		if dr.Spec.Host == hostName {
 			match := dr
 			matches = append(matches, &match)

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -36,8 +36,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			JustBeforeEach(func() {
-				mutatedDestinationRule, err = mutateDestinationRule(destinationRule, "dr-test")
-				Expect(err).ToNot(HaveOccurred())
+				mutatedDestinationRule = mutateDestinationRule(destinationRule, "dr-test")
 			})
 
 			It("new subset added", func() {
@@ -67,14 +66,14 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			It("new subset removed", func() {
-				revertedDestinationRule, err = revertDestinationRule(destinationRule, "dr-test")
+				revertedDestinationRule = revertDestinationRule(destinationRule, "dr-test")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(revertedDestinationRule.Spec.Subsets).To(HaveLen(2))
 			})
 
 			It("correct subset removed", func() {
-				revertedDestinationRule, err = revertDestinationRule(destinationRule, "dr-test")
+				revertedDestinationRule = revertDestinationRule(destinationRule, "dr-test")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(revertedDestinationRule.Spec.Subsets).ToNot(ContainElement(WithTransform(GetName, Equal("dr-test"))))

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -37,7 +37,7 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error {
 			return err
 		}
 
-		for _, vs := range vss.Items { //nolint[:rangeValCopy]
+		for _, vs := range vss.Items { //nolint:gocritic //reason for readability
 			if !mutationRequired(vs, hostName, targetVersion) {
 				continue
 			}
@@ -76,7 +76,7 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 		}
 
 		ctx.Log.Info("Found VirtualService", "name", resource.Name)
-		mutatedVs := revertVirtualService(ctx, ref.GetNewVersion(ctx.Name), *vs)
+		mutatedVs := revertVirtualService(ref.GetNewVersion(ctx.Name), *vs)
 		err = ctx.Client.Update(ctx, &mutatedVs)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: resource.Name, Action: model.ActionFailed})
@@ -89,7 +89,7 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	return nil
 }
 
-func mutateVirtualService(ctx model.SessionContext, hostName, version, newVersion string, source istionetwork.VirtualService) (istionetwork.VirtualService, error) { //nolint:gocyclo
+func mutateVirtualService(ctx model.SessionContext, hostName, version, newVersion string, source istionetwork.VirtualService) (istionetwork.VirtualService, error) { //nolint:lll,gocyclo //reason for readability
 	findRoutes := func(vs *istionetwork.VirtualService, host, subset string) []*v1alpha3.HTTPRoute {
 		routes := []*v1alpha3.HTTPRoute{}
 		for _, h := range vs.Spec.Http {
@@ -170,7 +170,7 @@ func mutateVirtualService(ctx model.SessionContext, hostName, version, newVersio
 	return *target, nil
 }
 
-func revertVirtualService(ctx model.SessionContext, subsetName string, vs istionetwork.VirtualService) istionetwork.VirtualService { //nolint[:unparam]
+func revertVirtualService(subsetName string, vs istionetwork.VirtualService) istionetwork.VirtualService {
 	for i := 0; i < len(vs.Spec.Http); i++ {
 		http := vs.Spec.Http[i]
 		for n := 0; n < len(http.Route); n++ {

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -183,24 +183,14 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 			})
 
 			Context("existing rule", func() {
-				var (
-					revertedVirtualService istionetwork.VirtualService
-					ctx                    model.SessionContext
-				)
+				var revertedVirtualService istionetwork.VirtualService
 
 				BeforeEach(func() {
 					yaml = complextMutatedVirtualService
-					ctx = model.SessionContext{
-						Route: model.Route{
-							Type:  "header",
-							Name:  "test",
-							Value: "x",
-						},
-					}
 				})
 
 				JustBeforeEach(func() {
-					revertedVirtualService = revertVirtualService(ctx, "v1-vs-test", virtualService)
+					revertedVirtualService = revertVirtualService("v1-vs-test", virtualService)
 				})
 
 				It("route removed", func() {

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -200,8 +200,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 				})
 
 				JustBeforeEach(func() {
-					revertedVirtualService, err = revertVirtualService(ctx, "v1-vs-test", virtualService)
-					Expect(err).ToNot(HaveOccurred())
+					revertedVirtualService = revertVirtualService(ctx, "v1-vs-test", virtualService)
 				})
 
 				It("route removed", func() {

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -23,7 +23,7 @@ var _ model.Mutator = DeploymentMutator
 var _ model.Revertor = DeploymentRevertor
 
 // DeploymentLocator attempts to locate a Deployment kind based on Ref name
-func DeploymentLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func DeploymentLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	deployment, err := getDeployment(ctx, ctx.Namespace, ref.Name)
 	if err != nil {
 		if errors.IsNotFound(err) { // Ref is not a Deployment type
@@ -37,7 +37,7 @@ func DeploymentLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint
 }
 
 // DeploymentMutator attempts to clone the located Deployment
-func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error {
 	if len(ref.GetResourceStatus(DeploymentKind)) > 0 {
 		return nil
 	}
@@ -73,7 +73,7 @@ func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error { //nolin
 }
 
 // DeploymentRevertor attempts to delete the cloned Deployment
-func DeploymentRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func DeploymentRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	statuses := ref.GetResourceStatus(DeploymentKind)
 	for _, status := range statuses {
 		deployment := &appsv1.Deployment{
@@ -114,7 +114,7 @@ func cloneDeployment(deployment *appsv1.Deployment, ref *model.Ref, version stri
 	return &clone, nil
 }
 
-func getDeployment(ctx model.SessionContext, namespace, name string) (*appsv1.Deployment, error) { //nolint[:hugeParam]
+func getDeployment(ctx model.SessionContext, namespace, name string) (*appsv1.Deployment, error) {
 	deployment := appsv1.Deployment{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment)
 	return &deployment, err

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -27,7 +27,7 @@ func ServiceLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	}
 	found := false
 	for _, deployment := range deployments {
-		for _, service := range services.Items { //nolint:rangeValCopy
+		for _, service := range services.Items { //nolint:gocritic //reason for readability
 			selector := labels.SelectorFromSet(service.Spec.Selector)
 			if selector.Matches(labels.Set(deployment.Labels)) {
 				found = true

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -27,7 +27,7 @@ func ServiceLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	}
 	found := false
 	for _, deployment := range deployments {
-		for _, service := range services.Items { //nolint[:rangeValCopy]
+		for _, service := range services.Items { //nolint:rangeValCopy
 			selector := labels.SelectorFromSet(service.Spec.Selector)
 			if selector.Matches(labels.Set(deployment.Labels)) {
 				found = true

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -17,7 +17,7 @@ const (
 var _ model.Locator = ServiceLocator
 
 // ServiceLocator attempts to locate the Services for the target Deployment/DeploymentConfig
-func ServiceLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func ServiceLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	deployments := ref.GetTargetsByKind("Deployment", "DeploymentConfig")
 
 	services, err := getServices(ctx, ctx.Namespace)
@@ -38,7 +38,7 @@ func ServiceLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:h
 	return found
 }
 
-func getServices(ctx model.SessionContext, namespace string) (*corev1.ServiceList, error) { //nolint[:hugeParam]
+func getServices(ctx model.SessionContext, namespace string) (*corev1.ServiceList, error) {
 	services := corev1.ServiceList{}
 	err := ctx.Client.List(ctx, &services, client.InNamespace(namespace))
 	return &services, err

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -28,7 +28,7 @@ var _ model.Mutator = DeploymentConfigMutator
 var _ model.Revertor = DeploymentConfigRevertor
 
 // DeploymentConfigLocator attempts to locate a DeploymentConfig kind based on Ref name
-func DeploymentConfigLocator(ctx model.SessionContext, ref *model.Ref) bool { //nolint[:hugeParam]
+func DeploymentConfigLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	deployment, err := getDeploymentConfig(ctx, ctx.Namespace, ref.Name)
 	if err != nil {
 		if errors.IsNotFound(err) { // Ref is not a DeploymentConfig type
@@ -42,7 +42,7 @@ func DeploymentConfigLocator(ctx model.SessionContext, ref *model.Ref) bool { //
 }
 
 // DeploymentConfigMutator attempts to clone the located DeploymentConfig
-func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error {
 	if len(ref.GetResourceStatus(DeploymentConfigKind)) > 0 {
 		return nil
 	}
@@ -78,7 +78,7 @@ func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error { /
 }
 
 // DeploymentConfigRevertor attempts to delete the cloned DeploymentConfig
-func DeploymentConfigRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func DeploymentConfigRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	statuses := ref.GetResourceStatus(DeploymentConfigKind)
 	for _, status := range statuses {
 		deployment := &appsv1.DeploymentConfig{
@@ -119,7 +119,7 @@ func cloneDeployment(deployment *appsv1.DeploymentConfig, ref *model.Ref, versio
 	return &clone, nil
 }
 
-func getDeploymentConfig(ctx model.SessionContext, namespace, name string) (*appsv1.DeploymentConfig, error) { //nolint[:hugeParam]
+func getDeploymentConfig(ctx model.SessionContext, namespace, name string) (*appsv1.DeploymentConfig, error) {
 	deployment := appsv1.DeploymentConfig{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment)
 	return &deployment, err

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -25,10 +25,6 @@ const (
 	EnvServiceCall = "SERVICE_CALL"
 )
 
-var (
-	rootDir = "test/cmd/test-service/assets/" //nolint:deadcode
-)
-
 func main() {
 	logf.SetLogger(log.CreateClusterAwareLogger())
 

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -25,6 +25,10 @@ const (
 	EnvServiceCall = "SERVICE_CALL"
 )
 
+var (
+	rootDir = "test/cmd/test-service/assets/" //nolint:varcheck,deadcode,unused //reason This is required to use the dev mode for assets (reading from fs)
+)
+
 func main() {
 	logf.SetLogger(log.CreateClusterAwareLogger())
 

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	rootDir = "test/cmd/test-service/assets/" //nolint[:deadcode]
+	rootDir = "test/cmd/test-service/assets/" //nolint:deadcode
 )
 
 func main() {

--- a/test/ginkgo_custom_reporter.go
+++ b/test/ginkgo_custom_reporter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RunSpecWithJUnitReporter calls custom ginkgo junit reporter
-func RunSpecWithJUnitReporter(t *testing.T, description string) { //nolint[:unused] false negative as this is used by suite files
+func RunSpecWithJUnitReporter(t *testing.T, description string) { //nolint:unused false negative as this is used by suite files
 	junitReporter := reporters.NewJUnitReporter("ginkgo-test-results.xml")
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, description, []ginkgo.Reporter{junitReporter})
 }

--- a/test/ginkgo_custom_reporter.go
+++ b/test/ginkgo_custom_reporter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RunSpecWithJUnitReporter calls custom ginkgo junit reporter
-func RunSpecWithJUnitReporter(t *testing.T, description string) { //nolint:unused false negative as this is used by suite files
+func RunSpecWithJUnitReporter(t *testing.T, description string) { //nolint:unused //reason false negative as this is used by suite files
 	junitReporter := reporters.NewJUnitReporter("ginkgo-test-results.xml")
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, description, []ginkgo.Reporter{junitReporter})
 }

--- a/test/ginkgo_custom_reporter.go
+++ b/test/ginkgo_custom_reporter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RunSpecWithJUnitReporter calls custom ginkgo junit reporter
-func RunSpecWithJUnitReporter(t *testing.T, description string) { //nolint[:unused]
+func RunSpecWithJUnitReporter(t *testing.T, description string) { //nolint[:unused] false negative as this is used by suite files
 	junitReporter := reporters.NewJUnitReporter("ginkgo-test-results.xml")
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, description, []ginkgo.Reporter{junitReporter})
 }

--- a/test/shell/test_setup.go
+++ b/test/shell/test_setup.go
@@ -41,8 +41,7 @@ func ExecuteCommand(outputChan chan string, execute func() (string, error)) func
 
 var appFs = afero.NewOsFs()
 
-func buildBinary(packagePath, name string, flags ...string) string { //nolint[:unparam]
-
+func buildBinary(packagePath, name string, flags ...string) string { //nolint[:unparam] at this moment we always pass the same value for packagePath
 	binPath, err := gexec.Build(packagePath, flags...)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/test/shell/test_setup.go
+++ b/test/shell/test_setup.go
@@ -41,7 +41,7 @@ func ExecuteCommand(outputChan chan string, execute func() (string, error)) func
 
 var appFs = afero.NewOsFs()
 
-func buildBinary(packagePath, name string, flags ...string) string { //nolint:unparam at this moment we always pass the same value for packagePath
+func buildBinary(packagePath, name string, flags ...string) string { //nolint:unparam //reason at this moment we always pass the same value for packagePath
 	binPath, err := gexec.Build(packagePath, flags...)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/test/shell/test_setup.go
+++ b/test/shell/test_setup.go
@@ -41,7 +41,7 @@ func ExecuteCommand(outputChan chan string, execute func() (string, error)) func
 
 var appFs = afero.NewOsFs()
 
-func buildBinary(packagePath, name string, flags ...string) string { //nolint[:unparam] at this moment we always pass the same value for packagePath
+func buildBinary(packagePath, name string, flags ...string) string { //nolint:unparam at this moment we always pass the same value for packagePath
 	binPath, err := gexec.Build(packagePath, flags...)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/test/tmp_file.go
+++ b/test/tmp_file.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestReporter can be used to report test failures. It is satisfied by the standard library's *testing.T.
-type TestReporter interface { //nolint:golint
+type TestReporter interface { //nolint:golint //reason test code
 	Errorf(format string, args ...interface{})
 }
 

--- a/test/tmp_file.go
+++ b/test/tmp_file.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestReporter can be used to report test failures. It is satisfied by the standard library's *testing.T.
-type TestReporter interface { //nolint[:golint]
+type TestReporter interface { //nolint:golint
 	Errorf(format string, args ...interface{})
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:

As we learnt in #378 our usage of golangi-ci linter was a bit wrong. This PR brings order and sanity :)

#### Changes proposed in this pull request:

- fix: disables hugeParam linter
- fix: proper usage of nolint comment
- fix: bypass gocyclo for few functions
- removes unused variable
- adds reasons behind every `//nolint` directive

For example `//nolint[:gosec]` is a wrong syntax (most likely from previous linter we had in place). With this syntax all linter checks are bypassed. The proper syntax is `//nolint:linter1,linter2 //reason explanation`.

Fixes #382 
