### PR TITLE
feat: hints how to reach new service

### DIFF
--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -20,7 +20,7 @@ func NewCmd() *cobra.Command {
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, _, err := internal.Sessions(cmd)
+			_, _, _, err := internal.Sessions(cmd)
 			return err
 		},
 	}

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -29,7 +29,7 @@ var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "develop")
 
 const urlHint = `Knowing your application url you can now access your new version by using
 
-$ curl -H"%s:%s" YOUR_APP_URL.\n
+$ curl -H"%s:%s" YOUR_APP_URL.
 
 If you can't see any changes make sure that this header is respected by your app and propagated down the call chain.`
 

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/maistra/istio-workspace/pkg/internal/session"
+
 	"github.com/maistra/istio-workspace/pkg/log"
 
 	"github.com/maistra/istio-workspace/pkg/telepresence"
@@ -25,6 +27,12 @@ import (
 
 var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "develop")
 
+const urlHint = `Knowing your application url you can now access your new version by using
+
+$ curl -H"%s:%s" YOUR_APP_URL.\n
+
+If you can't see any changes make sure that this header is respected by your app and propagated down the call chain.`
+
 var DefaultExclusions = []string{"*.log", ".git/"}
 
 // NewCmd creates instance of "develop" Cobra Command with flags and execution logic defined
@@ -44,7 +52,7 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sessionState, sessionClose, err := internal.Sessions(cmd)
+			sessionState, options, sessionClose, err := internal.Sessions(cmd)
 			if err != nil {
 				return err
 			}
@@ -71,6 +79,10 @@ func NewCmd() *cobra.Command {
 				shell.ShutdownHook(tp, done)
 				shell.Start(tp, done)
 			}()
+
+			if route, _ := session.ParseRoute(options.RouteExp); route != nil {
+				logger.Info(fmt.Sprintf(urlHint, route.Name, route.Value))
+			}
 
 			finalStatus := <-done
 			return finalStatus.Error

--- a/pkg/cmd/internal/session/session_func.go
+++ b/pkg/cmd/internal/session/session_func.go
@@ -11,7 +11,7 @@ import (
 // Sessions creates a Handler for the given session operation
 // session expects that cmd has offline, namespace, route, deployment and session flags defined.
 // otherwise it fails
-func Sessions(cmd *cobra.Command) (session.State, func(), error) {
+func Sessions(cmd *cobra.Command) (session.State, session.Options, func(), error) {
 	var sessionHandler session.Handler = session.Offline
 
 	if offline, err := cmd.Flags().GetBool("offline"); err == nil && !offline {
@@ -20,9 +20,10 @@ func Sessions(cmd *cobra.Command) (session.State, func(), error) {
 
 	options, err := ToOptions(cmd.Flags())
 	if err != nil {
-		return session.State{}, nil, err
+		return session.State{}, options, nil, err
 	}
-	return sessionHandler(options)
+	state, f, err := sessionHandler(options)
+	return state, options, f, err
 }
 
 // RemoveSessions creates a Handler for the given session operation for removing a session


### PR DESCRIPTION
Basic hint on how to reach the service when header defined in combination with `ike create|develop`

```
Knowing your application url you can now access your new version by using

$ curl -H"x-test-suite:smoke" YOUR_APP_URL.

If you can't see any changes make sure that this header is respected by your app and propagated down the call chain.
```

Fixes #455 
