### PR TITLE
feat(operator): expose host route in session status

### DIFF
--- a/pkg/apis/istio/v1alpha1/session_types.go
+++ b/pkg/apis/istio/v1alpha1/session_types.go
@@ -41,9 +41,10 @@ type RefStatus struct {
 
 // RefResource defines the observed resources mutated/created as part of the Ref.
 type RefResource struct {
-	Kind   *string `json:"kind,omitempty"`
-	Name   *string `json:"name,omitempty"`
-	Action *string `json:"action,omitempty"`
+	Kind   *string           `json:"kind,omitempty"`
+	Name   *string           `json:"name,omitempty"`
+	Action *string           `json:"action,omitempty"`
+	Prop   map[string]string `json:"prop,omitempty"`
 }
 
 // LabeledRefResource is a RefResource with Labels.

--- a/pkg/apis/istio/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1alpha1/zz_generated.deepcopy.go
@@ -73,6 +73,13 @@ func (in *RefResource) DeepCopyInto(out *RefResource) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Prop != nil {
+		in, out := &in.Prop, &out.Prop
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/session/model_convert.go
+++ b/pkg/controller/session/model_convert.go
@@ -35,7 +35,7 @@ func ConvertModelRefToAPIStatus(ref model.Ref, session *istiov1alpha1.Session) {
 	for _, refStat := range ref.ResourceStatuses {
 		rs := refStat
 		action := string(rs.Action)
-		statusRef.Resources = append(statusRef.Resources, &istiov1alpha1.RefResource{Name: &rs.Name, Kind: &rs.Kind, Action: &action})
+		statusRef.Resources = append(statusRef.Resources, &istiov1alpha1.RefResource{Name: &rs.Name, Kind: &rs.Kind, Action: &action, Prop: rs.Prop})
 	}
 	var existsInStatus bool
 	for i, statRef := range session.Status.Refs {
@@ -85,7 +85,7 @@ func ConvertAPIStatusToModelRef(session istiov1alpha1.Session, ref *model.Ref) {
 			}
 			for _, resource := range statusRef.Resources {
 				r := resource
-				ref.AddResourceStatus(model.ResourceStatus{Name: *r.Name, Kind: *r.Kind, Action: model.ResourceAction(*r.Action)})
+				ref.AddResourceStatus(model.ResourceStatus{Name: *r.Name, Kind: *r.Kind, Action: model.ResourceAction(*r.Action), Prop: r.Prop})
 			}
 		}
 	}

--- a/pkg/controller/session/model_convert_test.go
+++ b/pkg/controller/session/model_convert_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Basic model conversion", func() {
 				ResourceStatuses: []model.ResourceStatus{
 					{Kind: kind, Name: name, Action: model.ActionCreated},
 					{Kind: "test", Name: "2", Action: model.ActionModified},
-					{Kind: "test-2", Name: "2", Action: model.ActionFailed},
+					{Kind: "test-2", Name: "2", Action: model.ActionFailed, Prop: map[string]string{"host": "x"}},
 				}}
 		})
 
@@ -84,14 +84,18 @@ var _ = Describe("Basic model conversion", func() {
 			Expect(*sess.Status.Refs[0].Resources[0].Kind).To(Equal(ref.ResourceStatuses[0].Kind))
 			Expect(*sess.Status.Refs[0].Resources[0].Name).To(Equal(ref.ResourceStatuses[0].Name))
 			Expect(*sess.Status.Refs[0].Resources[0].Action).To(Equal(aCreated))
+			Expect(sess.Status.Refs[0].Resources[0].Prop).To(BeEmpty())
 
 			Expect(*sess.Status.Refs[0].Resources[1].Kind).To(Equal(ref.ResourceStatuses[1].Kind))
 			Expect(*sess.Status.Refs[0].Resources[1].Name).To(Equal(ref.ResourceStatuses[1].Name))
 			Expect(*sess.Status.Refs[0].Resources[1].Action).To(Equal(aModified))
+			Expect(sess.Status.Refs[0].Resources[1].Prop).To(BeEmpty())
 
 			Expect(*sess.Status.Refs[0].Resources[2].Kind).To(Equal(ref.ResourceStatuses[2].Kind))
 			Expect(*sess.Status.Refs[0].Resources[2].Name).To(Equal(ref.ResourceStatuses[2].Name))
 			Expect(*sess.Status.Refs[0].Resources[2].Action).To(Equal(aFailed))
+			Expect(sess.Status.Refs[0].Resources[2].Prop).ToNot(BeEmpty())
+			Expect(sess.Status.Refs[0].Resources[2].Prop["host"]).To(Equal("x"))
 		})
 
 		Context("exists in status", func() {
@@ -184,6 +188,7 @@ var _ = Describe("Basic model conversion", func() {
 							Resources: []*v1alpha1.RefResource{
 								{
 									Kind: &kind, Name: &name, Action: &aFailed,
+									Prop: map[string]string{"host": "x"},
 								},
 							},
 						},
@@ -210,6 +215,9 @@ var _ = Describe("Basic model conversion", func() {
 			Expect(refs[1].ResourceStatuses[0].Kind).To(Equal(*sess.Status.Refs[1].Resources[0].Kind))
 			Expect(refs[1].ResourceStatuses[0].Name).To(Equal(*sess.Status.Refs[1].Resources[0].Name))
 			Expect(refs[1].ResourceStatuses[0].Action).To(Equal(model.ActionFailed))
+			Expect(refs[1].ResourceStatuses[0].Action).To(Equal(model.ActionFailed))
+			Expect(refs[1].ResourceStatuses[0].Prop).ToNot(BeEmpty())
+			Expect(refs[1].ResourceStatuses[0].Prop["host"]).To(Equal("x"))
 		})
 
 		It("targets mapped", func() {

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -29,14 +29,20 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error {
 		}
 
 		ctx.Log.Info("Found Gateway", "name", gw.Name)
-		mutatedGw := mutateGateway(ctx, *gw)
+		mutatedGw, addedHosts, err := mutateGateway(ctx, *gw)
 		err = ctx.Client.Update(ctx, &mutatedGw)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedGw.Name, Action: model.ActionFailed})
 			return err
 		}
 
-		ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedGw.Name, Action: model.ActionModified})
+		ref.AddResourceStatus(model.ResourceStatus{
+			Kind:   GatewayKind,
+			Name:   mutatedGw.Name,
+			Action: model.ActionModified,
+			Prop: map[string]string{
+				"hosts": strings.Join(addedHosts, ","),
+			}})
 	}
 	return nil
 }
@@ -69,10 +75,11 @@ func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error {
 	return nil
 }
 
-func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) istionetwork.Gateway {
+func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (istionetwork.Gateway, []string, error) {
 	if source.Annotations == nil {
 		source.Annotations = map[string]string{}
 	}
+	addedHosts := []string{}
 	existingHosts := []string{}
 	if hosts := source.Annotations[LabelIkeHosts]; hosts != "" {
 		existingHosts = strings.Split(hosts, ",") // split on empty string return empty (len(1))
@@ -84,12 +91,13 @@ func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) istion
 			if !existInList(existingHosts, host) && !existInList(existingHosts, newHost) {
 				existingHosts = append(existingHosts, newHost)
 				hosts = append(hosts, newHost)
+				addedHosts = append(addedHosts, newHost)
 			}
 		}
 		server.Hosts = hosts
 	}
 	source.Annotations[LabelIkeHosts] = strings.Join(existingHosts, ",")
-	return source
+	return source, addedHosts, nil
 }
 
 func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) istionetwork.Gateway {

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -91,6 +91,17 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
 			})
 
+			It("add single session - verify ref", func() {
+				err := istio.GatewayMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(ref.ResourceStatuses).To(HaveLen(1))
+				Expect(ref.ResourceStatuses[0].Name).To(Equal("gateway"))
+				Expect(ref.ResourceStatuses[0].Kind).To(Equal("Gateway"))
+				Expect(ref.ResourceStatuses[0].Prop).ToNot(BeEmpty())
+				Expect(ref.ResourceStatuses[0].Prop["hosts"]).To(Equal("test.domain.com"))
+			})
+
 			It("add multiple session", func() {
 				err := istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -98,7 +98,6 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				Expect(ref.ResourceStatuses).To(HaveLen(1))
 				Expect(ref.ResourceStatuses[0].Name).To(Equal("gateway"))
 				Expect(ref.ResourceStatuses[0].Kind).To(Equal("Gateway"))
-				Expect(ref.ResourceStatuses[0].Prop).ToNot(BeEmpty())
 				Expect(ref.ResourceStatuses[0].Prop["hosts"]).To(Equal("test.domain.com"))
 			})
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -190,6 +190,7 @@ type ResourceStatus struct {
 	Name string
 	// created, mutated, failed
 	Action ResourceAction
+	Prop   map[string]string
 }
 
 // LocatedResourceStatus is a ResourceStatus with labels.


### PR DESCRIPTION
Allow a client to know which session routes have been exposed for this
session.

fixes #242