### PR TITLE
fix(tests): controls tp version env var

### DIFF
--- a/pkg/telepresence/wrapper_test.go
+++ b/pkg/telepresence/wrapper_test.go
@@ -14,6 +14,16 @@ import (
 
 var _ = Describe("telepresence commands wrapper", func() {
 
+	var restoreOriginalTelepresenceEnvVar func()
+
+	BeforeEach(func() {
+		restoreOriginalTelepresenceEnvVar = TemporaryEnvVars("TELEPRESENCE_VERSION", "")
+	})
+
+	AfterEach(func() {
+		restoreOriginalTelepresenceEnvVar()
+	})
+
 	Context("telepresence not available", func() {
 
 		tmpPath := NewTmpPath()


### PR DESCRIPTION
#### Short description of what this resolves:

Controls `TELEPRESENCE_VERSION` in dependent tests so that it's wiped out before each one and restored to whatever value it's been set afterwards.

Fixes #389 
