### PR TITLE
fix(docs): adds extra space between include directives

### DIFF
--- a/docs/modules/ROOT/pages/release_notes.adoc
+++ b/docs/modules/ROOT/pages/release_notes.adoc
@@ -1,7 +1,9 @@
 = Releases
 
 include::release_notes/v0.0.3.adoc[]
+
 include::release_notes/v0.0.2.adoc[]
+
 include::release_notes/v0.0.1.adoc[]
 
 


### PR DESCRIPTION
#### Short description of what this resolves:

Adding extra line between `include::` directives, so headers are rendered correctly. Currently, this looks as follows:

![image](https://user-images.githubusercontent.com/719616/77645263-bc02ce00-6f62-11ea-96bb-1ef6fbd0d1fd.png)

