### PR TITLE
fix(docs): proper install snippet [skip-e2e]

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ Get latest `ike` binary through simple download script:
 curl -sL http://git.io/get-ike | bash
 ----
 
-TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s -- --version=v0.0.1 --dir=~/bin`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=~/bin`
 
 When logged in to the cluster run the following for a cluster wide operator:
 

--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -20,7 +20,7 @@ curl -sL http://git.io/get-ike | bash
 
 to get latest `ike` binary.
 
-TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s -- --version=v0.0.1 --dir=~/bin`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=~/bin`
 
 == Installing cluster component
 
@@ -41,8 +41,6 @@ Or if you only want to install it for a single Namespace:
 ----
 ike install-operator -l
 ----
-
-// TODO single install script
 
 == Using `ike` CLI
 
@@ -71,7 +69,3 @@ Let's break it down to see what is going on under the hood:
 
 
 // TODO add screencast showing the basic flow
-
-// TODO add sources to our binary once released
-
-


### PR DESCRIPTION
Wrongly formatted bash snippet resulted in

```
╰─ curl -sL http://git.io/get-ike | bash -s — --version=v0.0.2
bash: -�: invalid option
Usage:	bash [GNU long option] [option] ...
	bash [GNU long option] [option] script-file ...
GNU long options:
	--debug
	--debugger
	--dump-po-strings
	--dump-strings
	--help
	--init-file
	--login
	--noediting
	--noprofile
	--norc
	--posix
	--pretty-print
	--rcfile
	--rpm-requires
	--restricted
	--verbose
	--version
Shell options:
	-ilrsD or -c command or -O shopt_option		(invocation only)
	-abefhkmnptuvxBCHP or -o option
(23) Failed writing body
```