### PR TITLE
feat: expose session host route

### DIFF
--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -83,7 +83,7 @@ const charset = "abcdefghijklmnopqrstuvwxyz"
 var seededRand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
-// StringWithCharset returns a random string of length based on charset
+// stringWithCharset returns a random string of length based on charset
 func stringWithCharset(length int, charset string) string {
 	b := make([]byte, length)
 	for i := range b {

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"time"
 
@@ -75,6 +76,25 @@ func setTestNamespace(namespace string) {
 // GetGatewayHost returns the host the Gateway in the scenario is bound to (http header Host)
 func GetGatewayHost(namespace string) string {
 	return namespace + "-test.com"
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyz"
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+// StringWithCharset returns a random string of length based on charset
+func stringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// GenerateSessionName returns a random safe string to be used as a session name
+func GenerateSessionName(length int) string {
+	return stringWithCharset(length, charset)
 }
 
 // PublisherRuby contains fixed response to be changed by tests

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -80,7 +80,7 @@ func GetGatewayHost(namespace string) string {
 
 const charset = "abcdefghijklmnopqrstuvwxyz"
 
-var seededRand *rand.Rand = rand.New(
+var seededRand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
 // StringWithCharset returns a random string of length based on charset

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -93,8 +93,8 @@ func stringWithCharset(length int, charset string) string {
 }
 
 // GenerateSessionName returns a random safe string to be used as a session name.
-func GenerateSessionName(length int) string {
-	return stringWithCharset(length, charset)
+func GenerateSessionName() string {
+	return stringWithCharset(8, charset)
 }
 
 // PublisherRuby contains fixed response to be changed by tests.

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -83,7 +83,7 @@ const charset = "abcdefghijklmnopqrstuvwxyz"
 var seededRand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
-// stringWithCharset returns a random string of length based on charset
+// stringWithCharset returns a random string of length based on charset.
 func stringWithCharset(length int, charset string) string {
 	b := make([]byte, length)
 	for i := range b {
@@ -92,7 +92,7 @@ func stringWithCharset(length int, charset string) string {
 	return string(b)
 }
 
-// GenerateSessionName returns a random safe string to be used as a session name
+// GenerateSessionName returns a random safe string to be used as a session name.
 func GenerateSessionName(length int) string {
 	return stringWithCharset(length, charset)
 }

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -284,7 +284,7 @@ func EnsureSessionRouteIsReachable(namespace, sessionName string, matchers ...ty
 		3*time.Minute, 1*time.Second).Should(And(matchers...))
 }
 
-// EnsureSessionRouteIsNotReachable the manipulated route is reachable
+// EnsureSessionRouteIsNotReachable the manipulated route is reachable.
 func EnsureSessionRouteIsNotReachable(namespace, sessionName string, matchers ...types.GomegaMatcher) {
 	productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -289,9 +289,10 @@ func EnsureSessionRouteIsNotReachable(namespace, sessionname string, matchers ..
 	productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
 
 	// check original response using headers
-	Expect(call(productPageURL, map[string]string{
+	Eventually(call(productPageURL, map[string]string{
 		"Host":         GetGatewayHost(namespace),
-		"x-test-suite": "smoke"})()).Should(And(matchers...))
+		"x-test-suite": "smoke"}),
+		3*time.Minute, 1*time.Second).Should(And(matchers...))
 }
 
 // ChangeNamespace switch to different namespace - so we also test -n parameter of $ ike

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 						Eventually(ikeDel.Done(), 1*time.Minute).Should(BeClosed())
 
 						// check original response
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
+						EnsureSessionRouteIsNotReachable(namespace, sessionname, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -282,6 +282,16 @@ func EnsureSessionRouteIsReachable(namespace, sessionname string, matchers ...ty
 	Eventually(call(productPageURL, map[string]string{
 		"Host": sessionname + "." + GetGatewayHost(namespace)}),
 		3*time.Minute, 1*time.Second).Should(And(matchers...))
+}
+
+// EnsureSessionRouteIsNotReachable the manipulated route is reachable
+func EnsureSessionRouteIsNotReachable(namespace, sessionname string, matchers ...types.GomegaMatcher) {
+	productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
+
+	// check original response using headers
+	Expect(call(productPageURL, map[string]string{
+		"Host":         GetGatewayHost(namespace),
+		"x-test-suite": "smoke"})()).Should(And(matchers...))
 }
 
 // ChangeNamespace switch to different namespace - so we also test -n parameter of $ ike

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			EnablePullingImages(namespace)
 			InstallLocalOperator(namespace)
 			DeployTestScenario(scenario, namespace)
-			sessionName = GenerateSessionName(7)
+			sessionName = GenerateSessionName()
 		})
 
 		AfterEach(func() {

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -27,7 +27,8 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 		var (
 			namespace,
 			tmpDir string
-			scenario string
+			scenario    string
+			sessionname string
 		)
 
 		JustBeforeEach(func() {
@@ -40,6 +41,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			EnablePullingImages(namespace)
 			InstallLocalOperator(namespace)
 			DeployTestScenario(scenario, namespace)
+			sessionname = GenerateSessionName(7)
 		})
 
 		AfterEach(func() {
@@ -73,15 +75,16 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--watch",
 							"--run", "ruby ratings.rb 9080",
 							"--route", "header:x-test-suite=smoke",
+							"--session", sessionname,
 						)
 						EnsureAllPodsAreReady(namespace)
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring("PublisherA"))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"))
 
 						// then modify the service
 						modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
 						CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring("Publisher Ike"))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("Publisher Ike"))
 
 						Stop(ike)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -105,15 +108,16 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--watch",
 							"--run", "ruby ratings.rb 9080",
 							"--route", "header:x-test-suite=smoke",
+							"--session", sessionname,
 						)
 						EnsureAllPodsAreReady(namespace)
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring("PublisherA"))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"))
 
 						// then modify the service
 						modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
 						CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring("Publisher Ike"))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("Publisher Ike"))
 
 						Stop(ike)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -135,7 +139,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"-n", namespace,
 							"--route", "header:x-test-suite=smoke",
 							"--image", registry+"/"+ImageRepo+"/istio-workspace-test-prepared-"+PreparedImageV1+":latest",
-							"-s", "test-session",
+							"--session", sessionname,
 						)
 						Eventually(ike1.Done(), 1*time.Minute).Should(BeClosed())
 
@@ -143,7 +147,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 						EnsureAllPodsAreReady(namespace)
 
 						// check original response
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring(PreparedImageV1), Not(ContainSubstring("ratings-v1")))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring(PreparedImageV1), Not(ContainSubstring("ratings-v1")))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -155,12 +159,12 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"-n", namespace,
 							"--route", "header:x-test-suite=smoke",
 							"--image", registry+"/"+ImageRepo+"/istio-workspace-test-prepared-"+PreparedImageV2+":latest",
-							"-s", "test-session",
+							"--session", sessionname,
 						)
 						Eventually(ike2.Done(), 1*time.Minute).Should(BeClosed())
 
 						// check original response
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring(PreparedImageV2), Not(ContainSubstring("ratings-v1")))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring(PreparedImageV2), Not(ContainSubstring("ratings-v1")))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
@@ -169,12 +173,12 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 						ikeDel := RunIke(tmpDir, "delete",
 							"--deployment", "ratings-v1",
 							"-n", namespace,
-							"-s", "test-session",
+							"--session", sessionname,
 						)
 						Eventually(ikeDel.Done(), 1*time.Minute).Should(BeClosed())
 
 						// check original response
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -199,10 +203,11 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--method", "inject-tcp",
 							"--run", "go run ./test/cmd/test-service -serviceName=PublisherA",
 							"--route", "header:x-test-suite=smoke",
+							"--session", sessionname,
 						)
 						EnsureAllPodsAreReady(namespace)
 
-						EnsureSessionRouteIsReachable(namespace, ContainSubstring("PublisherA"), ContainSubstring("grpc"))
+						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"), ContainSubstring("grpc"))
 
 						Stop(ike)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -231,15 +236,16 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 					"--watch",
 					"--run", "ruby ratings.rb 9080",
 					"--route", "header:x-test-suite=smoke",
+					"--session", sessionname,
 				)
 				EnsureAllPodsAreReady(namespace)
-				EnsureSessionRouteIsReachable(namespace, ContainSubstring("PublisherA"))
+				EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"))
 
 				// then modify the service
 				modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
 				CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-				EnsureSessionRouteIsReachable(namespace, ContainSubstring("Publisher Ike"))
+				EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("Publisher Ike"))
 
 				Stop(ike)
 				EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -263,13 +269,18 @@ func EnsureProdRouteIsReachable(namespace string, matchers ...types.GomegaMatche
 }
 
 // EnsureSessionRouteIsReachable the manipulated route is reachable
-func EnsureSessionRouteIsReachable(namespace string, matchers ...types.GomegaMatcher) {
+func EnsureSessionRouteIsReachable(namespace, sessionname string, matchers ...types.GomegaMatcher) {
 	productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
 
-	// check original response
+	// check original response using headers
 	Eventually(call(productPageURL, map[string]string{
 		"Host":         GetGatewayHost(namespace),
 		"x-test-suite": "smoke"}),
+		3*time.Minute, 1*time.Second).Should(And(matchers...))
+
+	// check original response using host route
+	Eventually(call(productPageURL, map[string]string{
+		"Host": sessionname + "." + GetGatewayHost(namespace)}),
 		3*time.Minute, 1*time.Second).Should(And(matchers...))
 }
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			namespace,
 			tmpDir string
 			scenario    string
-			sessionname string
+			sessionName string
 		)
 
 		JustBeforeEach(func() {
@@ -41,7 +41,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			EnablePullingImages(namespace)
 			InstallLocalOperator(namespace)
 			DeployTestScenario(scenario, namespace)
-			sessionname = GenerateSessionName(7)
+			sessionName = GenerateSessionName(7)
 		})
 
 		AfterEach(func() {
@@ -75,16 +75,16 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--watch",
 							"--run", "ruby ratings.rb 9080",
 							"--route", "header:x-test-suite=smoke",
-							"--session", sessionname,
+							"--session", sessionName,
 						)
 						EnsureAllPodsAreReady(namespace)
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("PublisherA"))
 
 						// then modify the service
 						modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
 						CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("Publisher Ike"))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("Publisher Ike"))
 
 						Stop(ike)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -108,16 +108,16 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--watch",
 							"--run", "ruby ratings.rb 9080",
 							"--route", "header:x-test-suite=smoke",
-							"--session", sessionname,
+							"--session", sessionName,
 						)
 						EnsureAllPodsAreReady(namespace)
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("PublisherA"))
 
 						// then modify the service
 						modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
 						CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("Publisher Ike"))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("Publisher Ike"))
 
 						Stop(ike)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -139,7 +139,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"-n", namespace,
 							"--route", "header:x-test-suite=smoke",
 							"--image", registry+"/"+ImageRepo+"/istio-workspace-test-prepared-"+PreparedImageV1+":latest",
-							"--session", sessionname,
+							"--session", sessionName,
 						)
 						Eventually(ike1.Done(), 1*time.Minute).Should(BeClosed())
 
@@ -147,7 +147,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 						EnsureAllPodsAreReady(namespace)
 
 						// check original response
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring(PreparedImageV1), Not(ContainSubstring("ratings-v1")))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring(PreparedImageV1), Not(ContainSubstring("ratings-v1")))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -159,12 +159,12 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"-n", namespace,
 							"--route", "header:x-test-suite=smoke",
 							"--image", registry+"/"+ImageRepo+"/istio-workspace-test-prepared-"+PreparedImageV2+":latest",
-							"--session", sessionname,
+							"--session", sessionName,
 						)
 						Eventually(ike2.Done(), 1*time.Minute).Should(BeClosed())
 
 						// check original response
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring(PreparedImageV2), Not(ContainSubstring("ratings-v1")))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring(PreparedImageV2), Not(ContainSubstring("ratings-v1")))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
@@ -173,12 +173,12 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 						ikeDel := RunIke(tmpDir, "delete",
 							"--deployment", "ratings-v1",
 							"-n", namespace,
-							"--session", sessionname,
+							"--session", sessionName,
 						)
 						Eventually(ikeDel.Done(), 1*time.Minute).Should(BeClosed())
 
 						// check original response
-						EnsureSessionRouteIsNotReachable(namespace, sessionname, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
+						EnsureSessionRouteIsNotReachable(namespace, sessionName, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV2)))
 
 						// but also check if prod is intact
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -203,11 +203,11 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--method", "inject-tcp",
 							"--run", "go run ./test/cmd/test-service -serviceName=PublisherA",
 							"--route", "header:x-test-suite=smoke",
-							"--session", sessionname,
+							"--session", sessionName,
 						)
 						EnsureAllPodsAreReady(namespace)
 
-						EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"), ContainSubstring("grpc"))
+						EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("PublisherA"), ContainSubstring("grpc"))
 
 						Stop(ike)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -236,16 +236,16 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 					"--watch",
 					"--run", "ruby ratings.rb 9080",
 					"--route", "header:x-test-suite=smoke",
-					"--session", sessionname,
+					"--session", sessionName,
 				)
 				EnsureAllPodsAreReady(namespace)
-				EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("PublisherA"))
+				EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("PublisherA"))
 
 				// then modify the service
 				modifiedDetails := strings.Replace(PublisherRuby, "PublisherA", "Publisher Ike", 1)
 				CreateFile(tmpDir+"/ratings.rb", modifiedDetails)
 
-				EnsureSessionRouteIsReachable(namespace, sessionname, ContainSubstring("Publisher Ike"))
+				EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("Publisher Ike"))
 
 				Stop(ike)
 				EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"))
@@ -269,7 +269,7 @@ func EnsureProdRouteIsReachable(namespace string, matchers ...types.GomegaMatche
 }
 
 // EnsureSessionRouteIsReachable the manipulated route is reachable
-func EnsureSessionRouteIsReachable(namespace, sessionname string, matchers ...types.GomegaMatcher) {
+func EnsureSessionRouteIsReachable(namespace, sessionName string, matchers ...types.GomegaMatcher) {
 	productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
 
 	// check original response using headers
@@ -280,12 +280,12 @@ func EnsureSessionRouteIsReachable(namespace, sessionname string, matchers ...ty
 
 	// check original response using host route
 	Eventually(call(productPageURL, map[string]string{
-		"Host": sessionname + "." + GetGatewayHost(namespace)}),
+		"Host": sessionName + "." + GetGatewayHost(namespace)}),
 		3*time.Minute, 1*time.Second).Should(And(matchers...))
 }
 
 // EnsureSessionRouteIsNotReachable the manipulated route is reachable
-func EnsureSessionRouteIsNotReachable(namespace, sessionname string, matchers ...types.GomegaMatcher) {
+func EnsureSessionRouteIsNotReachable(namespace, sessionName string, matchers ...types.GomegaMatcher) {
 	productPageURL := GetIstioIngressHostname() + "/test-service/productpage"
 
 	// check original response using headers

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -154,10 +154,10 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 	if deleted {
 		r.deleteAllRefs(ctx, session, refs)
 	} else {
+		r.deleteRemovedRefs(ctx, session, refs)
 		if err := r.syncAllRefs(ctx, session); err != nil {
 			return reconcile.Result{}, err
 		}
-		r.deleteRemovedRefs(ctx, session, refs)
 	}
 
 	if deleted {

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -38,20 +38,20 @@ func DefaultManipulators() Manipulators {
 			k8s.DeploymentLocator,
 			openshift.DeploymentConfigLocator,
 			k8s.ServiceLocator,
-			istio.VirtualServiceGatewayLocator, // finds all connected virtual services
+			istio.VirtualServiceGatewayLocator,
 		},
 		Mutators: []model.Mutator{
 			k8s.DeploymentMutator,
 			openshift.DeploymentConfigMutator,
 			istio.DestinationRuleMutator,
-			istio.GatewayMutator, //add host to gw
+			istio.GatewayMutator,
 			istio.VirtualServiceMutator,
 		},
 		Revertors: []model.Revertor{
 			k8s.DeploymentRevertor,
 			openshift.DeploymentConfigRevertor,
 			istio.DestinationRuleRevertor,
-			istio.GatewayRevertor, //remove host from gw
+			istio.GatewayRevertor,
 			istio.VirtualServiceRevertor,
 		},
 	}

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -38,17 +38,20 @@ func DefaultManipulators() Manipulators {
 			k8s.DeploymentLocator,
 			openshift.DeploymentConfigLocator,
 			k8s.ServiceLocator,
+			istio.VirtualServiceGatewayLocator, // finds all connected virtual services
 		},
 		Mutators: []model.Mutator{
 			k8s.DeploymentMutator,
 			openshift.DeploymentConfigMutator,
 			istio.DestinationRuleMutator,
+			istio.GatewayMutator, //add host to gw
 			istio.VirtualServiceMutator,
 		},
 		Revertors: []model.Revertor{
 			k8s.DeploymentRevertor,
 			openshift.DeploymentConfigRevertor,
 			istio.DestinationRuleRevertor,
+			istio.GatewayRevertor, //remove host from gw
 			istio.VirtualServiceRevertor,
 		},
 	}

--- a/pkg/controller/session/session_controller_int_test.go
+++ b/pkg/controller/session/session_controller_int_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/controller/session"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/test/cmd/test-scenario/generator"
-	"github.com/maistra/istio-workspace/test/operator"
+	"github.com/maistra/istio-workspace/test/testclient"
 
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
@@ -38,7 +38,7 @@ var _ = Describe("Complete session manipulation", func() {
 		schema     *runtime.Scheme
 		c          client.Client
 		scenario   func(io.Writer)
-		get        *operator.Helpers
+		get        *testclient.Getters
 	)
 	JustBeforeEach(func() {
 		logf.SetLogger(log.CreateOperatorAwareLogger("test").WithValues("type", "session_controller_int_test"))
@@ -53,7 +53,7 @@ var _ = Describe("Complete session manipulation", func() {
 		objects = append(objects, objs...)
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(c)
+		get = testclient.New(c)
 		controller = session.NewStandaloneReconciler(c, session.DefaultManipulators())
 	})
 

--- a/pkg/controller/session/session_controller_int_test.go
+++ b/pkg/controller/session/session_controller_int_test.go
@@ -3,7 +3,6 @@ package session_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"strings"
 
@@ -203,7 +202,6 @@ var _ = Describe("Complete session manipulation", func() {
 
 			// Verify
 			gw := get.Gateway("test", "test-gateway")
-			fmt.Println(gw.Spec.Servers[0].Hosts)
 			Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
 
 			vss := get.VirtualServices("test")
@@ -220,14 +218,10 @@ var _ = Describe("Complete session manipulation", func() {
 
 			// Verify - no vs removed (only gateway connected duplicated)
 			vss = get.VirtualServices("test")
-			for _, vs := range vss.Items {
-				fmt.Println(vs.Name)
-			}
 			Expect(vss.Items).To(HaveLen(4))
 
 			// Verify - same Gateways Hosts still connected, ref01 still need them
 			gw = get.Gateway("test", "test-gateway")
-			fmt.Println(gw.Spec.Servers[0].Hosts)
 			Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
 		})
 

--- a/pkg/controller/session/session_controller_int_test.go
+++ b/pkg/controller/session/session_controller_int_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Complete session manipulation", func() {
 		objects = append(objects, objs...)
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(&c)
+		get = operator.New(c)
 		controller = session.NewStandaloneReconciler(c, session.DefaultManipulators())
 	})
 
@@ -171,7 +171,7 @@ var _ = Describe("Complete session manipulation", func() {
 
 		})
 
-		FIt("with multiple ref", func() {
+		It("with multiple ref", func() {
 			req1 := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "test-session1",

--- a/pkg/controller/session/session_controller_int_test.go
+++ b/pkg/controller/session/session_controller_int_test.go
@@ -56,16 +56,6 @@ var _ = Describe("Complete session manipulation", func() {
 			return s
 		}
 	}(&c)
-	/*
-		GetVirtualService := func(c *client.Client) func(namespace, name string) istionetwork.VirtualService {
-			return func(namespace, name string) istionetwork.VirtualService {
-				s := istionetwork.VirtualService{}
-				err = (*c).Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
-				Expect(err).ToNot(HaveOccurred())
-				return s
-			}
-		}(&c)
-	*/
 	GetVirtualServices := func(c *client.Client) func(namespace string) istionetwork.VirtualServiceList {
 		return func(namespace string) istionetwork.VirtualServiceList {
 			s := istionetwork.VirtualServiceList{}

--- a/pkg/controller/session/session_controller_int_test.go
+++ b/pkg/controller/session/session_controller_int_test.go
@@ -3,6 +3,7 @@ package session_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -35,7 +36,6 @@ var _ = Describe("Complete session manipulation", func() {
 		objects    []runtime.Object
 		err        error
 		controller reconcile.Reconciler
-		req        reconcile.Request
 		schema     *runtime.Scheme
 		c          client.Client
 		scenario   func(io.Writer)
@@ -44,6 +44,32 @@ var _ = Describe("Complete session manipulation", func() {
 		return func(namespace, name string) v1alpha1.Session {
 			s := v1alpha1.Session{}
 			err = (*c).Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+			Expect(err).ToNot(HaveOccurred())
+			return s
+		}
+	}(&c)
+	GetGateway := func(c *client.Client) func(namespace, name string) istionetwork.Gateway {
+		return func(namespace, name string) istionetwork.Gateway {
+			s := istionetwork.Gateway{}
+			err = (*c).Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+			Expect(err).ToNot(HaveOccurred())
+			return s
+		}
+	}(&c)
+	/*
+		GetVirtualService := func(c *client.Client) func(namespace, name string) istionetwork.VirtualService {
+			return func(namespace, name string) istionetwork.VirtualService {
+				s := istionetwork.VirtualService{}
+				err = (*c).Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+				Expect(err).ToNot(HaveOccurred())
+				return s
+			}
+		}(&c)
+	*/
+	GetVirtualServices := func(c *client.Client) func(namespace string) istionetwork.VirtualServiceList {
+		return func(namespace string) istionetwork.VirtualServiceList {
+			s := istionetwork.VirtualServiceList{}
+			err = (*c).List(context.Background(), &s, client.InNamespace(namespace))
 			Expect(err).ToNot(HaveOccurred())
 			return s
 		}
@@ -60,12 +86,6 @@ var _ = Describe("Complete session manipulation", func() {
 		Expect(err).ToNot(HaveOccurred())
 		objects = append(objects, objs...)
 
-		req = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "test-session",
-				Namespace: "test",
-			},
-		}
 		c = fake.NewFakeClientWithScheme(schema, objects...)
 		controller = session.NewStandaloneReconciler(c, session.DefaultManipulators())
 	})
@@ -73,9 +93,10 @@ var _ = Describe("Complete session manipulation", func() {
 	Context("in a complete lifecycle", func() {
 		BeforeEach(func() {
 			scenario = generator.TestScenario1HTTPThreeServicesInSequence
+			objects = []runtime.Object{}
 			objects = append(objects, &v1alpha1.Session{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-session",
+					Name:      "test-session1",
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.SessionSpec{
@@ -90,32 +111,106 @@ var _ = Describe("Complete session manipulation", func() {
 					},
 				},
 			})
+			objects = append(objects, &v1alpha1.Session{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-session2",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.SessionSpec{
+					Refs: []v1alpha1.Ref{
+						{
+							Name:     "reviews-v1",
+							Strategy: "prepared-image",
+							Args: map[string]string{
+								"image": "x:x:x",
+							},
+						},
+					},
+				},
+			})
 		})
 
 		It("with update", func() {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-session1",
+					Namespace: "test",
+				},
+			}
+
 			res, err := controller.Reconcile(req)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Requeue).To(BeFalse())
 
-			target := GetSession("test", "test-session")
+			target := GetSession("test", "test-session1")
 			target.Spec.Refs[0].Args["image"] = "y:y:y"
 
 			res, err = controller.Reconcile(req)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Requeue).To(BeFalse())
 
-			sess := GetSession("test", "test-session")
-
+			sess := GetSession("test", "test-session1")
+			Expect(target.Spec.Refs[0].Args["image"]).To(Equal("y:y:y"))
 			Expect(sess.Status.Refs).To(HaveLen(1))
-			Expect(sess.Status.Refs[0].Resources).To(HaveLen(3))
-			Expect(sess.Status.Refs[0].Targets).To(HaveLen(2))
+			Expect(sess.Status.Refs[0].Resources).To(HaveLen(5))
+			Expect(sess.Status.Refs[0].Targets).To(HaveLen(3))
 		})
+
+		It("with multiple", func() {
+			req1 := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-session1",
+					Namespace: "test",
+				},
+			}
+			req2 := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-session2",
+					Namespace: "test",
+				},
+			}
+
+			// Create first session
+			res1, err := controller.Reconcile(req1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res1.Requeue).To(BeFalse())
+
+			// Create second session
+			res2, err := controller.Reconcile(req2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res2.Requeue).To(BeFalse())
+
+			// Verify
+			gw := GetGateway("test", "test-gateway")
+			fmt.Println(gw.Spec.Servers[0].Hosts)
+			Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(3))
+
+			vss := GetVirtualServices("test")
+			Expect(vss.Items).To(HaveLen(5))
+
+			// Delete first session
+			sess := GetSession("test", "test-session1")
+			now := metav1.Now()
+			sess.DeletionTimestamp = &now
+
+			c.Update(context.Background(), &sess)
+			res1, err = controller.Reconcile(req1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res2.Requeue).To(BeFalse())
+
+			// Verify
+			vss = GetVirtualServices("test")
+			Expect(vss.Items).To(HaveLen(4))
+
+		})
+
 	})
 })
 
 func Scenario(scheme *runtime.Scheme, namespace string, scenarioGenerator func(io.Writer)) ([]runtime.Object, error) {
 	generator.Namespace = namespace
 	generator.TestImageName = "x:x:x"
+	generator.GatewayHost = "test.io"
 
 	buf := new(bytes.Buffer)
 	scenarioGenerator(buf)

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -24,7 +24,7 @@ var _ model.Revertor = DestinationRuleRevertor
 // DestinationRuleMutator creates destination rule mutator which is responsible for alternating the traffic for development
 // of the forked service
 func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
-	if len(ref.GetResourceStatus(DestinationRuleKind)) > 0 {
+	if len(ref.GetResources(model.Kind(DestinationRuleKind))) > 0 {
 		return nil
 	}
 
@@ -50,7 +50,7 @@ func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
 
 // DestinationRuleRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects
 func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
-	resources := ref.GetResourceStatus(DestinationRuleKind)
+	resources := ref.GetResources(model.Kind(DestinationRuleKind))
 
 	for _, resource := range resources {
 		dr, err := getDestinationRule(ctx, ctx.Namespace, resource.Name)

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -1,10 +1,11 @@
-package istio //nolint:testpackage //reason we want to test converters in isolation
+package istio_test
 
 import (
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
-	"github.com/maistra/istio-workspace/test/operator"
+	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -25,7 +26,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 		objects []runtime.Object
 		c       client.Client
 		ctx     model.SessionContext
-		get     *operator.Helpers
+		get     *testclient.Getters
 	)
 
 	BeforeEach(func() {
@@ -79,7 +80,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			&istionetwork.DestinationRuleList{}).Build()
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(c)
+		get = testclient.New(c)
 		ctx = model.SessionContext{
 			Name:      "test",
 			Namespace: "test",
@@ -107,7 +108,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			It("new subset added", func() {
-				err := DestinationRuleMutator(ctx, ref)
+				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-mutate")
@@ -115,7 +116,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			It("new subset added with name", func() {
-				err := DestinationRuleMutator(ctx, ref)
+				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-mutate")
@@ -123,11 +124,11 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			It("new subset only added once", func() {
-				err := DestinationRuleMutator(ctx, ref)
+				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				// apply twice
-				err = DestinationRuleMutator(ctx, ref)
+				err = istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-mutate")
@@ -156,7 +157,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 		Context("existing rule", func() {
 
 			It("new subset removed", func() {
-				err := DestinationRuleRevertor(ctx, ref)
+				err := istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-revert")
@@ -164,7 +165,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			It("correct subset removed", func() {
-				err := DestinationRuleRevertor(ctx, ref)
+				err := istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-revert")

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -5,22 +5,21 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/test/operator"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
+	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
-
-	"istio.io/api/networking/v1alpha3"
-	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Operations for istio DestinationRule kind", func() {
 
-	GetName := func(s *v1alpha3.Subset) string { return s.Name }
+	GetName := func(s *istionetworkv1alpha3.Subset) string { return s.Name }
 
 	var (
 		objects []runtime.Object
@@ -80,7 +79,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			&istionetwork.DestinationRuleList{}).Build()
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(&c)
+		get = operator.New(c)
 		ctx = model.SessionContext{
 			Name:      "test",
 			Namespace: "test",

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -83,7 +83,6 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 		ctx = model.SessionContext{
 			Name:      "test",
 			Namespace: "test",
-			Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
 			Client:    c,
 			Log:       log.CreateOperatorAwareLogger("destinationrule"),
 		}

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -1,13 +1,21 @@
 package istio
 
 import (
+	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/log"
+	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/test/operator"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
 	"istio.io/api/networking/v1alpha3"
-	k8yaml "sigs.k8s.io/yaml"
+	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Operations for istio DestinationRule kind", func() {
@@ -15,113 +23,155 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 	GetName := func(s *v1alpha3.Subset) string { return s.Name }
 
 	var (
-		err             error
-		destinationRule istionetwork.DestinationRule
-		yaml            string
+		objects []runtime.Object
+		c       client.Client
+		ctx     model.SessionContext
+		get     *operator.Helpers
 	)
+
+	BeforeEach(func() {
+		objects = []runtime.Object{
+			&istionetwork.DestinationRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "customer-mutate",
+					Namespace: "test",
+				},
+				Spec: istionetworkv1alpha3.DestinationRule{
+					Host: "customer-mutate",
+					Subsets: []*istionetworkv1alpha3.Subset{
+						&istionetworkv1alpha3.Subset{
+							Name: "v1",
+							Labels: map[string]string{
+								"version": "v1",
+							},
+						},
+					},
+				},
+			},
+			&istionetwork.DestinationRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "customer-revert",
+					Namespace: "test",
+				},
+				Spec: istionetworkv1alpha3.DestinationRule{
+					Host: "customer-revert",
+					Subsets: []*istionetworkv1alpha3.Subset{
+						&istionetworkv1alpha3.Subset{
+							Name: "v1",
+							Labels: map[string]string{
+								"version": "v1",
+							},
+						},
+						&istionetworkv1alpha3.Subset{
+							Name: "dr-test",
+							Labels: map[string]string{
+								"version": "dr-test",
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		schema, _ := v1alpha1.SchemeBuilder.Register(
+			&istionetwork.DestinationRule{},
+			&istionetwork.DestinationRuleList{}).Build()
+
+		c = fake.NewFakeClientWithScheme(schema, objects...)
+		get = operator.New(&c)
+		ctx = model.SessionContext{
+			Name:      "test",
+			Namespace: "test",
+			Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
+			Client:    c,
+			Log:       log.CreateOperatorAwareLogger("destinationrule"),
+		}
+	})
 
 	Context("mutators", func() {
 
-		JustBeforeEach(func() {
-			err = k8yaml.Unmarshal([]byte(yaml), &destinationRule)
-		})
-
 		Context("existing rule", func() {
+
 			var (
-				mutatedDestinationRule istionetwork.DestinationRule
+				ref *model.Ref
 			)
 
 			BeforeEach(func() {
-				yaml = simpleDestinationRule
-			})
-
-			JustBeforeEach(func() {
-				mutatedDestinationRule = mutateDestinationRule(destinationRule, "dr-test")
+				ref = &model.Ref{
+					Name: "customer-v1",
+					Targets: []model.LocatedResourceStatus{
+						model.NewLocatedResource("Deployment", "customer-v1", map[string]string{"version": "v1"}),
+						model.NewLocatedResource("Service", "customer-mutate", nil),
+					},
+				}
 			})
 
 			It("new subset added", func() {
-				Expect(mutatedDestinationRule.Spec.Subsets).To(HaveLen(3))
+				err := DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				dr := get.DestinationRule("test", "customer-mutate")
+				Expect(dr.Spec.Subsets).To(HaveLen(2))
 			})
 
 			It("new subset added with name", func() {
-				Expect(mutatedDestinationRule.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal("dr-test"))))
+				err := DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				dr := get.DestinationRule("test", "customer-mutate")
+				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal("v1-test"))))
 			})
 
+			It("new subset only added once", func() {
+				err := DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				// apply twice
+				err = DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				dr := get.DestinationRule("test", "customer-mutate")
+				Expect(dr.Spec.Subsets).To(HaveLen(2))
+				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal("v1-test"))))
+			})
 		})
 	})
 
 	Context("revertors", func() {
 
-		JustBeforeEach(func() {
-			err = k8yaml.Unmarshal([]byte(yaml), &destinationRule)
+		var (
+			ref *model.Ref
+		)
+
+		BeforeEach(func() {
+			ref = &model.Ref{
+				Name: "customer-v1",
+				Targets: []model.LocatedResourceStatus{
+					model.NewLocatedResource("Deployment", "customer-v1", map[string]string{"version": "v1"}),
+					model.NewLocatedResource("Service", "customer-revert", nil),
+				},
+			}
 		})
 
 		Context("existing rule", func() {
-			var (
-				revertedDestinationRule istionetwork.DestinationRule
-			)
-
-			BeforeEach(func() {
-				yaml = simpleMutatedDestinationRule
-			})
 
 			It("new subset removed", func() {
-				revertedDestinationRule = revertDestinationRule(destinationRule, "dr-test")
+				err := DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(revertedDestinationRule.Spec.Subsets).To(HaveLen(2))
+				dr := get.DestinationRule("test", "customer-revert")
+				Expect(dr.Spec.Subsets).To(HaveLen(2))
 			})
 
 			It("correct subset removed", func() {
-				revertedDestinationRule = revertDestinationRule(destinationRule, "dr-test")
+				err := DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(revertedDestinationRule.Spec.Subsets).ToNot(ContainElement(WithTransform(GetName, Equal("dr-test"))))
+				dr := get.DestinationRule("test", "customer-revert")
+				Expect(dr.Spec.Subsets).ToNot(ContainElement(WithTransform(GetName, Equal("v1-test"))))
 			})
 		})
 	})
 })
-
-var simpleDestinationRule = `kind: DestinationRule
-metadata:
-  annotations:
-  creationTimestamp: 2019-01-16T19:28:05Z
-  generation: 1
-  name: details
-  namespace: bookinfo
-  resourceVersion: "4955188"
-  selfLink: /apis/networking.istio.io/v1alpha3/namespaces/bookinfo/destinationrules/details
-  uid: d928001c-19c4-11e9-a489-482ae3045b54
-spec:
-  host: details
-  subsets:
-  - labels:
-      version: v1
-    name: v1
-  - labels:
-      version: v2
-    name: v2
-`
-
-var simpleMutatedDestinationRule = `kind: DestinationRule
-metadata:
-  creationTimestamp: "2019-01-16T19:28:05Z"
-  generation: 1
-  name: details
-  namespace: bookinfo
-  resourceVersion: "4955188"
-  selfLink: /apis/networking.istio.io/v1alpha3/namespaces/bookinfo/destinationrules/details
-  uid: d928001c-19c4-11e9-a489-482ae3045b54
-spec:
-  host: details
-  subsets:
-  - labels:
-      version: v1
-    name: v1
-  - labels:
-      version: v2
-    name: v2
-  - labels:
-      version: dr-test
-    name: dr-test
-`

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -1,0 +1,101 @@
+package istio
+
+import (
+	"github.com/maistra/istio-workspace/pkg/model"
+
+	istionetwork "istio.io/api/pkg/kube/apis/networking/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// GatewayKind is the k8s Kind for a istio Gateway
+	GatewayKind = "Gateway"
+)
+
+var _ model.Mutator = GatewayMutator
+var _ model.Revertor = GatewayRevertor
+
+// GatewayMutator attempts to expose a external host on the gateway
+func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+	if len(ref.GetResourceStatus(GatewayKind)) > 0 {
+		return nil
+	}
+
+	gws, err := getGateways(ctx, ctx.Namespace)
+	if err != nil {
+		return err
+	}
+
+	for _, vs := range gws.Items { //nolint[:rangeValCopy]
+		mutatedVs, err := mutateGateway(ctx, vs)
+		if err != nil {
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: vs.Name, Action: model.ActionFailed})
+			return err
+		}
+
+		err = ctx.Client.Update(ctx, &mutatedVs)
+		if err != nil {
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedVs.Name, Action: model.ActionFailed})
+			return err
+		}
+
+		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedVs.Name, Action: model.ActionModified})
+	}
+	return nil
+}
+
+// GatewayRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects
+func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+	resources := ref.GetResourceStatus(GatewayKind)
+
+	for _, resource := range resources {
+		gw, err := getGateway(ctx, ctx.Namespace, resource.Name)
+		if err != nil {
+			if errors.IsNotFound(err) { // Not found, nothing to clean
+				break
+			}
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: resource.Name, Action: model.ActionFailed})
+			break
+		}
+
+		ctx.Log.Info("Found Gateway", "name", resource.Name)
+		mutatedGw, err := revertGateway(ctx, *gw)
+		if err != nil {
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: resource.Name, Action: model.ActionFailed})
+			break
+		}
+		err = ctx.Client.Update(ctx, &mutatedGw)
+		if err != nil {
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: resource.Name, Action: model.ActionFailed})
+			break
+		}
+		// ok, removed
+		ref.RemoveResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: resource.Name})
+	}
+
+	return nil
+}
+
+func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+	return source, nil
+}
+
+func revertGateway(ctx model.SessionContext, vs istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+
+	return vs, nil
+}
+
+func getGateway(ctx model.SessionContext, namespace, name string) (*istionetwork.Gateway, error) { //nolint[:hugeParam]
+	Gateway := istionetwork.Gateway{}
+	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &Gateway)
+	return &Gateway, err
+}
+
+func getGateways(ctx model.SessionContext, namespace string) (*istionetwork.GatewayList, error) { //nolint[:hugeParam]
+	gateways := istionetwork.GatewayList{}
+	err := ctx.Client.List(ctx, &gateways, client.InNamespace(namespace))
+	return &gateways, err
+}

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -22,10 +22,10 @@ var _ model.Revertor = GatewayRevertor
 
 // GatewayMutator attempts to expose a external host on the gateway
 func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
-	if len(ref.GetResourceStatus(GatewayKind)) > 0 {
+	if len(ref.GetResources(model.Kind(GatewayKind))) > 0 {
 		return nil
 	}
-	for _, gwName := range ref.GetTargetsByKind(GatewayKind) {
+	for _, gwName := range ref.GetTargets(model.Kind(GatewayKind)) {
 		gw, err := getGateway(ctx, ctx.Namespace, gwName.Name)
 		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})
 		if err != nil {
@@ -51,7 +51,7 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:
 
 // GatewayRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects
 func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
-	resources := ref.GetResourceStatus(GatewayKind)
+	resources := ref.GetResources(model.Kind(GatewayKind))
 
 	for _, resource := range resources {
 		gw, err := getGateway(ctx, ctx.Namespace, resource.Name)

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -22,9 +22,6 @@ var _ model.Revertor = GatewayRevertor
 
 // GatewayMutator attempts to expose a external host on the gateway
 func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
-	if len(ref.GetResources(model.Kind(GatewayKind))) > 0 {
-		return nil
-	}
 	for _, gwName := range ref.GetTargets(model.Kind(GatewayKind)) {
 		gw, err := getGateway(ctx, ctx.Namespace, gwName.Name)
 		if err != nil {
@@ -32,6 +29,7 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:
 			return err
 		}
 
+		ctx.Log.Info("Found Gateway", "name", gw.Name)
 		mutatedGw, err := mutateGateway(ctx, *gw)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -1,6 +1,8 @@
 package istio
 
 import (
+	"strings"
+
 	"github.com/maistra/istio-workspace/pkg/model"
 
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -24,25 +26,27 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:
 		return nil
 	}
 
-	gws, err := getGateways(ctx, ctx.Namespace)
-	if err != nil {
-		return err
-	}
+	for _, gwName := range ref.GetTargetsByKind(GatewayKind) {
 
-	for _, vs := range gws.Items { //nolint[:rangeValCopy]
-		mutatedVs, err := mutateGateway(ctx, vs)
+		gw, err := getGateway(ctx, ctx.Namespace, gwName.Name)
+		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})
 		if err != nil {
-			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: vs.Name, Action: model.ActionFailed})
 			return err
 		}
 
-		err = ctx.Client.Update(ctx, &mutatedVs)
+		mutatedGw, err := mutateGateway(ctx, *gw)
 		if err != nil {
-			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedVs.Name, Action: model.ActionFailed})
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})
 			return err
 		}
 
-		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedVs.Name, Action: model.ActionModified})
+		err = ctx.Client.Update(ctx, &mutatedGw)
+		if err != nil {
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedGw.Name, Action: model.ActionFailed})
+			return err
+		}
+
+		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedGw.Name, Action: model.ActionModified})
 	}
 	return nil
 }
@@ -80,12 +84,55 @@ func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[
 }
 
 func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+	if source.Annotations == nil {
+		source.Annotations = map[string]string{}
+	}
+	existingHosts := []string{}
+	if hosts := source.Annotations[LabelIkeHosts]; hosts != "" {
+		existingHosts = strings.Split(hosts, ",") // split on empty string return empty (len(1))
+	}
+	for _, server := range source.Spec.Servers {
+		hosts := server.Hosts
+		for _, host := range hosts {
+			if !existInList(existingHosts, host) {
+				newHost := ctx.Name + "." + host
+				existingHosts = append(existingHosts, newHost)
+				hosts = append(hosts, newHost)
+			}
+		}
+		server.Hosts = hosts
+	}
+	source.Annotations[LabelIkeHosts] = strings.Join(existingHosts, ",")
 	return source, nil
 }
 
-func revertGateway(ctx model.SessionContext, vs istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+	if source.Annotations == nil {
+		source.Annotations = map[string]string{}
+	}
+	existingHosts := []string{}
+	if hosts := source.Annotations[LabelIkeHosts]; hosts != "" {
+		existingHosts = strings.Split(hosts, ",") // split on empty string return empty (len(1))
+	}
+	for _, server := range source.Spec.Servers {
+		hosts := server.Hosts
+		for i := 0; i < len(hosts); i++ {
+			host := hosts[i]
+			if existInList(existingHosts, host) && strings.HasPrefix(host, ctx.Name+".") {
+				existingHosts = removeFromList(existingHosts, host)
+				hosts = append(hosts[:i], hosts[i+1:]...)
+				i--
+			}
+		}
+		server.Hosts = hosts
+	}
+	if len(existingHosts) == 0 {
+		delete(source.Annotations, LabelIkeHosts)
+	} else {
+		source.Annotations[LabelIkeHosts] = strings.Join(existingHosts, ",")
+	}
 
-	return vs, nil
+	return source, nil
 }
 
 func getGateway(ctx model.SessionContext, namespace, name string) (*istionetwork.Gateway, error) { //nolint[:hugeParam]
@@ -98,4 +145,23 @@ func getGateways(ctx model.SessionContext, namespace string) (*istionetwork.Gate
 	gateways := istionetwork.GatewayList{}
 	err := ctx.Client.List(ctx, &gateways, client.InNamespace(namespace))
 	return &gateways, err
+}
+
+func existInList(hosts []string, host string) bool {
+	for _, eh := range hosts {
+		if eh == host {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFromList(hosts []string, host string) []string {
+	for i, eh := range hosts {
+		if eh == host {
+			hosts = append(hosts[:i], hosts[i+1:]...)
+			return hosts
+		}
+	}
+	return hosts
 }

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -21,7 +21,7 @@ var _ model.Mutator = GatewayMutator
 var _ model.Revertor = GatewayRevertor
 
 // GatewayMutator attempts to expose a external host on the gateway
-func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error {
 	for _, gwName := range ref.GetTargets(model.Kind(GatewayKind)) {
 		gw, err := getGateway(ctx, ctx.Namespace, gwName.Name)
 		if err != nil {
@@ -48,7 +48,7 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:
 }
 
 // GatewayRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects
-func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[:hugeParam]
+func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	resources := ref.GetResources(model.Kind(GatewayKind))
 
 	for _, resource := range resources {
@@ -79,7 +79,7 @@ func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error { //nolint[
 	return nil
 }
 
-func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) {
 	if source.Annotations == nil {
 		source.Annotations = map[string]string{}
 	}
@@ -102,7 +102,7 @@ func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istio
 	return source, nil
 }
 
-func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) { //nolint[:hugeParam]
+func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, error) {
 	if source.Annotations == nil {
 		source.Annotations = map[string]string{}
 	}
@@ -131,13 +131,13 @@ func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) (istio
 	return source, nil
 }
 
-func getGateway(ctx model.SessionContext, namespace, name string) (*istionetwork.Gateway, error) { //nolint[:hugeParam]
+func getGateway(ctx model.SessionContext, namespace, name string) (*istionetwork.Gateway, error) {
 	Gateway := istionetwork.Gateway{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &Gateway)
 	return &Gateway, err
 }
 
-func getGateways(ctx model.SessionContext, namespace string) (*istionetwork.GatewayList, error) { //nolint[:hugeParam]
+func getGateways(ctx model.SessionContext, namespace string) (*istionetwork.GatewayList, error) {
 	gateways := istionetwork.GatewayList{}
 	err := ctx.Client.List(ctx, &gateways, client.InNamespace(namespace))
 	return &gateways, err

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -92,8 +92,8 @@ func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istio
 	for _, server := range source.Spec.Servers {
 		hosts := server.Hosts
 		for _, host := range hosts {
-			if !existInList(existingHosts, host) {
-				newHost := ctx.Name + "." + host
+			newHost := ctx.Name + "." + host
+			if !existInList(existingHosts, host) && !existInList(existingHosts, newHost) {
 				existingHosts = append(existingHosts, newHost)
 				hosts = append(hosts, newHost)
 			}

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -3,7 +3,7 @@ package istio
 import (
 	"github.com/maistra/istio-workspace/pkg/model"
 
-	istionetwork "istio.io/api/pkg/kube/apis/networking/v1alpha3"
+	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -27,8 +27,8 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:
 	}
 	for _, gwName := range ref.GetTargets(model.Kind(GatewayKind)) {
 		gw, err := getGateway(ctx, ctx.Namespace, gwName.Name)
-		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})
 		if err != nil {
+			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})
 			return err
 		}
 

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -25,9 +25,7 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint[:
 	if len(ref.GetResourceStatus(GatewayKind)) > 0 {
 		return nil
 	}
-
 	for _, gwName := range ref.GetTargetsByKind(GatewayKind) {
-
 		gw, err := getGateway(ctx, ctx.Namespace, gwName.Name)
 		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: gw.Name, Action: model.ActionFailed})
 		if err != nil {

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
 			})
-			It("add multipe session", func() {
+			It("add multiple session", func() {
 				gw, err := mutateGateway(ctx, gateway)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -88,7 +88,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(3))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com", "gw-test2.domain.com"))
 			})
-			It("add multipe refs", func() {
+			It("add multiple refs", func() {
 				gw, err := mutateGateway(ctx, gateway)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -59,14 +59,14 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				}
 			})
 
-			It("single add", func() {
+			It("add single session", func() {
 				gw, err := mutateGateway(ctx, gateway)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
 			})
-			It("multiple add", func() {
+			It("add multipe session", func() {
 				gw, err := mutateGateway(ctx, gateway)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -87,6 +87,20 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				fmt.Println(gw.Labels[LabelIkeHosts])
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(3))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com", "gw-test2.domain.com"))
+			})
+			It("add multipe refs", func() {
+				gw, err := mutateGateway(ctx, gateway)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
+
+				gw, err = mutateGateway(ctx, gw)
+				Expect(err).ToNot(HaveOccurred())
+
+				fmt.Println(gw.Labels[LabelIkeHosts])
+				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
 			})
 		})
 

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/maistra/istio-workspace/pkg/model"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/networking/v1alpha3"
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Operations for istio gateway kind", func() {

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -1,7 +1,8 @@
-package istio
+package istio_test
 
 import (
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/test/operator"
@@ -82,7 +83,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			})
 
 			It("add single session", func() {
-				err := GatewayMutator(ctx, ref)
+				err := istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw := get.Gateway("test", "gateway")
@@ -91,7 +92,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			})
 
 			It("add multiple session", func() {
-				err := GatewayMutator(ctx, ref)
+				err := istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw := get.Gateway("test", "gateway")
@@ -109,7 +110,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 					Client: ctx.Client,
 					Log:    ctx.Log,
 				}
-				err = GatewayMutator(ctx2, ref)
+				err = istio.GatewayMutator(ctx2, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw = get.Gateway("test", "gateway")
@@ -118,14 +119,14 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			})
 
 			It("add multiple refs", func() {
-				err := GatewayMutator(ctx, ref)
+				err := istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
 
-				err = GatewayMutator(ctx, ref)
+				err = istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw = get.Gateway("test", "gateway")
@@ -142,7 +143,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "gateway",
 							Namespace:   "test",
-							Annotations: map[string]string{LabelIkeHosts: "test.domain.com,test2.domain.com"},
+							Annotations: map[string]string{istio.LabelIkeHosts: "test.domain.com,test2.domain.com"},
 						},
 						Spec: v1alpha3.Gateway{
 							Selector: map[string]string{
@@ -174,7 +175,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			})
 
 			It("single remove session", func() {
-				err := GatewayRevertor(ctx, ref)
+				err := istio.GatewayRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw := get.Gateway("test", "gateway")
@@ -182,7 +183,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			})
 
 			It("multiple remove sessions", func() {
-				err := GatewayRevertor(ctx, ref)
+				err := istio.GatewayRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw := get.Gateway("test", "gateway")
@@ -202,13 +203,13 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				}
 				// Another Context would have had another Ref object with the Gateway Resource Status modifed. simulate.
 				ref.AddResourceStatus(model.ResourceStatus{Kind: "Gateway", Name: "gateway", Action: model.ActionModified})
-				err = GatewayRevertor(ctx2, ref)
+				err = istio.GatewayRevertor(ctx2, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(1))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com"))
-				Expect(gw.Labels).ToNot(HaveKey(LabelIkeHosts))
+				Expect(gw.Labels).ToNot(HaveKey(istio.LabelIkeHosts))
 			})
 		})
 	})

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/networking/v1alpha3"
-	istionetwork "istio.io/api/pkg/kube/apis/networking/v1alpha3"
+	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 )
 
 var _ = Describe("Operations for istio gateway kind", func() {

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -5,8 +5,6 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/test/operator"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,6 +13,8 @@ import (
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Operations for istio gateway kind", func() {
@@ -33,7 +33,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			&istionetwork.GatewayList{}).Build()
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(&c)
+		get = operator.New(c)
 		ctx = model.SessionContext{
 			Name:      "test",
 			Namespace: "test",

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -1,0 +1,104 @@
+package istio
+
+import (
+	"github.com/maistra/istio-workspace/pkg/model"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/networking/v1alpha3"
+	istionetwork "istio.io/api/pkg/kube/apis/networking/v1alpha3"
+)
+
+var _ = Describe("Operations for istio gateway kind", func() {
+
+	Context("manipulation", func() {
+		var (
+			ctx     model.SessionContext
+			gateway istionetwork.Gateway
+		)
+		BeforeEach(func() {
+			ctx = model.SessionContext{
+				Name: "gw-test",
+				Route: model.Route{
+					Type:  "header",
+					Name:  "test",
+					Value: "x",
+				},
+			}
+		})
+
+		Context("mutators", func() {
+
+			JustBeforeEach(func() {
+				gateway = istionetwork.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway",
+						Namespace: "test",
+					},
+					Spec: v1alpha3.Gateway{
+						Selector: map[string]string{
+							"istio": "ingressgateway",
+						},
+						Servers: []*v1alpha3.Server{
+							{
+								Port: &v1alpha3.Port{
+									Protocol: "HTTP",
+									Name:     "http",
+									Number:   80,
+								},
+								Hosts: []string{
+									"domain.com",
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("add gateway", func() {
+				gw, err := mutateGateway(ctx, gateway)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
+			})
+		})
+
+		Context("revertors", func() {
+
+			JustBeforeEach(func() {
+				gateway = istionetwork.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway",
+						Namespace: "test",
+					},
+					Spec: v1alpha3.Gateway{
+						Selector: map[string]string{
+							"istio": "ingressgateway",
+						},
+						Servers: []*v1alpha3.Server{
+							{
+								Port: &v1alpha3.Port{
+									Protocol: "HTTP",
+									Name:     "http",
+									Number:   80,
+								},
+								Hosts: []string{
+									"domain.com",
+									"test.domain.com",
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("remove gateway", func() {
+				gw, err := revertGateway(ctx, gateway)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(1))
+			})
+		})
+	})
+})

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -1,9 +1,12 @@
 package istio
 
 import (
-	"fmt"
-
+	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/test/operator"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,155 +14,198 @@ import (
 	"istio.io/api/networking/v1alpha3"
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var _ = Describe("Operations for istio gateway kind", func() {
 
+	var (
+		objects []runtime.Object
+		c       client.Client
+		ctx     model.SessionContext
+		get     *operator.Helpers
+		ref     *model.Ref
+	)
+
+	JustBeforeEach(func() {
+		schema, _ := v1alpha1.SchemeBuilder.Register(
+			&istionetwork.Gateway{},
+			&istionetwork.GatewayList{}).Build()
+
+		c = fake.NewFakeClientWithScheme(schema, objects...)
+		get = operator.New(&c)
+		ctx = model.SessionContext{
+			Name:      "test",
+			Namespace: "test",
+			Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
+			Client:    c,
+			Log:       log.CreateOperatorAwareLogger("gateway"),
+		}
+	})
+
 	Context("manipulation", func() {
-		var (
-			ctx     model.SessionContext
-			gateway istionetwork.Gateway
-		)
-		BeforeEach(func() {
-			ctx = model.SessionContext{
-				Name: "gw-test",
-				Route: model.Route{
-					Type:  "header",
-					Name:  "test",
-					Value: "x",
-				},
-			}
-		})
 
 		Context("mutators", func() {
 
-			JustBeforeEach(func() {
-				gateway = istionetwork.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "gateway",
-						Namespace: "test",
-					},
-					Spec: v1alpha3.Gateway{
-						Selector: map[string]string{
-							"istio": "ingressgateway",
+			BeforeEach(func() {
+				objects = []runtime.Object{
+					&istionetwork.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gateway",
+							Namespace: "test",
 						},
-						Servers: []*v1alpha3.Server{
-							{
-								Port: &v1alpha3.Port{
-									Protocol: "HTTP",
-									Name:     "http",
-									Number:   80,
-								},
-								Hosts: []string{
-									"domain.com",
+						Spec: v1alpha3.Gateway{
+							Selector: map[string]string{
+								"istio": "ingressgateway",
+							},
+							Servers: []*v1alpha3.Server{
+								{
+									Port: &v1alpha3.Port{
+										Protocol: "HTTP",
+										Name:     "http",
+										Number:   80,
+									},
+									Hosts: []string{
+										"domain.com",
+									},
 								},
 							},
 						},
+					},
+				}
+				ref = &model.Ref{
+					Name: "customer-v1",
+					Targets: []model.LocatedResourceStatus{
+						model.NewLocatedResource("Gateway", "gateway", nil),
 					},
 				}
 			})
 
 			It("add single session", func() {
-				gw, err := mutateGateway(ctx, gateway)
+				err := GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
+				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
 			})
+
 			It("add multiple session", func() {
-				gw, err := mutateGateway(ctx, gateway)
+				err := GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
+				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
 
 				ctx2 := model.SessionContext{
-					Name: "gw-test2",
+					Name:      "test2",
+					Namespace: "test",
 					Route: model.Route{
 						Type:  "header",
 						Name:  "test",
 						Value: "x",
 					},
+					Client: ctx.Client,
+					Log:    ctx.Log,
 				}
-				gw, err = mutateGateway(ctx2, gw)
+				err = GatewayMutator(ctx2, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				fmt.Println(gw.Labels[LabelIkeHosts])
+				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(3))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com", "gw-test2.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com", "test2.domain.com"))
 			})
+
 			It("add multiple refs", func() {
-				gw, err := mutateGateway(ctx, gateway)
+				err := GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
+				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
 
-				gw, err = mutateGateway(ctx, gw)
+				err = GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				fmt.Println(gw.Labels[LabelIkeHosts])
+				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
 			})
 		})
 
 		Context("revertors", func() {
 
-			JustBeforeEach(func() {
-				gateway = istionetwork.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "gateway",
-						Namespace:   "test",
-						Annotations: map[string]string{LabelIkeHosts: "gw-test.domain.com,gw-test2.domain.com"},
-					},
-					Spec: v1alpha3.Gateway{
-						Selector: map[string]string{
-							"istio": "ingressgateway",
+			BeforeEach(func() {
+				objects = []runtime.Object{
+					&istionetwork.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "gateway",
+							Namespace:   "test",
+							Annotations: map[string]string{LabelIkeHosts: "test.domain.com,test2.domain.com"},
 						},
-						Servers: []*v1alpha3.Server{
-							{
-								Port: &v1alpha3.Port{
-									Protocol: "HTTP",
-									Name:     "http",
-									Number:   80,
-								},
-								Hosts: []string{
-									"domain.com",
-									"gw-test.domain.com",
-									"gw-test2.domain.com",
+						Spec: v1alpha3.Gateway{
+							Selector: map[string]string{
+								"istio": "ingressgateway",
+							},
+							Servers: []*v1alpha3.Server{
+								{
+									Port: &v1alpha3.Port{
+										Protocol: "HTTP",
+										Name:     "http",
+										Number:   80,
+									},
+									Hosts: []string{
+										"domain.com",
+										"test.domain.com",
+										"test2.domain.com",
+									},
 								},
 							},
 						},
 					},
 				}
+				ref = &model.Ref{
+					Name: "customer-v1",
+					ResourceStatuses: []model.ResourceStatus{
+						model.ResourceStatus{Kind: "Gateway", Name: "gateway", Action: model.ActionModified},
+					},
+				}
 			})
 
-			It("single remove", func() {
-				gw, err := revertGateway(ctx, gateway)
+			It("single remove session", func() {
+				err := GatewayRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
+				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
 			})
 
-			It("multiple remove", func() {
-				gw, err := revertGateway(ctx, gateway)
+			It("multiple remove sessions", func() {
+				err := GatewayRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
+				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "gw-test2.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test2.domain.com"))
 
 				ctx2 := model.SessionContext{
-					Name: "gw-test2",
+					Name:      "test2",
+					Namespace: "test",
 					Route: model.Route{
 						Type:  "header",
 						Name:  "test",
 						Value: "x",
 					},
+					Client: ctx.Client,
+					Log:    ctx.Log,
 				}
-				gw, err = revertGateway(ctx2, gw)
+				// Another Context would have had another Ref object with the Gateway Resource Status modifed. simulate.
+				ref.AddResourceStatus(model.ResourceStatus{Kind: "Gateway", Name: "gateway", Action: model.ActionModified})
+				err = GatewayRevertor(ctx2, ref)
 				Expect(err).ToNot(HaveOccurred())
 
+				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(1))
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com"))
 				Expect(gw.Labels).ToNot(HaveKey(LabelIkeHosts))

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
-	"github.com/maistra/istio-workspace/test/operator"
+	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,7 +24,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 		objects []runtime.Object
 		c       client.Client
 		ctx     model.SessionContext
-		get     *operator.Helpers
+		get     *testclient.Getters
 		ref     *model.Ref
 	)
 
@@ -34,7 +34,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 			&istionetwork.GatewayList{}).Build()
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(c)
+		get = testclient.New(c)
 		ctx = model.SessionContext{
 			Name:      "test",
 			Namespace: "test",

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -29,7 +29,7 @@ var _ model.Revertor = VirtualServiceRevertor
 
 // VirtualServiceMutator attempts to create a virtual service for forked service
 func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error {
-	if len(ref.GetResourceStatus(VirtualServiceKind)) > 0 {
+	if len(ref.GetResources(model.Kind(VirtualServiceKind))) > 0 {
 		return nil
 	}
 
@@ -78,7 +78,7 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error {
 
 // VirtualServiceRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects
 func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
-	resources := ref.GetResourceStatus(VirtualServiceKind)
+	resources := ref.GetResources(model.Kind(VirtualServiceKind))
 
 	for _, resource := range resources {
 		vs, err := getVirtualService(ctx, ctx.Namespace, resource.Name)

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -20,6 +20,7 @@ const (
 
 	// LabelIkeMutated is a bool label to indicated we own the resource
 	LabelIkeMutated = "ike.mutated"
+
 	// LabelIkeMutatedValue is the bool value of the LabelIkeMutated label
 	LabelIkeMutatedValue = "true"
 )

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -44,7 +44,7 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error {
 				continue
 			}
 			ctx.Log.Info("Found VirtualService", "name", hostName)
-			mutatedVs, created, err := mutateVirtualService(ctx, ref, hostName, ref.GetVersion(), ref.GetNewVersion(ctx.Name), vs)
+			mutatedVs, created, err := mutateVirtualService(ctx, ref, hostName, vs)
 			if err != nil {
 				ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: vs.Name, Action: model.ActionFailed})
 				return err
@@ -111,7 +111,9 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	return nil
 }
 
-func mutateVirtualService(ctx model.SessionContext, ref *model.Ref, hostName model.HostName, version, newVersion string, source istionetwork.VirtualService) (istionetwork.VirtualService, bool, error) {
+func mutateVirtualService(ctx model.SessionContext, ref *model.Ref, hostName model.HostName, source istionetwork.VirtualService) (istionetwork.VirtualService, bool, error) {
+	version := ref.GetVersion()
+	newVersion := ref.GetNewVersion(ctx.Name)
 	target := source.DeepCopy()
 	clonedSource := source.DeepCopy()
 	if gateways, connected := connectedToGateway(*target); connected {

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -30,10 +30,6 @@ var _ model.Revertor = VirtualServiceRevertor
 
 // VirtualServiceMutator attempts to create a virtual service for forked service
 func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error {
-	if len(ref.GetResources(model.Kind(VirtualServiceKind))) > 0 {
-		return nil
-	}
-
 	targetVersion := ref.GetVersion()
 
 	for _, hostName := range ref.GetTargetHostNames() {

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -111,7 +111,7 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	return nil
 }
 
-func mutateVirtualService(ctx model.SessionContext, ref *model.Ref, hostName model.HostName, version, newVersion string, source istionetwork.VirtualService) (istionetwork.VirtualService, bool, error) { //nolint:lll,gocyclo //reason for readability
+func mutateVirtualService(ctx model.SessionContext, ref *model.Ref, hostName model.HostName, version, newVersion string, source istionetwork.VirtualService) (istionetwork.VirtualService, bool, error) {
 	target := source.DeepCopy()
 	clonedSource := source.DeepCopy()
 	if gateways, connected := connectedToGateway(*target); connected {
@@ -201,7 +201,7 @@ func mutationRequired(vs istionetwork.VirtualService, targetHost model.HostName,
 	return false
 }
 
-func connectedToGateway(vs istionetwork.VirtualService) ([]string, bool) { //nolint[:hugeParam]
+func connectedToGateway(vs istionetwork.VirtualService) ([]string, bool) {
 	return vs.Spec.Gateways, len(vs.Spec.Gateways) > 0
 }
 

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -1,10 +1,10 @@
-package istio //nolint:testpackage //reason we want to test converters in isolation
+package istio //nolint:testpackage //reason we want to test mutationRequired in isolation
 
 import (
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
-	"github.com/maistra/istio-workspace/test/operator"
+	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,7 +23,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 		objects []runtime.Object
 		c       client.Client
 		ctx     model.SessionContext
-		get     *operator.Helpers
+		get     *testclient.Getters
 	)
 
 	JustBeforeEach(func() {
@@ -33,7 +33,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 			&istionetwork.Gateway{}).Build()
 
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(c)
+		get = testclient.New(c)
 		ctx = model.SessionContext{
 			Name:      "vs-test",
 			Namespace: "test",

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -237,9 +237,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 									{
 										Destination: &istionetworkv1alpha3.Destination{
 											Host: "customer",
-											Port: &istionetworkv1alpha3.PortSelector{
-												Port: &istionetworkv1alpha3.PortSelector_Number{Number: 8080},
-											},
+											Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
 										},
 									},
 								},
@@ -261,9 +259,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 									{
 										Destination: &istionetworkv1alpha3.Destination{
 											Host: "reviews",
-											Port: &istionetworkv1alpha3.PortSelector{
-												Port: &istionetworkv1alpha3.PortSelector_Number{Number: 8080},
-											},
+											Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
 										},
 									},
 								},

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -1,11 +1,10 @@
 package istio
 
 import (
-	"context"
-
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/test/operator"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,27 +13,123 @@ import (
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	k8yaml "sigs.k8s.io/yaml"
 )
 
 var _ = Describe("Operations for istio VirtualService kind", func() {
 
+	var (
+		objects []runtime.Object
+		c       client.Client
+		ctx     model.SessionContext
+		get     *operator.Helpers
+	)
+
+	JustBeforeEach(func() {
+		schema, _ := v1alpha1.SchemeBuilder.Register(
+			&istionetwork.VirtualService{},
+			&istionetwork.VirtualServiceList{},
+			&istionetwork.Gateway{}).Build()
+
+		c = fake.NewFakeClientWithScheme(schema, objects...)
+		get = operator.New(c)
+		ctx = model.SessionContext{
+			Name:      "vs-test",
+			Namespace: "test",
+			Route:     model.Route{Type: "header", Name: "test", Value: "x"},
+			Client:    c,
+			Log:       log.CreateOperatorAwareLogger("destinationrule"),
+		}
+	})
+
 	Context("manipulation", func() {
-		var (
-			err            error
-			virtualService istionetwork.VirtualService
-			yaml           string
-		)
 
 		Context("mutators", func() {
 
-			JustBeforeEach(func() {
-				err = k8yaml.Unmarshal([]byte(yaml), &virtualService)
-				Expect(err).ToNot(HaveOccurred())
+			BeforeEach(func() {
+				objects = []runtime.Object{
+					&istionetwork.VirtualService{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "details",
+							Namespace: "test",
+						},
+						Spec: istionetworkv1alpha3.VirtualService{
+							Hosts: []string{"details"},
+							Http: []*istionetworkv1alpha3.HTTPRoute{
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v1",
+											},
+											Weight: 50,
+										},
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v2",
+											},
+											Weight: 50,
+										},
+									},
+									Match: []*istionetworkv1alpha3.HTTPMatchRequest{
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Uri: &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Prefix{Prefix: "/a"}},
+										},
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Uri: &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Prefix{Prefix: "/b"}},
+										},
+									},
+									Mirror: &istionetworkv1alpha3.Destination{
+										Host:   "details",
+										Subset: "v3",
+									},
+									Redirect: &istionetworkv1alpha3.HTTPRedirect{
+										Uri: "/redirected",
+									},
+								},
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v4",
+											},
+										},
+									},
+								},
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v5",
+											},
+										},
+									},
+									Match: []*istionetworkv1alpha3.HTTPMatchRequest{
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Headers: map[string]*istionetworkv1alpha3.StringMatch{
+												"request-id": &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Exact{Exact: "test"}},
+											},
+										},
+									},
+								},
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host: "x",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
 			})
 
 			Context("existing rule", func() {
@@ -49,68 +144,82 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 					return nil
 				}
 				var (
-					mutatedVirtualService istionetwork.VirtualService
-					ctx                   model.SessionContext
-					ref                   model.Ref
-					targetV1              = model.NewLocatedResource("Deployment", "details-v1", map[string]string{"version": "v1"})
-					targetV1Host          = model.HostName{Name: "details"}
-					targetV1Subset        = "v1-vs-test"
-					targetV4              = model.NewLocatedResource("Deployment", "details-v4", map[string]string{"version": "v4"})
-					targetV4Host          = model.HostName{Name: "details"}
-					targetV4Subset        = "v4-vs-test"
-					targetV5              = model.NewLocatedResource("Deployment", "details-v5", map[string]string{"version": "v5"})
-					targetV5Host          = model.HostName{Name: "details"}
-					targetV5Subset        = "v5-vs-test"
-					targetV6              = model.NewLocatedResource("Deployment", "x-v5", map[string]string{"version": "v5"})
-					targetV6Host          = model.HostName{Name: "x"}
-					targetV6Subset        = "v5-vs-test"
+					ref            model.Ref
+					targetV1       = model.NewLocatedResource("Deployment", "details-v1", map[string]string{"version": "v1"})
+					targetV1Host   = model.HostName{Name: "details"}
+					targetV1Subset = "v1-vs-test"
+					targetV4       = model.NewLocatedResource("Deployment", "details-v4", map[string]string{"version": "v4"})
+					targetV4Host   = model.HostName{Name: "details"}
+					targetV4Subset = "v4-vs-test"
+					targetV5       = model.NewLocatedResource("Deployment", "details-v5", map[string]string{"version": "v5"})
+					targetV5Host   = model.HostName{Name: "details"}
+					targetV5Subset = "v5-vs-test"
+					targetV6       = model.NewLocatedResource("Deployment", "x-v5", map[string]string{"version": "v5"})
+					targetV6Host   = model.HostName{Name: "x"}
+					targetV6Subset = "v5-vs-test"
 				)
 
 				BeforeEach(func() {
-					yaml = complexVirtualService
-					ctx = model.SessionContext{
-						Name: "vs-test",
-						Route: model.Route{
-							Type:  "header",
-							Name:  "test",
-							Value: "x",
-						},
-					}
 					ref = model.Ref{
-						Name: "customer-v1",
+						Name:      "details-v1",
+						Namespace: "test",
 					}
-
 				})
 
 				It("route added", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset)).ToNot(BeNil())
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset)).ToNot(BeNil())
 				})
 
 				It("route added before target route", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(mutatedVirtualService.Spec.Http[0].Route[0].Destination.Subset).To(Equal(targetV1Subset))
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(virtualService.Spec.Http[0].Route[0].Destination.Subset).To(Equal(targetV1Subset))
 				})
 
 				It("has match", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Match).ToNot(BeNil())
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset).Match).ToNot(BeNil())
 				})
 
 				It("has subset", func() { // covered by GetMutatedRoute
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Route[0].Destination.Subset).To(Equal(targetV1Subset))
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset).Route[0].Destination.Subset).To(Equal(targetV1Subset))
 				})
 
 				It("create match when no match found", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV4Host, targetV4.Labels["version"], targetV4Subset, virtualService)
+					ref.AddTargetResource(targetV4)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					mutated := GetMutatedRoute(mutatedVirtualService, targetV4Host, targetV4Subset)
+					virtualService := get.VirtualService("test", "details")
+
+					mutated := GetMutatedRoute(virtualService, targetV4Host, targetV4Subset)
 					Expect(mutated).ToNot(BeNil())
 					Expect(mutated.Match).To(HaveLen(1))
 					for _, m := range mutated.Match {
@@ -120,10 +229,15 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 				})
 
 				It("add route headers to found match with no headers", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					mutated := GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset)
+					virtualService := get.VirtualService("test", "details")
+
+					mutated := GetMutatedRoute(virtualService, targetV1Host, targetV1Subset)
 					Expect(mutated).ToNot(BeNil())
 					Expect(mutated.Match).To(HaveLen(2))
 					for _, m := range mutated.Match {
@@ -133,10 +247,15 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 				})
 
 				It("add route headers to found match with found headers", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV5Host, targetV5.Labels["version"], targetV5Subset, virtualService)
+					ref.AddTargetResource(targetV5)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					mutated := GetMutatedRoute(mutatedVirtualService, targetV5Host, targetV5Subset)
+					virtualService := get.VirtualService("test", "details")
+
+					mutated := GetMutatedRoute(virtualService, targetV5Host, targetV5Subset)
 					Expect(mutated).ToNot(BeNil())
 					Expect(mutated.Match).To(HaveLen(1))
 					for _, m := range mutated.Match {
@@ -146,360 +265,350 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 				})
 
 				It("remove weighted destination", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Route[0].Weight).To(Equal(int32(0)))
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset).Route[0].Weight).To(Equal(int32(0)))
 				})
+
 				It("remove other destinations", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Route).To(HaveLen(1))
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset).Route).To(HaveLen(1))
 				})
+
 				It("remove mirror", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Mirror).To(BeNil())
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset).Mirror).To(BeNil())
 				})
+
 				It("remove redirect", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV1Host, targetV1.Labels["version"], targetV1Subset, virtualService)
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV1Host, targetV1Subset).Redirect).To(BeNil())
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV1Host, targetV1Subset).Redirect).To(BeNil())
 				})
+
 				It("include destinations with no subset", func() {
-					mutatedVirtualService, _, err = mutateVirtualService(ctx, &ref, targetV6Host, targetV6.Labels["version"], targetV6Subset, virtualService)
+					ref.AddTargetResource(targetV6)
+					ref.Name = "x-v5"
+					ref.AddTargetResource(model.NewLocatedResource("Service", "x", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(GetMutatedRoute(mutatedVirtualService, targetV6Host, targetV6Subset).Redirect).To(BeNil())
-				})
-
-				It("route missing", func() {
-					_, _, err = mutateVirtualService(ctx, &ref, model.HostName{Name: "miss-v5"}, "v5", "v5-vs-test", virtualService)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("route not found"))
-				})
-				It("route missing version", func() {
-					_, _, err = mutateVirtualService(ctx, &ref, model.HostName{Name: "details-v10"}, "v10", "v10-vs-test", virtualService)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("route not found"))
+					virtualService := get.VirtualService("test", "details")
+					Expect(GetMutatedRoute(virtualService, targetV6Host, targetV6Subset).Redirect).To(BeNil())
 				})
 			})
 		})
 
 		Context("revertors", func() {
 
-			JustBeforeEach(func() {
-				err = k8yaml.Unmarshal([]byte(yaml), &virtualService)
-				Expect(err).ToNot(HaveOccurred())
+			BeforeEach(func() {
+				objects = []runtime.Object{
+					&istionetwork.VirtualService{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "details",
+							Namespace: "test",
+						},
+						Spec: istionetworkv1alpha3.VirtualService{
+							Hosts: []string{"details"},
+							Http: []*istionetworkv1alpha3.HTTPRoute{
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v1-vs-test",
+											},
+										},
+									},
+									Match: []*istionetworkv1alpha3.HTTPMatchRequest{
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Headers: map[string]*istionetworkv1alpha3.StringMatch{
+												"x-test-suite": &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Exact{Exact: "feature-x"}},
+											},
+										},
+									},
+								},
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v1-vs-test",
+											},
+										},
+									},
+									Match: []*istionetworkv1alpha3.HTTPMatchRequest{
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Headers: map[string]*istionetworkv1alpha3.StringMatch{
+												"x-test-suite": &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Exact{Exact: "feature-x"}},
+											},
+										},
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Uri: &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Exact{Exact: "/test-service"}},
+										},
+									},
+									Rewrite: &istionetworkv1alpha3.HTTPRewrite{
+										Uri: "/",
+									},
+								},
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host: "details",
+											},
+										},
+									},
+									Match: []*istionetworkv1alpha3.HTTPMatchRequest{
+										&istionetworkv1alpha3.HTTPMatchRequest{
+											Uri: &istionetworkv1alpha3.StringMatch{MatchType: &istionetworkv1alpha3.StringMatch_Exact{Exact: "/test-service"}},
+										},
+									},
+									Rewrite: &istionetworkv1alpha3.HTTPRewrite{
+										Uri: "/",
+									},
+								},
+								&istionetworkv1alpha3.HTTPRoute{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										&istionetworkv1alpha3.HTTPRouteDestination{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host:   "details",
+												Subset: "v1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
 			})
 
 			Context("existing rule", func() {
-				var revertedVirtualService istionetwork.VirtualService
+
+				var (
+					ref model.Ref
+				)
 
 				BeforeEach(func() {
-					yaml = complextMutatedVirtualService
-				})
+					ref = model.Ref{
+						Name:      "details-v1",
+						Namespace: "test",
+						Targets: []model.LocatedResourceStatus{
+							model.NewLocatedResource("Deployment", "details-v1", map[string]string{"version": "v1"}),
+							model.NewLocatedResource("Service", "details", map[string]string{}),
+						},
+						ResourceStatuses: []model.ResourceStatus{
+							model.ResourceStatus{Kind: VirtualServiceKind, Name: "details", Action: model.ActionModified},
+						},
+					}
 
-				JustBeforeEach(func() {
-					revertedVirtualService = revertVirtualService("v1-vs-test", virtualService)
 				})
 
 				It("route removed", func() {
-					Expect(revertedVirtualService.Spec.Http).To(HaveLen(2))
+					err := VirtualServiceRevertor(ctx, &ref)
+					Expect(err).ToNot(HaveOccurred())
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(virtualService.Spec.Http).To(HaveLen(2))
 				})
 
 				It("correct route removed", func() {
-					Expect(revertedVirtualService.Spec.Http[0].Route[0].Destination.Subset).ToNot(Equal("v1-vs-test"))
+					err := VirtualServiceRevertor(ctx, &ref)
+					Expect(err).ToNot(HaveOccurred())
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(virtualService.Spec.Http[0].Route[0].Destination.Subset).ToNot(Equal("v1-vs-test"))
 				})
 			})
 		})
-	})
 
-	Context("gateway attachment", func() {
+		Context("gateway attachment", func() {
 
-		var (
-			objects []runtime.Object
-			c       client.Client
-			ctx     model.SessionContext
-		)
-
-		BeforeEach(func() {
-			objects = []runtime.Object{
-				&istionetwork.VirtualService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "customer",
-						Namespace: "bookinfo",
-					},
-					Spec: istionetworkv1alpha3.VirtualService{
-						Hosts:    []string{"*"},
-						Gateways: []string{"test-gateway"},
-						Http: []*istionetworkv1alpha3.HTTPRoute{
-							{
-								Route: []*istionetworkv1alpha3.HTTPRouteDestination{
-									{
-										Destination: &istionetworkv1alpha3.Destination{
-											Host: "customer",
-											Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
+			BeforeEach(func() {
+				objects = []runtime.Object{
+					&istionetwork.VirtualService{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "customer",
+							Namespace: "test",
+						},
+						Spec: istionetworkv1alpha3.VirtualService{
+							Hosts:    []string{"*"},
+							Gateways: []string{"test-gateway"},
+							Http: []*istionetworkv1alpha3.HTTPRoute{
+								{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host: "customer",
+												Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
+											},
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-				&istionetwork.VirtualService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "non-customer",
-						Namespace: "bookinfo",
-					},
-					Spec: istionetworkv1alpha3.VirtualService{
-						Hosts:    []string{"*"},
-						Gateways: []string{"test-gateway"},
-						Http: []*istionetworkv1alpha3.HTTPRoute{
-							{
-								Route: []*istionetworkv1alpha3.HTTPRouteDestination{
-									{
-										Destination: &istionetworkv1alpha3.Destination{
-											Host: "reviews",
-											Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
+					&istionetwork.VirtualService{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "non-customer",
+							Namespace: "test",
+						},
+						Spec: istionetworkv1alpha3.VirtualService{
+							Hosts:    []string{"*"},
+							Gateways: []string{"test-gateway"},
+							Http: []*istionetworkv1alpha3.HTTPRoute{
+								{
+									Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+										{
+											Destination: &istionetworkv1alpha3.Destination{
+												Host: "reviews",
+												Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
+											},
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-				&istionetwork.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-gateway",
-						Namespace: "bookinfo",
+					&istionetwork.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gateway",
+							Namespace: "test",
+						},
+						Spec: istionetworkv1alpha3.Gateway{
+							Selector: map[string]string{"istio": "ingressgateway"},
+							Servers: []*istionetworkv1alpha3.Server{
+								{
+									Port:  &istionetworkv1alpha3.Port{Name: "http", Protocol: "HTTP", Number: 80},
+									Hosts: []string{"redhat-kubecon.io"},
+								},
+							},
+						},
 					},
-					Spec: istionetworkv1alpha3.Gateway{
-						Selector: map[string]string{"istio": "ingressgateway"},
-						Servers: []*istionetworkv1alpha3.Server{
+				}
+			})
+
+			It("should attach to a host", func() {
+				ref := model.Ref{
+					Name: "customer-v1",
+					Targets: []model.LocatedResourceStatus{
+						model.NewLocatedResource("Service", "customer", nil),
+						model.NewLocatedResource("Gateway", "test-gateway", map[string]string{LabelIkeHosts: "redhat-kubecon.io"}),
+					},
+				}
+
+				err := VirtualServiceMutator(ctx, &ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				created := get.VirtualService("test", "customer-"+ctx.Name)
+				Expect(created.Spec.Hosts).To(ContainElement(ctx.Name + ".redhat-kubecon.io"))
+			})
+
+			It("should add request headers", func() {
+				ref := model.Ref{
+					Name: "customer-v1",
+					Targets: []model.LocatedResourceStatus{
+						model.NewLocatedResource("Service", "customer", nil),
+						model.NewLocatedResource("Gateway", "test-gateway", map[string]string{LabelIkeHosts: "redhat-kubecon.io"}),
+					},
+				}
+
+				err := VirtualServiceMutator(ctx, &ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				created := get.VirtualService("test", "customer-"+ctx.Name)
+				Expect(created.Spec.Http[0].Headers.Request.Add).To(HaveKeyWithValue(ctx.Route.Name, ctx.Route.Value))
+			})
+
+			It("should duplicate non effected vs", func() {
+				ref := model.Ref{
+					Name: "customer-v1",
+					Targets: []model.LocatedResourceStatus{
+						model.NewLocatedResource("Service", "customer", nil),
+						model.NewLocatedResource("Gateway", "test-gateway", map[string]string{LabelIkeHosts: "redhat-kubecon.io"}),
+					},
+				}
+
+				err := VirtualServiceMutator(ctx, &ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				created := get.VirtualService("test", "non-customer-"+ctx.Name)
+				Expect(created.Spec.Hosts).To(ContainElement(ctx.Name + ".redhat-kubecon.io"))
+				Expect(created.Spec.Http[0].Headers.Request.Add).To(HaveKeyWithValue(ctx.Route.Name, ctx.Route.Value))
+			})
+
+		})
+		Context("required", func() {
+			var (
+				virtualService istionetwork.VirtualService
+			)
+
+			BeforeEach(func() {
+				virtualService = istionetwork.VirtualService{
+					Spec: istionetworkv1alpha3.VirtualService{
+						Http: []*istionetworkv1alpha3.HTTPRoute{
 							{
-								Port:  &istionetworkv1alpha3.Port{Name: "http", Protocol: "HTTP", Number: 80},
-								Hosts: []string{"redhat-kubecon.io"},
-							},
-						},
-					},
-				},
-			}
-		})
-
-		JustBeforeEach(func() {
-			schema, _ := v1alpha1.SchemeBuilder.Register(
-				&istionetwork.VirtualServiceList{},
-				&istionetwork.VirtualService{},
-				&istionetwork.Gateway{}).Build()
-
-			c = fake.NewFakeClientWithScheme(schema, objects...)
-			ctx = model.SessionContext{
-				Name:      "test",
-				Namespace: "bookinfo",
-				Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
-				Client:    c,
-				Log:       log.CreateOperatorAwareLogger("session").WithValues("type", "controller"),
-			}
-		})
-
-		It("should attach to a host", func() {
-			ref := model.Ref{
-				Name: "customer-v1",
-				Targets: []model.LocatedResourceStatus{
-					model.NewLocatedResource("Service", "customer", nil),
-					model.NewLocatedResource("Gateway", "test-gateway", map[string]string{LabelIkeHosts: "redhat-kubecon.io"}),
-				},
-			}
-
-			err := VirtualServiceMutator(ctx, &ref)
-			Expect(err).ToNot(HaveOccurred())
-
-			created := istionetwork.VirtualService{}
-			err = c.Get(context.Background(), types.NamespacedName{Namespace: "bookinfo", Name: "customer-" + ctx.Name}, &created)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(created.Spec.Hosts).To(ContainElement(ctx.Name + ".redhat-kubecon.io"))
-		})
-
-		It("should add request headers", func() {
-			ref := model.Ref{
-				Name: "customer-v1",
-				Targets: []model.LocatedResourceStatus{
-					model.NewLocatedResource("Service", "customer", nil),
-					model.NewLocatedResource("Gateway", "test-gateway", map[string]string{LabelIkeHosts: "redhat-kubecon.io"}),
-				},
-			}
-
-			err := VirtualServiceMutator(ctx, &ref)
-			Expect(err).ToNot(HaveOccurred())
-
-			created := istionetwork.VirtualService{}
-			err = c.Get(context.Background(), types.NamespacedName{Namespace: "bookinfo", Name: "customer-" + ctx.Name}, &created)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(created.Spec.Http[0].Headers.Request.Add).To(HaveKeyWithValue(ctx.Route.Name, ctx.Route.Value))
-		})
-
-		It("should duplicate non effected vs", func() {
-			ref := model.Ref{
-				Name: "customer-v1",
-				Targets: []model.LocatedResourceStatus{
-					model.NewLocatedResource("Service", "customer", nil),
-					model.NewLocatedResource("Gateway", "test-gateway", map[string]string{LabelIkeHosts: "redhat-kubecon.io"}),
-				},
-			}
-
-			err := VirtualServiceMutator(ctx, &ref)
-			Expect(err).ToNot(HaveOccurred())
-
-			created := istionetwork.VirtualService{}
-			err = c.Get(context.Background(), types.NamespacedName{Namespace: "bookinfo", Name: "non-customer-" + ctx.Name}, &created)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(created.Spec.Hosts).To(ContainElement(ctx.Name + ".redhat-kubecon.io"))
-			Expect(created.Spec.Http[0].Headers.Request.Add).To(HaveKeyWithValue(ctx.Route.Name, ctx.Route.Value))
-		})
-
-	})
-
-	Context("required", func() {
-		var (
-			virtualService istionetwork.VirtualService
-		)
-
-		BeforeEach(func() {
-			virtualService = istionetwork.VirtualService{
-				Spec: istionetworkv1alpha3.VirtualService{
-					Http: []*istionetworkv1alpha3.HTTPRoute{
-						{
-							Route: []*istionetworkv1alpha3.HTTPRouteDestination{
-								{
-									Destination: &istionetworkv1alpha3.Destination{
-										Host: "x",
+								Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+									{
+										Destination: &istionetworkv1alpha3.Destination{
+											Host: "x",
+										},
 									},
-								},
-								{
-									Destination: &istionetworkv1alpha3.Destination{
-										Host:   "y",
-										Subset: "v1",
+									{
+										Destination: &istionetworkv1alpha3.Destination{
+											Host:   "y",
+											Subset: "v1",
+										},
 									},
 								},
 							},
-						},
-						{
-							Route: []*istionetworkv1alpha3.HTTPRouteDestination{
-								{
-									Destination: &istionetworkv1alpha3.Destination{
-										Host:   "z",
-										Subset: "v2",
+							{
+								Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+									{
+										Destination: &istionetworkv1alpha3.Destination{
+											Host:   "z",
+											Subset: "v2",
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-			}
-		})
-		It("Should require unversioned targets", func() {
-			Expect(mutationRequired(virtualService, model.HostName{Name: "x"}, "v1")).To(BeTrue())
-		})
-		It("Should require versioned targets", func() {
-			Expect(mutationRequired(virtualService, model.HostName{Name: "y"}, "v1")).To(BeTrue())
-		})
-		It("Should not require other versioned targets", func() {
-			Expect(mutationRequired(virtualService, model.HostName{Name: "z"}, "v1")).To(BeFalse())
+				}
+			})
+			It("Should require unversioned targets", func() {
+				Expect(mutationRequired(virtualService, model.HostName{Name: "x"}, "v1")).To(BeTrue())
+			})
+			It("Should require versioned targets", func() {
+				Expect(mutationRequired(virtualService, model.HostName{Name: "y"}, "v1")).To(BeTrue())
+			})
+			It("Should not require other versioned targets", func() {
+				Expect(mutationRequired(virtualService, model.HostName{Name: "z"}, "v1")).To(BeFalse())
+			})
 		})
 	})
 })
-
-var complexVirtualService = `kind: VirtualService
-metadata:
-  name: details
-  namespace: bookinfo
-spec:
-  hosts:
-  - details
-  http:
-  - route:
-    - destination:
-        host: details
-        subset: v1
-      weight: 50
-    - destination:
-        host: details
-        subset: v2
-      weight: 50
-    match:
-      - uri:
-          prefix: /a
-      - uri:
-          prefix: /b
-    mirror:
-      host: details
-      subset: v3
-    redirect:
-      uri: /redirected
-  - route:
-    - destination:
-        host: details
-        subset: v4
-  - route:
-    - destination:
-        host: details
-        subset: v5
-    match:
-      - headers:
-          request-id:
-            exact: test
-  - route:
-    - destination:
-        host: x
-`
-
-var complextMutatedVirtualService = `apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  creationTimestamp: "2020-01-15T22:53:54Z"
-  generation: 11
-  name: reviews
-  namespace: aslak-devconf
-  resourceVersion: "591982"
-  selfLink: /apis/networking.istio.io/v1alpha3/namespaces/aslak-devconf/virtualservices/reviews
-  uid: e7a2a377-37e9-11ea-bd3f-02fb5d7d8a95
-spec:
-  hosts:
-  - details
-  http:
-  - match:
-    - headers:
-        x-test-suite:
-          exact: feature-x
-    route:
-    - destination:
-        host: details
-        subset: v1-vs-test
-  - match:
-    - headers:
-        x-test-suite:
-          exact: feature-x
-      uri:
-        prefix: /test-service
-    rewrite:
-      uri: /
-    route:
-    - destination:
-        host: details
-        subset: v1-vs-test
-  - match:
-    - uri:
-        prefix: /test-service
-    rewrite:
-      uri: /
-    route:
-    - destination:
-        host: details
-  - route:
-    - destination:
-        host: details
-        subset: v1`

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"istio.io/api/networking/v1alpha3"
 	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
 	k8yaml "sigs.k8s.io/yaml"
 )
 
@@ -38,7 +38,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 			})
 
 			Context("existing rule", func() {
-				GetMutatedRoute := func(vs istionetwork.VirtualService, host model.HostName, subset string) *v1alpha3.HTTPRoute {
+				GetMutatedRoute := func(vs istionetwork.VirtualService, host model.HostName, subset string) *istionetworkv1alpha3.HTTPRoute {
 					for _, h := range vs.Spec.Http {
 						for _, r := range h.Route {
 							if host.Match(r.Destination.Host) && r.Destination.Subset == subset {
@@ -302,7 +302,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 				Namespace: "bookinfo",
 				Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
 				Client:    c,
-				Log:       logf.Log.WithName("controller_session"),
+				Log:       log.CreateOperatorAwareLogger("session").WithValues("type", "controller"),
 			}
 		})
 
@@ -370,17 +370,17 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 
 		BeforeEach(func() {
 			virtualService = istionetwork.VirtualService{
-				Spec: v1alpha3.VirtualService{
-					Http: []*v1alpha3.HTTPRoute{
+				Spec: istionetworkv1alpha3.VirtualService{
+					Http: []*istionetworkv1alpha3.HTTPRoute{
 						{
-							Route: []*v1alpha3.HTTPRouteDestination{
+							Route: []*istionetworkv1alpha3.HTTPRouteDestination{
 								{
-									Destination: &v1alpha3.Destination{
+									Destination: &istionetworkv1alpha3.Destination{
 										Host: "x",
 									},
 								},
 								{
-									Destination: &v1alpha3.Destination{
+									Destination: &istionetworkv1alpha3.Destination{
 										Host:   "y",
 										Subset: "v1",
 									},
@@ -388,9 +388,9 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 							},
 						},
 						{
-							Route: []*v1alpha3.HTTPRouteDestination{
+							Route: []*istionetworkv1alpha3.HTTPRouteDestination{
 								{
-									Destination: &v1alpha3.Destination{
+									Destination: &istionetworkv1alpha3.Destination{
 										Host:   "z",
 										Subset: "v2",
 									},

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -1,0 +1,51 @@
+package istio
+
+import (
+	"strings"
+
+	"github.com/maistra/istio-workspace/pkg/model"
+)
+
+const (
+	// LabelIkeHosts describes the labels key used on the Gateway LocatedResource of Hosts bound to this Gateway.
+	LabelIkeHosts = "ike.hosts"
+)
+
+var _ model.Locator = VirtualServiceGatewayLocator
+
+// VirtualServiceGatewayLocator locates the Gateways that are connected to VirtualServices
+func VirtualServiceGatewayLocator(ctx model.SessionContext, ref *model.Ref) bool {
+	located := false
+	vss, err := getVirtualServices(ctx, ctx.Namespace)
+	if err != nil {
+		return false
+	}
+
+	for _, vs := range vss.Items { //nolint:gocritic //reason for readability
+		if gateways, connected := connectedToGateway(vs); connected {
+			located = true
+			for _, gwName := range gateways {
+				gw, err := getGateway(ctx, ctx.Namespace, gwName)
+				if err != nil {
+					continue
+				}
+
+				existingHosts := []string{}
+				if hosts := gw.Annotations[LabelIkeHosts]; hosts != "" {
+					existingHosts = strings.Split(hosts, ",") // split on empty string return empty (len(1))
+				}
+
+				hosts := []string{}
+				for _, server := range gw.Spec.Servers {
+					for _, host := range server.Hosts {
+						if !existInList(existingHosts, host) {
+							hosts = append(hosts, host)
+						}
+					}
+				}
+				ref.AddTargetResource(model.NewLocatedResource(GatewayKind, gwName, map[string]string{LabelIkeHosts: strings.Join(hosts, ",")}))
+			}
+		}
+	}
+	return located
+}

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -13,7 +13,7 @@ const (
 
 var _ model.Locator = VirtualServiceGatewayLocator
 
-// VirtualServiceGatewayLocator locates the Gateways that are connected to VirtualServices
+// VirtualServiceGatewayLocator locates the Gateways that are connected to VirtualServices.
 func VirtualServiceGatewayLocator(ctx model.SessionContext, ref *model.Ref) bool {
 	located := false
 	vss, err := getVirtualServices(ctx, ctx.Namespace)

--- a/pkg/istio/virtualservicegatway_test.go
+++ b/pkg/istio/virtualservicegatway_test.go
@@ -1,7 +1,8 @@
-package istio
+package istio_test
 
 import (
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 
@@ -113,12 +114,12 @@ var _ = Describe("Location of Gateway connected VirtualService Kind", func() {
 				Name: "customer-v1",
 			}
 
-			found := VirtualServiceGatewayLocator(ctx, &ref)
+			found := istio.VirtualServiceGatewayLocator(ctx, &ref)
 			Expect(found).To(BeTrue())
 
-			gws := ref.GetTargets(model.Kind(GatewayKind))
+			gws := ref.GetTargets(model.Kind(istio.GatewayKind))
 			Expect(gws).To(HaveLen(1))
-			Expect(gws[0].Labels[LabelIkeHosts]).To(Equal("redhat-kubecon.io,redhat-devcon.io"))
+			Expect(gws[0].Labels[istio.LabelIkeHosts]).To(Equal("redhat-kubecon.io,redhat-devcon.io"))
 		})
 	})
 })

--- a/pkg/istio/virtualservicegatway_test.go
+++ b/pkg/istio/virtualservicegatway_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Location of Gateway connected VirtualService Kind", func() {
 			found := VirtualServiceGatewayLocator(ctx, &ref)
 			Expect(found).To(BeTrue())
 
-			gws := ref.GetTargetsByKind(GatewayKind)
+			gws := ref.GetTargets(model.Kind(GatewayKind))
 			Expect(gws).To(HaveLen(1))
 			Expect(gws[0].Labels[LabelIkeHosts]).To(Equal("redhat-kubecon.io,redhat-devcon.io"))
 		})

--- a/pkg/istio/virtualservicegatway_test.go
+++ b/pkg/istio/virtualservicegatway_test.go
@@ -2,6 +2,7 @@ package istio
 
 import (
 	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 
 	. "github.com/onsi/ginkgo"
@@ -13,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var _ = Describe("Location of Gateway connected VirtualService Kind", func() {
@@ -104,7 +104,7 @@ var _ = Describe("Location of Gateway connected VirtualService Kind", func() {
 				Namespace: "bookinfo",
 				Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
 				Client:    c,
-				Log:       logf.Log.WithName("controller_session"),
+				Log:       log.CreateOperatorAwareLogger("session").WithValues("type", "controller"),
 			}
 		})
 

--- a/pkg/istio/virtualservicegatway_test.go
+++ b/pkg/istio/virtualservicegatway_test.go
@@ -1,0 +1,124 @@
+package istio
+
+import (
+	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
+	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var _ = Describe("Location of Gateway connected VirtualService Kind", func() {
+
+	// Missing tests:
+	//  - verify existing host logic from GW works (filter out our own sub domains)
+	Context("gateway attachment", func() {
+
+		var (
+			objects []runtime.Object
+			c       client.Client
+			ctx     model.SessionContext
+		)
+
+		BeforeEach(func() {
+			objects = []runtime.Object{
+				&istionetwork.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "customer",
+						Namespace: "bookinfo",
+					},
+					Spec: istionetworkv1alpha3.VirtualService{
+						Hosts:    []string{"*"},
+						Gateways: []string{"test-gateway"},
+						Http: []*istionetworkv1alpha3.HTTPRoute{
+							{
+								Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+									{
+										Destination: &istionetworkv1alpha3.Destination{
+											Host: "customer",
+											Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&istionetwork.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "non-customer",
+						Namespace: "bookinfo",
+					},
+					Spec: istionetworkv1alpha3.VirtualService{
+						Hosts:    []string{"*"},
+						Gateways: []string{"test-gateway"},
+						Http: []*istionetworkv1alpha3.HTTPRoute{
+							{
+								Route: []*istionetworkv1alpha3.HTTPRouteDestination{
+									{
+										Destination: &istionetworkv1alpha3.Destination{
+											Host: "reviews",
+											Port: &istionetworkv1alpha3.PortSelector{Number: 8080},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&istionetwork.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-gateway",
+						Namespace: "bookinfo",
+					},
+					Spec: istionetworkv1alpha3.Gateway{
+						Selector: map[string]string{"istio": "ingressgateway"},
+						Servers: []*istionetworkv1alpha3.Server{
+							{
+								Port:  &istionetworkv1alpha3.Port{Name: "http", Protocol: "HTTP", Number: 80},
+								Hosts: []string{"redhat-kubecon.io", "redhat-devcon.io"},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			schema, _ := v1alpha1.SchemeBuilder.Register(
+				&istionetwork.VirtualServiceList{},
+				&istionetwork.VirtualService{},
+				&istionetwork.Gateway{}).Build()
+
+			c = fake.NewFakeClientWithScheme(schema, objects...)
+			ctx = model.SessionContext{
+				Name:      "test",
+				Namespace: "bookinfo",
+				Route:     model.Route{Type: "Header", Name: "x", Value: "y"},
+				Client:    c,
+				Log:       logf.Log.WithName("controller_session"),
+			}
+		})
+
+		It("should locate gateway", func() {
+			ref := model.Ref{
+				Name: "customer-v1",
+			}
+
+			found := VirtualServiceGatewayLocator(ctx, &ref)
+			Expect(found).To(BeTrue())
+
+			gws := ref.GetTargetsByKind(GatewayKind)
+			Expect(gws).To(HaveLen(1))
+			Expect(gws[0].Labels[LabelIkeHosts]).To(Equal("redhat-kubecon.io,redhat-devcon.io"))
+		})
+	})
+})

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -38,10 +38,10 @@ func DeploymentLocator(ctx model.SessionContext, ref *model.Ref) bool {
 
 // DeploymentMutator attempts to clone the located Deployment
 func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error {
-	if len(ref.GetResourceStatus(DeploymentKind)) > 0 {
+	if len(ref.GetResources(model.Kind(DeploymentKind))) > 0 {
 		return nil
 	}
-	targets := ref.GetTargetsByKind(DeploymentKind)
+	targets := ref.GetTargets(model.Kind(DeploymentKind))
 	if len(targets) == 0 {
 		return nil
 	}
@@ -74,7 +74,7 @@ func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error {
 
 // DeploymentRevertor attempts to delete the cloned Deployment
 func DeploymentRevertor(ctx model.SessionContext, ref *model.Ref) error {
-	statuses := ref.GetResourceStatus(DeploymentKind)
+	statuses := ref.GetResources(model.Kind(DeploymentKind))
 	for _, status := range statuses {
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: status.Name, Namespace: ctx.Namespace},

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -173,8 +172,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(ctx, &notMatchingRef)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.Deployment{}
-			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: notMatchingRef.Name + "-v1-" + ctx.Name}, &deployment)
+			_, err := get.DeploymentWithError(ctx.Namespace, notMatchingRef.Name+"-v1-"+ctx.Name)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -242,15 +240,13 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.Deployment{}
-
-			mutatedFetchErr := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
+			_, mutatedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(mutatedFetchErr).ToNot(HaveOccurred())
 
 			revertorErr := k8s.DeploymentRevertor(ctx, &ref)
 			Expect(revertorErr).ToNot(HaveOccurred())
 
-			revertedFetchErr := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
+			_, revertedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(revertedFetchErr).To(HaveOccurred())
 			Expect(errors.IsNotFound(revertedFetchErr)).To(BeTrue())
 		})

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/k8s"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
-	"github.com/maistra/istio-workspace/test/operator"
+	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,7 +27,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 		objects []runtime.Object
 		c       client.Client
 		ctx     model.SessionContext
-		get     *operator.Helpers
+		get     *testclient.Getters
 	)
 
 	CreateTestRef := func() model.Ref {
@@ -43,7 +43,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 		err := appsv1.AddToScheme(schema)
 		Expect(err).ToNot(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(c)
+		get = testclient.New(c)
 		ctx = model.SessionContext{
 			Context:   context.Background(),
 			Name:      "test",

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -18,7 +18,7 @@ var _ model.Locator = ServiceLocator
 
 // ServiceLocator attempts to locate the Services for the target Deployment/DeploymentConfig
 func ServiceLocator(ctx model.SessionContext, ref *model.Ref) bool {
-	deployments := ref.GetTargetsByKind("Deployment", "DeploymentConfig")
+	deployments := ref.GetTargets(model.AnyKind("Deployment", "DeploymentConfig"))
 
 	services, err := getServices(ctx, ctx.Namespace)
 	if err != nil {

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Operations for k8s Service kind", func() {
 		It("should find services for Deployment", func() {
 			ref := CreateTestRef(k8s.DeploymentKind, map[string]string{"app": "x"})
 			k8s.ServiceLocator(ctx, &ref)
-			services := ref.GetTargetsByKind(k8s.ServiceKind)
+			services := ref.GetTargets(model.Kind(k8s.ServiceKind))
 			Expect(len(services)).To(Equal(1))
 
 			Expect(services[0].Name).To(Equal("test-1"))
@@ -106,7 +106,7 @@ var _ = Describe("Operations for k8s Service kind", func() {
 		It("should find services for DeploymentConfig", func() {
 			ref := CreateTestRef(openshift.DeploymentConfigKind, map[string]string{"app": "x"})
 			k8s.ServiceLocator(ctx, &ref)
-			services := ref.GetTargetsByKind(k8s.ServiceKind)
+			services := ref.GetTargets(model.Kind(k8s.ServiceKind))
 			Expect(len(services)).To(Equal(1))
 
 			Expect(services[0].Name).To(Equal("test-1"))
@@ -123,7 +123,7 @@ var _ = Describe("Operations for k8s Service kind", func() {
 		It("should add all matching services", func() {
 			ref := CreateTestRef(k8s.DeploymentKind, map[string]string{"app": "z"})
 			k8s.ServiceLocator(ctx, &ref)
-			services := ref.GetTargetsByKind(k8s.ServiceKind)
+			services := ref.GetTargets(model.Kind(k8s.ServiceKind))
 			Expect(len(services)).To(Equal(2))
 
 			Expect(services[0].Name).To(Equal("test-2"))

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -45,7 +45,7 @@ type HostName struct {
 // Predicate base function to filter Resources.
 type Predicate func(ResourceStatus) bool
 
-// Any Predicate returns true if any of the predicates match
+// Any Predicate returns true if any of the predicates match.
 func Any(predicates ...Predicate) Predicate {
 	return func(resource ResourceStatus) bool {
 		for _, predicate := range predicates {
@@ -57,7 +57,7 @@ func Any(predicates ...Predicate) Predicate {
 	}
 }
 
-// All Predicate returns true if all of the predicates match
+// All Predicate returns true if all of the predicates match.
 func All(predicates ...Predicate) Predicate {
 	return func(resource ResourceStatus) bool {
 		for _, predicate := range predicates {
@@ -69,21 +69,21 @@ func All(predicates ...Predicate) Predicate {
 	}
 }
 
-// Kind Predicate returns true if kind matches resource
+// Kind Predicate returns true if kind matches resource.
 func Kind(kind string) Predicate {
 	return func(resource ResourceStatus) bool {
 		return resource.Kind == kind
 	}
 }
 
-// Name Predicate returns true if name matches resource
+// Name Predicate returns true if name matches resource.
 func Name(name string) Predicate {
 	return func(resource ResourceStatus) bool {
 		return resource.Name == name
 	}
 }
 
-// AnyKind is a shortcut Predicate for Any and Kind from strings
+// AnyKind is a shortcut Predicate for Any and Kind from strings.
 func AnyKind(kinds ...string) Predicate {
 	pred := []Predicate{}
 	for _, kind := range kinds {

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -8,7 +8,6 @@ import (
 	"github.com/maistra/istio-workspace/pkg/template"
 
 	appsv1 "github.com/openshift/api/apps/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -43,10 +43,10 @@ func DeploymentConfigLocator(ctx model.SessionContext, ref *model.Ref) bool {
 
 // DeploymentConfigMutator attempts to clone the located DeploymentConfig
 func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error {
-	if len(ref.GetResourceStatus(DeploymentConfigKind)) > 0 {
+	if len(ref.GetResources(model.Kind(DeploymentConfigKind))) > 0 {
 		return nil
 	}
-	targets := ref.GetTargetsByKind(DeploymentConfigKind)
+	targets := ref.GetTargets(model.Kind(DeploymentConfigKind))
 	if len(targets) == 0 {
 		return nil
 	}
@@ -79,7 +79,7 @@ func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error {
 
 // DeploymentConfigRevertor attempts to delete the cloned DeploymentConfig
 func DeploymentConfigRevertor(ctx model.SessionContext, ref *model.Ref) error {
-	statuses := ref.GetResourceStatus(DeploymentConfigKind)
+	statuses := ref.GetResources(model.Kind(DeploymentConfigKind))
 	for _, status := range statuses {
 		deployment := &appsv1.DeploymentConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: status.Name, Namespace: ctx.Namespace},

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -7,17 +7,17 @@ import (
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/openshift"
 	"github.com/maistra/istio-workspace/test/operator"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	appsv1 "github.com/openshift/api/apps/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/openshift"
+	"github.com/maistra/istio-workspace/test/operator"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 
@@ -15,15 +17,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 
-	var objects []runtime.Object
-	var ctx model.SessionContext
+	var (
+		objects []runtime.Object
+		c       client.Client
+		ctx     model.SessionContext
+		get     *operator.Helpers
+	)
 
 	CreateTestRef := func() model.Ref {
 		return model.Ref{
@@ -37,12 +42,14 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 		schema := runtime.NewScheme()
 		err := appsv1.Install(schema)
 		Expect(err).ToNot(HaveOccurred())
+		c = fake.NewFakeClientWithScheme(schema, objects...)
+		get = operator.New(c)
 		ctx = model.SessionContext{
 			Context:   context.Background(),
 			Name:      "test",
 			Namespace: "test",
 			Log:       log.CreateOperatorAwareLogger("test").WithValues("type", "openshift-deploymentconfig"),
-			Client:    fake.NewFakeClientWithScheme(schema, objects...),
+			Client:    c,
 		}
 	})
 
@@ -138,9 +145,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.DeploymentConfig{}
-			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
-			Expect(err).ToNot(HaveOccurred())
+			_ = get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 		})
 
 		It("should remove liveness probe from cloned deployment", func() {
@@ -148,9 +153,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.DeploymentConfig{}
-			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
-			Expect(err).ToNot(HaveOccurred())
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 		})
 
@@ -159,9 +162,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.DeploymentConfig{}
-			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
-			Expect(err).ToNot(HaveOccurred())
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 		})
 
@@ -170,9 +171,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.DeploymentConfig{}
-			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
-			Expect(err).ToNot(HaveOccurred())
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo("v1-test"))
 		})
 
@@ -181,8 +180,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(ctx, &notMatchingRef)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.DeploymentConfig{}
-			err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: notMatchingRef.Name + "-v1-" + ctx.Name}, &deployment)
+			_, err := get.DeploymentConfigWithError(ctx.Namespace, notMatchingRef.Name+"-v1-"+ctx.Name)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -194,10 +192,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := appsv1.DeploymentConfig{}
-				err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
-				Expect(err).ToNot(HaveOccurred())
-
+				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("datawire/telepresence-k8s:"))
 			})
 
@@ -206,10 +201,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := appsv1.DeploymentConfig{}
-				err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
-				Expect(err).ToNot(HaveOccurred())
-
+				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("TELEPRESENCE_CONTAINER_NAMESPACE"))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
@@ -253,15 +245,13 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := appsv1.DeploymentConfig{}
-
-			mutatedFetchErr := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
+			_, mutatedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(mutatedFetchErr).ToNot(HaveOccurred())
 
 			revertorErr := openshift.DeploymentConfigRevertor(ctx, &ref)
 			Expect(revertorErr).ToNot(HaveOccurred())
 
-			revertedFetchErr := ctx.Client.Get(ctx, types.NamespacedName{Namespace: ctx.Namespace, Name: ref.Name + "-v1-" + ctx.Name}, &deployment)
+			_, revertedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
 			Expect(revertedFetchErr).To(HaveOccurred())
 			Expect(errors.IsNotFound(revertedFetchErr)).To(BeTrue())
 		})

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/openshift"
-	"github.com/maistra/istio-workspace/test/operator"
+	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,7 +27,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 		objects []runtime.Object
 		c       client.Client
 		ctx     model.SessionContext
-		get     *operator.Helpers
+		get     *testclient.Getters
 	)
 
 	CreateTestRef := func() model.Ref {
@@ -43,7 +43,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 		err := appsv1.Install(schema)
 		Expect(err).ToNot(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(schema, objects...)
-		get = operator.New(c)
+		get = testclient.New(c)
 		ctx = model.SessionContext{
 			Context:   context.Background(),
 			Name:      "test",

--- a/test/cmd/test-scenario/generator/modifiers.go
+++ b/test/cmd/test-scenario/generator/modifiers.go
@@ -10,10 +10,10 @@ import (
 )
 
 // ConnectToGateway modifier to connect VirtualService to a Gateway. Combine with ForService.
-func ConnectToGateway() Modifier {
+func ConnectToGateway(hostname string) Modifier {
 	return func(service Entry, object runtime.Object) {
 		if obj, ok := object.(*istionetwork.VirtualService); ok {
-			obj.Spec.Hosts = []string{"*"}
+			obj.Spec.Hosts = []string{hostname}
 			obj.Spec.Gateways = append(obj.Spec.Gateways, "test-gateway")
 			for i := 0; i < len(obj.Spec.Http); i++ {
 				http := obj.Spec.Http[i]

--- a/test/cmd/test-scenario/generator/scenarios.go
+++ b/test/cmd/test-scenario/generator/scenarios.go
@@ -19,7 +19,7 @@ func TestScenario1HTTPThreeServicesInSequence(out io.Writer) {
 		out,
 		[]Entry{productpage, reviews, ratings},
 		WithVersion("v1"),
-		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway()),
+		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway(GatewayHost)),
 		ForService(reviews, Call(HTTP(), ratings)),
 		GatewayOnHost(GatewayHost),
 	)
@@ -36,7 +36,7 @@ func TestScenario1GRPCThreeServicesInSequence(out io.Writer) {
 		out,
 		[]Entry{productpage, reviews, ratings},
 		WithVersion("v1"),
-		ForService(productpage, Call(GRPC(), reviews), ConnectToGateway()),
+		ForService(productpage, Call(GRPC(), reviews), ConnectToGateway(GatewayHost)),
 		ForService(reviews, Call(GRPC(), ratings)),
 		GatewayOnHost(GatewayHost),
 	)
@@ -54,7 +54,7 @@ func TestScenario2ThreeServicesInSequenceDeploymentConfig(out io.Writer) {
 		out,
 		[]Entry{productpage, reviews, ratings},
 		WithVersion("v1"),
-		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway()),
+		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway(GatewayHost)),
 		ForService(reviews, Call(HTTP(), ratings)),
 		GatewayOnHost(GatewayHost),
 	)
@@ -72,9 +72,9 @@ func DemoScenario(out io.Writer) {
 		out,
 		[]Entry{productpage, reviews, ratings, authors, locations},
 		WithVersion("v1"),
-		ForService(productpage, Call(HTTP(), reviews), Call(HTTP(), authors), ConnectToGateway()),
+		ForService(productpage, Call(HTTP(), reviews), Call(HTTP(), authors), ConnectToGateway("ike-demo.io")),
 		ForService(reviews, Call(GRPC(), ratings)),
 		ForService(authors, Call(GRPC(), locations)),
-		GatewayOnHost("ike-demo.io"), GatewayOnHost("*.ike-demo.io"),
+		GatewayOnHost("ike-demo.io"),
 	)
 }

--- a/test/operator/getters.go
+++ b/test/operator/getters.go
@@ -17,7 +17,7 @@ import (
  * Test helpers for Operator test suite
  */
 
-// New returns a new set of helpers for a given Client
+// New returns a new set of helpers for a given Client.
 func New(c client.Client) *Helpers {
 	return &Helpers{
 		Session:                   Session(c),
@@ -32,7 +32,7 @@ func New(c client.Client) *Helpers {
 	}
 }
 
-// Helpers simple struct to hold funcs
+// Helpers simple struct to hold funcs.
 type Helpers struct {
 	Session                   func(namespace, name string) v1alpha1.Session
 	Gateway                   func(namespace, name string) istionetwork.Gateway
@@ -45,7 +45,7 @@ type Helpers struct {
 	VirtualServices           func(namespace string) istionetwork.VirtualServiceList
 }
 
-// Session returns a session by name in a given namespace
+// Session returns a session by name in a given namespace.
 func Session(c client.Client) func(namespace, name string) v1alpha1.Session {
 	return func(namespace, name string) v1alpha1.Session {
 		s := v1alpha1.Session{}
@@ -55,7 +55,7 @@ func Session(c client.Client) func(namespace, name string) v1alpha1.Session {
 	}
 }
 
-// Gateway returns a gateway by name in a given namespace
+// Gateway returns a gateway by name in a given namespace.
 func Gateway(c client.Client) func(namespace, name string) istionetwork.Gateway {
 	return func(namespace, name string) istionetwork.Gateway {
 		s := istionetwork.Gateway{}
@@ -65,7 +65,7 @@ func Gateway(c client.Client) func(namespace, name string) istionetwork.Gateway 
 	}
 }
 
-// DestinationRule returns a destinationrule by name in a given namespace
+// DestinationRule returns a destinationrule by name in a given namespace.
 func DestinationRule(c client.Client) func(namespace, name string) istionetwork.DestinationRule {
 	return func(namespace, name string) istionetwork.DestinationRule {
 		s := istionetwork.DestinationRule{}
@@ -75,7 +75,7 @@ func DestinationRule(c client.Client) func(namespace, name string) istionetwork.
 	}
 }
 
-// VirtualService returns a virtualservice by name in a given namespace
+// VirtualService returns a virtualservice by name in a given namespace.
 func VirtualService(c client.Client) func(namespace, name string) istionetwork.VirtualService {
 	return func(namespace, name string) istionetwork.VirtualService {
 		s := istionetwork.VirtualService{}
@@ -85,7 +85,7 @@ func VirtualService(c client.Client) func(namespace, name string) istionetwork.V
 	}
 }
 
-// Deployment returns a deployment by name in a given namespace
+// Deployment returns a deployment by name in a given namespace.
 func Deployment(c client.Client) func(namespace, name string) appsv1.Deployment {
 	return func(namespace, name string) appsv1.Deployment {
 		s := appsv1.Deployment{}
@@ -95,7 +95,7 @@ func Deployment(c client.Client) func(namespace, name string) appsv1.Deployment 
 	}
 }
 
-// DeploymentWithError returns a deployment by name in a given namespace or error
+// DeploymentWithError returns a deployment by name in a given namespace or error.
 func DeploymentWithError(c client.Client) func(namespace, name string) (appsv1.Deployment, error) {
 	return func(namespace, name string) (appsv1.Deployment, error) {
 		s := appsv1.Deployment{}
@@ -104,7 +104,7 @@ func DeploymentWithError(c client.Client) func(namespace, name string) (appsv1.D
 	}
 }
 
-// DeploymentConfig returns a deploymentconfig by name in a given namespace
+// DeploymentConfig returns a deploymentconfig by name in a given namespace.
 func DeploymentConfig(c client.Client) func(namespace, name string) osappsv1.DeploymentConfig {
 	return func(namespace, name string) osappsv1.DeploymentConfig {
 		s := osappsv1.DeploymentConfig{}
@@ -114,7 +114,7 @@ func DeploymentConfig(c client.Client) func(namespace, name string) osappsv1.Dep
 	}
 }
 
-// DeploymentConfigWithError returns a deploymentconfig by name in a given namespace or error
+// DeploymentConfigWithError returns a deploymentconfig by name in a given namespace or error.
 func DeploymentConfigWithError(c client.Client) func(namespace, name string) (osappsv1.DeploymentConfig, error) {
 	return func(namespace, name string) (osappsv1.DeploymentConfig, error) {
 		s := osappsv1.DeploymentConfig{}
@@ -123,7 +123,7 @@ func DeploymentConfigWithError(c client.Client) func(namespace, name string) (os
 	}
 }
 
-// VirtualServices returns all virtualservices in a given namespace
+// VirtualServices returns all virtualservices in a given namespace.
 func VirtualServices(c client.Client) func(namespace string) istionetwork.VirtualServiceList {
 	return func(namespace string) istionetwork.VirtualServiceList {
 		s := istionetwork.VirtualServiceList{}

--- a/test/operator/getters.go
+++ b/test/operator/getters.go
@@ -1,0 +1,134 @@
+package operator
+
+import (
+	"context"
+
+	"github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
+
+	"github.com/onsi/gomega"
+	osappsv1 "github.com/openshift/api/apps/v1"
+	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+ * Test helpers for Operator test suite
+ */
+
+// New returns a new set of helpers for a given Client
+func New(c client.Client) *Helpers {
+	return &Helpers{
+		Session:                   Session(c),
+		Gateway:                   Gateway(c),
+		DestinationRule:           DestinationRule(c),
+		VirtualService:            VirtualService(c),
+		VirtualServices:           VirtualServices(c),
+		Deployment:                Deployment(c),
+		DeploymentWithError:       DeploymentWithError(c),
+		DeploymentConfig:          DeploymentConfig(c),
+		DeploymentConfigWithError: DeploymentConfigWithError(c),
+	}
+}
+
+// Helpers simple struct to hold funcs
+type Helpers struct {
+	Session                   func(namespace, name string) v1alpha1.Session
+	Gateway                   func(namespace, name string) istionetwork.Gateway
+	DestinationRule           func(namespace, name string) istionetwork.DestinationRule
+	VirtualService            func(namespace, name string) istionetwork.VirtualService
+	Deployment                func(namespace, name string) appsv1.Deployment
+	DeploymentWithError       func(namespace, name string) (appsv1.Deployment, error)
+	DeploymentConfig          func(namespace, name string) osappsv1.DeploymentConfig
+	DeploymentConfigWithError func(namespace, name string) (osappsv1.DeploymentConfig, error)
+	VirtualServices           func(namespace string) istionetwork.VirtualServiceList
+}
+
+// Session returns a session by name in a given namespace
+func Session(c client.Client) func(namespace, name string) v1alpha1.Session {
+	return func(namespace, name string) v1alpha1.Session {
+		s := v1alpha1.Session{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}
+
+// Gateway returns a gateway by name in a given namespace
+func Gateway(c client.Client) func(namespace, name string) istionetwork.Gateway {
+	return func(namespace, name string) istionetwork.Gateway {
+		s := istionetwork.Gateway{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}
+
+// DestinationRule returns a destinationrule by name in a given namespace
+func DestinationRule(c client.Client) func(namespace, name string) istionetwork.DestinationRule {
+	return func(namespace, name string) istionetwork.DestinationRule {
+		s := istionetwork.DestinationRule{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}
+
+// VirtualService returns a virtualservice by name in a given namespace
+func VirtualService(c client.Client) func(namespace, name string) istionetwork.VirtualService {
+	return func(namespace, name string) istionetwork.VirtualService {
+		s := istionetwork.VirtualService{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}
+
+// Deployment returns a deployment by name in a given namespace
+func Deployment(c client.Client) func(namespace, name string) appsv1.Deployment {
+	return func(namespace, name string) appsv1.Deployment {
+		s := appsv1.Deployment{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}
+
+// DeploymentWithError returns a deployment by name in a given namespace or error
+func DeploymentWithError(c client.Client) func(namespace, name string) (appsv1.Deployment, error) {
+	return func(namespace, name string) (appsv1.Deployment, error) {
+		s := appsv1.Deployment{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		return s, err
+	}
+}
+
+// DeploymentConfig returns a deploymentconfig by name in a given namespace
+func DeploymentConfig(c client.Client) func(namespace, name string) osappsv1.DeploymentConfig {
+	return func(namespace, name string) osappsv1.DeploymentConfig {
+		s := osappsv1.DeploymentConfig{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}
+
+// DeploymentConfigWithError returns a deploymentconfig by name in a given namespace or error
+func DeploymentConfigWithError(c client.Client) func(namespace, name string) (osappsv1.DeploymentConfig, error) {
+	return func(namespace, name string) (osappsv1.DeploymentConfig, error) {
+		s := osappsv1.DeploymentConfig{}
+		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		return s, err
+	}
+}
+
+// VirtualServices returns all virtualservices in a given namespace
+func VirtualServices(c client.Client) func(namespace string) istionetwork.VirtualServiceList {
+	return func(namespace string) istionetwork.VirtualServiceList {
+		s := istionetwork.VirtualServiceList{}
+		err := c.List(context.Background(), &s, client.InNamespace(namespace))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return s
+	}
+}

--- a/test/testclient/getters.go
+++ b/test/testclient/getters.go
@@ -1,4 +1,4 @@
-package operator
+package testclient
 
 import (
 	"context"
@@ -14,12 +14,12 @@ import (
 )
 
 /*
- * Test helpers for Operator test suite
+ * Test Getters for Operator test suite
  */
 
-// New returns a new set of helpers for a given Client.
-func New(c client.Client) *Helpers {
-	return &Helpers{
+// New returns a new set of Getters for a given Client.
+func New(c client.Client) *Getters {
+	return &Getters{
 		Session:                   Session(c),
 		Gateway:                   Gateway(c),
 		DestinationRule:           DestinationRule(c),
@@ -32,8 +32,8 @@ func New(c client.Client) *Helpers {
 	}
 }
 
-// Helpers simple struct to hold funcs.
-type Helpers struct {
+// Getters simple struct to hold funcs.
+type Getters struct {
 	Session                   func(namespace, name string) v1alpha1.Session
 	Gateway                   func(namespace, name string) istionetwork.Gateway
 	DestinationRule           func(namespace, name string) istionetwork.DestinationRule


### PR DESCRIPTION
Add a subdomain host to the gateway which targets a virtual service that auto-add routing headers. 
This allows a user to more easily call into a special route from e.g. a browser.  

fixes #241 