### PR TITLE
fix: sets logger based on OPERATOR_NAME env var

### DIFF
--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -28,7 +28,7 @@ func main() {
 	// Logs to os.Stderr, where all structured logging should go
 	// When running outside of k8s cluster it will use development
 	// mode so the log is not in JSON, but plain text format
-	logger := log.CreateClusterAwareLogger()
+	logger := log.CreateOperatorAwareLogger()
 	logf.SetLogger(logger)
 
 	// Setting random seed e.g. for session name generator

--- a/pkg/controller/session/session_controller_int_test.go
+++ b/pkg/controller/session/session_controller_int_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Complete session manipulation", func() {
 		}
 	}(&c)
 	JustBeforeEach(func() {
-		logf.SetLogger(log.CreateClusterAwareLogger())
+		logf.SetLogger(log.CreateOperatorAwareLogger())
 
 		schema, _ = v1alpha1.SchemeBuilder.Build()
 		_ = corev1.AddToScheme(schema)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -13,12 +13,13 @@ import (
 	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func CreateClusterAwareLogger() logr.Logger {
+// CreateOperatorAwareLogger will set logging format to JSON when ran as operator or plain text when used as CLI
+func CreateOperatorAwareLogger() logr.Logger {
 	var opts []zap.Option
 	var enc zapcore.Encoder
 	var lvl zap.AtomicLevel
 
-	notInCluster := !isRunningInK8sCluster()
+	notInCluster := !isRunningAsOperator()
 	sink := zapcore.AddSync(os.Stderr)
 
 	if notInCluster {
@@ -54,7 +55,7 @@ func newCliEncoderConfig() zapcore.EncoderConfig {
 	}
 }
 
-func isRunningInK8sCluster() bool {
-	_, runningInCluster := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+func isRunningAsOperator() bool {
+	_, runningInCluster := os.LookupEnv("OPERATOR_NAME")
 	return runningInCluster
 }

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -30,7 +30,7 @@ var (
 )
 
 func main() {
-	logf.SetLogger(log.CreateClusterAwareLogger())
+	logf.SetLogger(log.CreateOperatorAwareLogger())
 
 	c := Config{}
 	if v, b := os.LookupEnv(EnvServiceName); b {


### PR DESCRIPTION
#### Short description of what this resolves:

Uses JSON only when runs as operator, console encoder otherwise.

#### Changes proposed in this pull request:

- Checks presence of `OPERATOR_NAME` env variable to determine logging format

Fixes #402 
