### PR TITLE
feat: ability to specify a file name when using get.sh

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,21 @@ Get latest `ike` binary through simple download script:
 curl -sL http://git.io/get-ike | bash
 ----
 
-TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=~/bin`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=/usr/bin`
+
+[source,bash]
+----
+get - downloads ike binary matching your operating system
+ 
+./get.sh [options]
+ 
+Options:
+-h, --help          shows brief help
+-v, --version       defines version specific version of the binary to download (defaults to latest)
+-d, --dir           target directory to which the binary is downloaded (defaults to random tmp dir in /tmp suffixed with ike-version)
+-n, --name          saves binary under specific name (defaults to ike)
+
+----
 
 When logged in to the cluster run the following for a cluster wide operator:
 
@@ -33,8 +47,6 @@ or if you only want to install the operator for a single namespace run:
 ----
 ike install-operator -l
 ----
-
-
 
 And you are all set!
 

--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -13,7 +13,7 @@ In this section we walk you through necessary steps to start using `ike`. It wil
 
 Run `curl -sL http://git.io/get-ike | bash` to get latest `ike` binary.
 
-TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=~/bin`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=/usr/bin`
 
 Here are all available flags of this installation script
 

--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -11,16 +11,13 @@ In this section we walk you through necessary steps to start using `ike`. It wil
 
 == Installing `ike` CLI
 
-Run:
-
-[source,bash]
-----
-curl -sL http://git.io/get-ike | bash
-----
-
-to get latest `ike` binary.
+Run `curl -sL http://git.io/get-ike | bash` to get latest `ike` binary.
 
 TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=~/bin`
+
+Here are all available flags of this installation script
+
+include::cmd:curl[flags='-sL http://git.io/get-ike | bash -s -- --help',block=true]
 
 == Installing cluster component
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,7 +30,8 @@ func NewCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:                    "ike",
-		Short:                  "ike lets you safely develop and test on prod without a sweat",
+		Short:                  "ike lets you safely develop and test on production without a sweat!\n\n" +
+			"For detailed documentation please visit https://istio-workspace-docs.netlify.com/\n\n",
 		BashCompletionFunction: completion.BashCompletionFunc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if v.Released() {

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -21,6 +21,7 @@ show_help() {
   echo "-h, --help          shows brief help"
   echo "-v, --version       defines version specific version of the binary to download (defaults to latest)"
   echo "-d, --dir           target directory to which the binary is downloaded (defaults to random tmp dir in /tmp suffixed with ike-version)"
+  echo "-n, --name          saves binary under specific name (defaults to ike)"
 }
 
 last_version() {
@@ -76,6 +77,19 @@ while test $# -gt 0; do
             dir=`echo $1 | sed -e 's/^[^=]*=//g'`
             shift
             ;;
+    -n)
+            shift
+            if test $# -gt 0; then
+              binary_name=$1
+            else
+              die "Please provide a name"
+            fi
+            shift
+            ;;
+    --name*)
+            binary_name=`echo $1 | sed -e 's/^[^=]*=//g'`
+            shift
+            ;;
     *)
             die "Unknown param $1"
             break
@@ -83,14 +97,16 @@ while test $# -gt 0; do
   esac
 done
 
+test -z "$binary_name" && binary_name="ike"
 test -z "$version" && version="$(last_version)"
 test -z "$version" && {
   die "Unable to get ike version. You can still try to download it manually from $RELEASES_URL."
 }
 test -z "$dir" &&  dir="$(mktemp -d --suffix=-ike-${version})"
 
-download ${version}
+download "${version}"
 tar -C "$dir" -xzf "$TAR_FILE" ike
+mv -n $dir/ike $dir/$binary_name
 
-echo "Downloaded ike binary ($version) to $dir"
+echo "Downloaded ike binary ($version) to $dir/$binary_name"
 echo "Make sure it's on your \$PATH."


### PR DESCRIPTION
You can now call `./scripts/get.sh -n ike_v_next` so it will be saved as `ike_v_next`. 

#### Changes

- adds `-n|--name` flag to `get.sh`
- updates README and documentation with installation instruction
- includes output of `./get.sh --help` in docs 

Related to #406 

