### PR TITLE
feat(ci): caches build results to avoid redundant runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       - run:
           name: "Obtain git tree hash"
           command: |
+            mkdir -p ./build/_output/
             git rev-parse HEAD: > /tmp/build.hash
       - restore_cache:
           keys:
@@ -73,6 +74,7 @@ jobs:
       - run:
           name: "Obtain git tree hash"
           command: |
+            mkdir -p ./build/_output/
             git rev-parse HEAD: > /tmp/e2e-openshift-4.hash
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
       - restore_cache:
           keys:
             - golang-deps-cache-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
             - build-cache-{{ checksum "/tmp/build.githash" }}
       - run:
           name: "Check if build with this content was already executed"
@@ -59,7 +61,7 @@ jobs:
       - save_cache:
           key: build-cache-{{ checksum "build.githash" }}
           paths:
-            - build.githash
+            - ./build.githash
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote_openshift_4:
@@ -81,12 +83,12 @@ jobs:
       - run:
           name: "Check if build with this content was already executed"
           command: |
-            if [[ -f e2e-openshift-4.githash ]]; then
+            if [[ -f ${CIRCLE_WORKING_DIRECTORY}/e2e-openshift-4.githash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt
             else
               echo "New build - if suceeds build git hash will be cached"
-              cp /tmp/e2e-openshift-4.githash e2e-openshift-4.githash
+              cp /tmp/e2e-openshift-4.githash ${CIRCLE_WORKING_DIRECTORY}/e2e-openshift-4.githash
             fi
 
       - run:
@@ -138,7 +140,7 @@ jobs:
       - save_cache:
           key: build-cache-{{ checksum "./build/_output/e2e-openshift-4.githash" }}
           paths:
-            - e2e-openshift-4.githash
+            - ./e2e-openshift-4.githash
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             git rev-parse HEAD: > /tmp/e2e-openshift-4.githash
       - restore_cache:
           keys:
-            - build-cache-{{ checksum "/tmp/e2e-openshift-4.githash" }}
+            - e2e-cache-{{ checksum "/tmp/e2e-openshift-4.githash" }}
       - run:
           name: "Check if build with this content was already executed"
           command: |
@@ -138,7 +138,7 @@ jobs:
           paths:
             - ./vendor
       - save_cache:
-          key: build-cache-{{ checksum "./build/_output/e2e-openshift-4.githash" }}
+          key: e2e-cache-{{ checksum "./build/_output/e2e-openshift-4.githash" }}
           paths:
             - ./e2e-openshift-4.githash
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
               circleci step halt
             else
               echo "New build - if suceeds build git hash will be cached"
-              cp /tmp/e2e-openshift-4.githash ${CIRCLE_WORKING_DIRECTORY}/e2e-openshift-4.githash
+              cp /tmp/e2e-openshift-4.githash e2e-openshift-4.githash
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
               echo "This exact code base has been successfully built"
               circleci step halt
             else
+              mkdir ./bin
               cp /tmp/build.hash ./bin/build.hash
             fi
       - run:
@@ -84,6 +85,7 @@ jobs:
               echo "This exact code base has been successfully built"
               circleci step halt
             else
+              mkdir ./bin
               cp /tmp/e2e-openshift-4.hash ./bin/e2e-openshift-4.hash
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,11 @@ jobs:
       - run:
           name: "Check if build with this content was already executed"
           command: |
-            if [[ -f ./bin/build.hash ]]; then
+            if [[ -f ./build/_output/build.hash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt
             else
-              mkdir ./bin
-              cp /tmp/build.hash ./bin/build.hash
+              cp /tmp/build.hash ./build/_output/build.hash
             fi
       - run:
           name: "Run the build"
@@ -57,9 +56,9 @@ jobs:
           paths:
             - ./vendor
       - save_cache:
-          key: build-cache-{{ checksum "./bin/build.hash" }}
+          key: build-cache-{{ checksum "./build/_output/build.hash" }}
           paths:
-            - ./bin/build.hash
+            - ./build/_output/build.hash
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote_openshift_4:
@@ -81,12 +80,11 @@ jobs:
       - run:
           name: "Check if build with this content was already executed"
           command: |
-            if [[ -f ./bin/e2e-openshift-4.hash ]]; then
+            if [[ -f ./build/_output/e2e-openshift-4.hash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt
             else
-              mkdir ./bin
-              cp /tmp/e2e-openshift-4.hash ./bin/e2e-openshift-4.hash
+              cp /tmp/e2e-openshift-4.hash ./build/_output/e2e-openshift-4.hash
             fi
 
       - run:
@@ -136,9 +134,9 @@ jobs:
           paths:
             - ./vendor
       - save_cache:
-          key: build-cache-{{ checksum "./bin/e2e-openshift-4.hash" }}
+          key: build-cache-{{ checksum "./build/_output/e2e-openshift-4.hash" }}
           paths:
-            - ./bin/e2e-openshift-4.hash
+            - ./build/_output/e2e-openshift-4.hash
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults:
   golang-install: &golang-install
-    name: "Installs latest Golang"
+    name: "Install latest Golang"
     command: |
       sudo rm -rf /usr/local/go
       sudo circleci-install golang 1.14.2
@@ -9,7 +9,7 @@ defaults:
   machine-conf: &machine-conf
     image: ubuntu-1604:201903-01
   skip-e2e-check: &skip-e2e-check
-    name: "Checks for /skip-e2e directive"
+    name: "Check for /skip-e2e directive"
     command: |
       COMMIT_MSG=$(git log --format=%B -n 1 $CIRCLE_SHA1)
       if [[ $COMMIT_MSG == *"/skip-e2e"* ]]; then
@@ -70,7 +70,6 @@ jobs:
       <<: *machine-conf
     environment:
       <<: *env-vars
-      IKE_CLUSTER_VERSION: 4
     steps:
       - checkout
       - run:
@@ -83,7 +82,7 @@ jobs:
       - run:
           name: "Check if build with this content was already executed"
           command: |
-            if [[ -f ${CIRCLE_WORKING_DIRECTORY}/e2e-openshift-4.githash ]]; then
+            if [[ -f e2e-openshift-4.githash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt
             else
@@ -96,7 +95,7 @@ jobs:
       - run:
           <<: *golang-install
       - run:
-          name: "Installs telepresence"
+          name: "Install telepresence"
           command: |
             cd ~
             pyenv global 3.5.2
@@ -104,7 +103,7 @@ jobs:
             sudo apt install --no-install-recommends telepresence
             telepresence --version
       - run:
-          name: "Configures Docker daemon with insecure-registry"
+          name: "Configure Docker daemon with insecure-registry"
           command: |
             json=`mktemp`
             echo '{ "insecure-registries": [ "172.30.0.0/16", "registry.access.redhat.com", "docker-registry-default.127.0.0.1.nip.io:80", "default-route-openshift-image-registry.apps.yuaxu-maistra-daily.devcluster.openshift.com"] }' > ${json}
@@ -112,7 +111,7 @@ jobs:
             sudo service docker restart
             echo "Configured Docker daemon with insecure-registry"
       - run:
-          name: "Installs Openshift and k8s client tools"
+          name: "Install Openshift and k8s client tools"
           command: |
             cd ~
             wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.3.2/openshift-client-linux-4.3.2.tar.gz" -O "oc.tar.gz"
@@ -125,7 +124,7 @@ jobs:
           keys:
             - golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
       - run:
-          name: "Runs end-to-end tests"
+          name: "Run end-to-end tests"
           command: |
             IKE_CLUSTER_USER=$QE_IKE_CLUSTER_USER \
             IKE_CLUSTER_PWD=$QE_IKE_CLUSTER_PWD \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ defaults:
       fi
   env-vars: &env-vars
     GOPATH: /home/circleci/.go_workspace
-    IKE_CLUSTER_DIR: "/home/circleci/cached-openshift-cluster"
     IKE_E2E_KEEP_NS: "false"
     IKE_E2E_MANAGE_CLUSTER: "false"
+
 version: 2.1
 jobs:
 
-  ## Regular build running unit tests and linters
+  ## Regular build running tests
   build:
     working_directory: /go/src/github.com/maistra/istio-workspace
     docker:
@@ -63,7 +63,7 @@ jobs:
           paths:
             - ./build.githash
 
-  ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
+  ## End-to-end testing involving OpenShift cluster with Istio (Maistra disitribution) running remotely
   e2e_tests_remote_openshift_4:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace
     machine:
@@ -137,7 +137,7 @@ jobs:
           paths:
             - ./vendor
       - save_cache:
-          key: e2e-cache-{{ checksum "./build/_output/e2e-openshift-4.githash" }}
+          key: e2e-cache-{{ checksum "e2e-openshift-4.githash" }}
           paths:
             - ./e2e-openshift-4.githash
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,20 +34,20 @@ jobs:
       - run:
           name: "Obtain git tree hash"
           command: |
-            mkdir -p ./build/_output/
-            git rev-parse HEAD: > /tmp/build.hash
+            git rev-parse HEAD: > /tmp/build.githash
       - restore_cache:
           keys:
             - golang-deps-cache-{{ checksum "Gopkg.lock" }}
-            - build-cache-{{ checksum "/tmp/build.hash" }}
+            - build-cache-{{ checksum "/tmp/build.githash" }}
       - run:
           name: "Check if build with this content was already executed"
           command: |
-            if [[ -f ./build/_output/build.hash ]]; then
+            if [[ -f build.githash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt
             else
-              cp /tmp/build.hash ./build/_output/build.hash
+              echo "New build - if suceeds build git hash will be cached"
+              cp /tmp/build.githash build.githash
             fi
       - run:
           name: "Run the build"
@@ -57,9 +57,9 @@ jobs:
           paths:
             - ./vendor
       - save_cache:
-          key: build-cache-{{ checksum "./build/_output/build.hash" }}
+          key: build-cache-{{ checksum "build.githash" }}
           paths:
-            - ./build/_output/build.hash
+            - build.githash
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote_openshift_4:
@@ -74,19 +74,19 @@ jobs:
       - run:
           name: "Obtain git tree hash"
           command: |
-            mkdir -p ./build/_output/
-            git rev-parse HEAD: > /tmp/e2e-openshift-4.hash
+            git rev-parse HEAD: > /tmp/e2e-openshift-4.githash
       - restore_cache:
           keys:
-            - build-cache-{{ checksum "/tmp/e2e-openshift-4.hash" }}
+            - build-cache-{{ checksum "/tmp/e2e-openshift-4.githash" }}
       - run:
           name: "Check if build with this content was already executed"
           command: |
-            if [[ -f ./build/_output/e2e-openshift-4.hash ]]; then
+            if [[ -f e2e-openshift-4.githash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt
             else
-              cp /tmp/e2e-openshift-4.hash ./build/_output/e2e-openshift-4.hash
+              echo "New build - if suceeds build git hash will be cached"
+              cp /tmp/e2e-openshift-4.githash e2e-openshift-4.githash
             fi
 
       - run:
@@ -136,9 +136,9 @@ jobs:
           paths:
             - ./vendor
       - save_cache:
-          key: build-cache-{{ checksum "./build/_output/e2e-openshift-4.hash" }}
+          key: build-cache-{{ checksum "./build/_output/e2e-openshift-4.githash" }}
           paths:
-            - ./build/_output/e2e-openshift-4.hash
+            - e2e-openshift-4.githash
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,16 +31,34 @@ jobs:
       - image: *golang-img
     steps:
       - checkout
+      - run:
+          name: "Obtain git tree hash"
+          command: |
+            git rev-parse HEAD: > /tmp/build.hash
       - restore_cache:
           keys:
             - golang-deps-cache-{{ checksum "Gopkg.lock" }}
+            - build-cache-{{ checksum "/tmp/build.hash" }}
       - run:
-          name: "Runs the build"
+          name: "Check if build with this content was already executed"
+          command: |
+            if [[ -f ./bin/build.hash ]]; then
+              echo "This exact code base has been successfully built"
+              circleci step halt
+            else
+              cp /tmp/build.hash ./bin/build.hash
+            fi
+      - run:
+          name: "Run the build"
           command: make build-ci
       - save_cache:
           key: golang-deps-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
+      - save_cache:
+          key: build-cache-{{ checksum "./bin/build.hash" }}
+          paths:
+            - ./bin/build.hash
 
   ## End-to-end testing involving OpenShift cluster with Istio (Maistra) running remotely
   e2e_tests_remote_openshift_4:
@@ -52,6 +70,23 @@ jobs:
       IKE_CLUSTER_VERSION: 4
     steps:
       - checkout
+      - run:
+          name: "Obtain git tree hash"
+          command: |
+            git rev-parse HEAD: > /tmp/e2e-openshift-4.hash
+      - restore_cache:
+          keys:
+            - build-cache-{{ checksum "/tmp/e2e-openshift-4.hash" }}
+      - run:
+          name: "Check if build with this content was already executed"
+          command: |
+            if [[ -f ./bin/e2e-openshift-4.hash ]]; then
+              echo "This exact code base has been successfully built"
+              circleci step halt
+            else
+              cp /tmp/e2e-openshift-4.hash ./bin/e2e-openshift-4.hash
+            fi
+
       - run:
           <<: *skip-e2e-check
       - run:
@@ -98,6 +133,10 @@ jobs:
           key: golang-deps-e2e-cache-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
+      - save_cache:
+          key: build-cache-{{ checksum "./bin/e2e-openshift-4.hash" }}
+          paths:
+            - ./bin/e2e-openshift-4.hash
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ converted-release-notes.md
 # Test results
 *ginkgo-test-results.xml
 
+# Git tree hash files - used for CircleCI build optimization - see https://github.com/Maistra/istio-workspace/issues/428
+
 # Temporary Files
 bin/
 build/_output


### PR DESCRIPTION
#### Short description of what this resolves:

Keeps build files cached (simple file containing content sha) so that when PR is merged to master and there were no other changes in repository redundant builds will be skipped.

#### Changes proposed in this pull request:

- tweaks circle ci jobs by caching build-sha files

Fixes #428 
