### PR TITLE
fix(operator): remove args and command from telepresence clone

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -55,6 +55,13 @@ func NewDefaultEngine() *Engine {
 					}
 				}
 				},
+				{{ if .Data.Has "/spec/template/spec/containers/0/args" }}
+				{"op": "remove", "path": "/spec/template/spec/containers/0/args"},
+				{{ end }}
+				{{ if .Data.Has "/spec/template/spec/containers/0/command" }}
+				{"op": "remove", "path": "/spec/template/spec/containers/0/command"},
+				{{ end }}
+
 					{{ template "_basic-remove" . }}
 				]
 `),

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -109,6 +109,8 @@ var _ = Describe("Operations for template system", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(o)).To(ContainSubstring("1000"))
 				Expect(string(o)).To(ContainSubstring("x-x-v"))
+				Expect(string(o)).ToNot(ContainSubstring("COMMAND"))
+				Expect(string(o)).ToNot(ContainSubstring("ARGS"))
 			})
 
 			It("should fail when no version is provided", func() {
@@ -130,6 +132,8 @@ var _ = Describe("Operations for template system", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(o)).To(ContainSubstring("1000"))
 				Expect(string(o)).To(ContainSubstring("maistra.org/test-image:test"))
+				Expect(string(o)).To(ContainSubstring("COMMAND"))
+				Expect(string(o)).To(ContainSubstring("ARGS"))
 			})
 		})
 
@@ -282,7 +286,9 @@ var testDeployment = `
                                 "value": "http://reviews:9080/"
                             }
                         ],
-                        "image": "docker.io/aslakknutsen/istio-workspace-test:latest",
+						"image": "docker.io/aslakknutsen/istio-workspace-test:latest",
+						"command": "COMMAND",
+						"args": ["ARGS"],
                         "imagePullPolicy": "Always",
                         "livenessProbe": {
                             "failureThreshold": 3,


### PR DESCRIPTION
The target deployment might have configured args and command for the users' image,
however, these make no sense for the telepresence proxy image and might break the startup.
