### PR TITLE
chore: minor code cleanups

### DIFF
--- a/pkg/controller/session/model_convert_test.go
+++ b/pkg/controller/session/model_convert_test.go
@@ -34,11 +34,11 @@ var _ = Describe("Basic model conversion", func() {
 				Strategy:  "prepared-image",
 				Args:      map[string]string{"image": "x"},
 				Targets: []model.LocatedResourceStatus{
-					model.LocatedResourceStatus{
+					{
 						ResourceStatus: model.ResourceStatus{Kind: "dc", Name: "dc-n", Action: model.ActionLocated},
 						Labels:         map[string]string{},
 					},
-					model.LocatedResourceStatus{
+					{
 						ResourceStatus: model.ResourceStatus{Kind: "service", Name: "serv-n", Action: model.ActionLocated},
 						Labels:         map[string]string{},
 					}},
@@ -164,11 +164,11 @@ var _ = Describe("Basic model conversion", func() {
 								Args:     map[string]string{"image": "x"},
 							},
 							Targets: []*v1alpha1.LabeledRefResource{
-								&v1alpha1.LabeledRefResource{
+								{
 									RefResource: v1alpha1.RefResource{Kind: &kind, Name: &name, Action: &aLocated},
 									Labels:      map[string]string{},
 								},
-								&v1alpha1.LabeledRefResource{
+								{
 									RefResource: v1alpha1.RefResource{Kind: &kind, Name: &servname, Action: &aLocated},
 									Labels:      map[string]string{},
 								},

--- a/pkg/controller/session/session_controller_test.go
+++ b/pkg/controller/session/session_controller_test.go
@@ -304,7 +304,7 @@ var _ = Describe("Basic session manipulation", func() {
 										}},
 									Resources: []*v1alpha1.RefResource{{Kind: &kind, Name: &name, Action: &action}},
 									Targets: []*v1alpha1.LabeledRefResource{
-										&v1alpha1.LabeledRefResource{
+										{
 											RefResource: v1alpha1.RefResource{
 												Kind:   &kind,
 												Name:   &locatedTargetName,

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -34,12 +34,15 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 		}
 	}
 	JustBeforeEach(func() {
+		schema := runtime.NewScheme()
+		err := appsv1.AddToScheme(schema)
+		Expect(err).ToNot(HaveOccurred())
 		ctx = model.SessionContext{
 			Context:   context.Background(),
 			Name:      "test",
 			Namespace: "test",
 			Log:       log.CreateOperatorAwareLogger("test").WithValues("type", "k8s-deployment"),
-			Client:    fake.NewFakeClient(objects...),
+			Client:    fake.NewFakeClientWithScheme(schema, objects...),
 		}
 	})
 

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -30,13 +30,17 @@ var _ = Describe("Operations for k8s Service kind", func() {
 			Args:      map[string]string{"version": "0.103"},
 		}
 	}
+	
 	JustBeforeEach(func() {
+		schema := runtime.NewScheme()
+		err := corev1.AddToScheme(schema)
+		Expect(err).ToNot(HaveOccurred())
 		ctx = model.SessionContext{
 			Context:   context.Background(),
 			Name:      "test",
 			Namespace: "test",
 			Log:       log.CreateOperatorAwareLogger("test").WithValues("type", "k8s-service"),
-			Client:    fake.NewFakeClient(objects...),
+			Client:    fake.NewFakeClientWithScheme(schema, objects...),
 		}
 	})
 

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Operations for k8s Service kind", func() {
 			Args:      map[string]string{"version": "0.103"},
 		}
 	}
-	
+
 	JustBeforeEach(func() {
 		schema := runtime.NewScheme()
 		err := corev1.AddToScheme(schema)

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	apis.AddToSchemes = append(apis.AddToSchemes, appsv1.AddToScheme)
+	apis.AddToSchemes = append(apis.AddToSchemes, appsv1.Install)
 }
 
 const (

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 	}
 	JustBeforeEach(func() {
 		schema := runtime.NewScheme()
-		err := appsv1.AddToScheme(schema)
+		err := appsv1.Install(schema)
 		Expect(err).ToNot(HaveOccurred())
 		ctx = model.SessionContext{
 			Context:   context.Background(),

--- a/pkg/openshift/parser/template.go
+++ b/pkg/openshift/parser/template.go
@@ -121,7 +121,7 @@ type DecodeFunc func(data []byte, defaults *schema.GroupVersionKind, into runtim
 // and constructs decode function to be applied on the source YAML
 func Decoder() (DecodeFunc, error) {
 	s := runtime.NewScheme()
-	if err := openshiftApi.AddToScheme(s); err != nil {
+	if err := openshiftApi.Install(s); err != nil {
 		return nil, err
 	}
 	if err := scheme.AddToScheme(s); err != nil {

--- a/test/cmd/test-scenario/generator/generators_test.go
+++ b/test/cmd/test-scenario/generator/generators_test.go
@@ -24,46 +24,46 @@ var _ = Describe("Operations for test scenario generator", func() {
 		}
 		Context("deploymentconfig", func() {
 			It("should be created if entry is correct DeploymentType", func() {
-				obj := DeploymentConfig(Entry{"test", "DeploymentConfig", ns})
+				obj := DeploymentConfig(Entry{Name: "test", DeploymentType: "DeploymentConfig", Namespace: ns})
 				Expect(obj).ToNot(BeNil())
 			})
 
 			It("should not be created if entry is not correct DeploymentType", func() {
-				obj := DeploymentConfig(Entry{"test", "X", ns})
+				obj := DeploymentConfig(Entry{Name: "test", DeploymentType: "X", Namespace: ns})
 				Expect(obj).To(BeNil())
 			})
 
 			It("should create with liveness probe", func() {
-				obj := DeploymentConfig(Entry{"test", "DeploymentConfig", ns})
+				obj := DeploymentConfig(Entry{Name: "test", DeploymentType: "DeploymentConfig", Namespace: ns})
 				Expect(obj).To(BeAssignableToTypeOf(&osappsv1.DeploymentConfig{}))
 				validateLivenessProbe(obj.(*osappsv1.DeploymentConfig).Spec.Template)
 			})
 
 			It("should create with readiness probe", func() {
-				obj := DeploymentConfig(Entry{"test", "DeploymentConfig", ns})
+				obj := DeploymentConfig(Entry{Name: "test", DeploymentType: "DeploymentConfig", Namespace: ns})
 				Expect(obj).To(BeAssignableToTypeOf(&osappsv1.DeploymentConfig{}))
 				validateReadinessProbe(obj.(*osappsv1.DeploymentConfig).Spec.Template)
 			})
 		})
 		Context("deployment", func() {
 			It("should be created if entry is correct DeploymentType", func() {
-				obj := Deployment(Entry{"test", "Deployment", ns})
+				obj := Deployment(Entry{Name: "test", DeploymentType: "Deployment", Namespace: ns})
 				Expect(obj).ToNot(BeNil())
 			})
 
 			It("should not be created if entry is not correct DeploymentType", func() {
-				obj := Deployment(Entry{"test", "X", ns})
+				obj := Deployment(Entry{Name: "test", DeploymentType: "X", Namespace: ns})
 				Expect(obj).To(BeNil())
 			})
 
 			It("should create with liveness probe", func() {
-				obj := Deployment(Entry{"test", "Deployment", ns})
+				obj := Deployment(Entry{Name: "test", DeploymentType: "Deployment", Namespace: ns})
 				Expect(obj).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
 				validateLivenessProbe(&obj.(*appsv1.Deployment).Spec.Template)
 			})
 
 			It("should create with readiness probe", func() {
-				obj := Deployment(Entry{"test", "Deployment", ns})
+				obj := Deployment(Entry{Name: "test", DeploymentType: "Deployment", Namespace: ns})
 				Expect(obj).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
 				validateReadinessProbe(&obj.(*appsv1.Deployment).Spec.Template)
 			})

--- a/test/cmd/test-service/grpc.go
+++ b/test/cmd/test-service/grpc.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	context "context"
+	"context"
 	"net/url"
 	"time"
 
 	"github.com/go-logr/logr"
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 


### PR DESCRIPTION
#### Short description of what this resolves:

Just a little bit of boy scouting prior to the release

#### Changes proposed in this pull request:

- removes explicit types
- adds named parameters in constructors
- removes redundant import aliases
- uses `NewFakeClientWithScheme` in favor of deprecated `NewFakeClient`
- uses `Install` instead of deprecated `AddToScheme`

