### PR TITLE
fix(log): use a single instance of Logger

### DIFF
--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -16,8 +16,6 @@ import (
 	"github.com/maistra/istio-workspace/pkg/cmd/serve"
 	"github.com/maistra/istio-workspace/pkg/cmd/version"
 	"github.com/maistra/istio-workspace/pkg/cmd/watch"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log" //nolint:depguard //reason registers wrapper as logger
 )
 
 func main() {
@@ -28,8 +26,7 @@ func main() {
 	// Logs to os.Stderr, where all structured logging should go
 	// When running outside of k8s cluster it will use development
 	// mode so the log is not in JSON, but plain text format
-	logger := log.CreateOperatorAwareLogger("root")
-	logf.SetLogger(logger)
+	log.SetLogger(log.CreateOperatorAwareLogger("root"))
 
 	// Setting random seed e.g. for session name generator
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -48,7 +45,7 @@ func main() {
 	cmd.VisitAll(rootCmd, completion.AddFlagCompletion)
 
 	if err := rootCmd.Execute(); err != nil {
-		logger.Error(err, "failed executing command")
+		log.Log.Error(err, "failed executing command")
 		os.Exit(23)
 	}
 }

--- a/pkg/cmd/config/env_vars.go
+++ b/pkg/cmd/config/env_vars.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	logger     = log.CreateOperatorAwareLogger("session").WithValues("type", "handler")
+	logger     = log.Log.WithValues("type", "handler")
 	Parameters []openshiftApi.Parameter
 )
 

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "create")
+var logger = log.Log.WithValues("type", "create")
 
 // NewCmd creates instance of "create" Cobra Command with flags and execution logic defined.
 func NewCmd() *cobra.Command {

--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "delete")
+var logger = log.Log.WithValues("type", "delete")
 
 // NewCmd creates instance of "create" Cobra Command with flags and execution logic defined.
 func NewCmd() *cobra.Command {

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "develop")
+var logger = log.Log.WithValues("type", "develop")
 
 const urlHint = `Knowing your application url you can now access your new version by using
 

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "install")
+var logger = log.Log.WithValues("type", "install")
 
 // NewCmd takes care of deploying server-side components of istio-workspace.
 func NewCmd() *cobra.Command {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "root")
+var logger = log.Log.WithValues("type", "root")
 
 // NewCmd creates instance of root "ike" Cobra Command with flags and execution logic defined.
 func NewCmd() *cobra.Command {

--- a/pkg/cmd/serve/serve.go
+++ b/pkg/cmd/serve/serve.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "serve")
+var logger = log.Log.WithValues("type", "serve")
 
 var (
 	metricsHost       = "0.0.0.0"

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "version")
+var logger = log.Log.WithValues("type", "version")
 
 // NewCmd creates version cmd which prints version and Build details of the executed binary.
 func NewCmd() *cobra.Command {

--- a/pkg/cmd/watch/watch.go
+++ b/pkg/cmd/watch/watch.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.CreateOperatorAwareLogger("cmd").WithValues("type", "watch")
+var logger = log.Log.WithValues("type", "watch")
 
 // NewCmd creates watch command which observes file system changes in the defined set of directories
 // and re-runs build and run command when they occur.

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	logger = log.CreateOperatorAwareLogger("session").WithValues("type", "controller")
+	logger = log.Log.WithValues("type", "controller")
 )
 
 // DefaultManipulators contains the default config for the reconciler.

--- a/pkg/internal/session/session.go
+++ b/pkg/internal/session/session.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	logger = log.CreateOperatorAwareLogger("session").WithValues("type", "controller")
+	logger = log.Log.WithValues("type", "session")
 )
 
 // Options holds the variables used by the Session Handler.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -11,14 +11,14 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log" //nolint:depguard //reason registers wrapper as logger
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// Log is the central logger for this program
+// Log is the central logger for this program.
 var Log = zapr2.NewLogger(zap.New(zapcore.NewNopCore()))
 
-// SetLogger sets the central logger to use
+// SetLogger sets the central logger to use.
 func SetLogger(logger logr.Logger) {
 	Log = logger
 	logf.SetLogger(logger)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -11,8 +11,18 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log" //nolint:depguard //reason registers wrapper as logger
 	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+// Log is the central logger for this program
+var Log = zapr2.NewLogger(zap.New(zapcore.NewNopCore()))
+
+// SetLogger sets the central logger to use
+func SetLogger(logger logr.Logger) {
+	Log = logger
+	logf.SetLogger(logger)
+}
 
 // CreateOperatorAwareLogger will set logging format to JSON when ran as operator or plain text when used as CLI.
 func CreateOperatorAwareLogger(name string) logr.Logger {

--- a/pkg/shell/funcs.go
+++ b/pkg/shell/funcs.go
@@ -13,7 +13,7 @@ import (
 	gocmd "github.com/go-cmd/cmd"
 )
 
-var logger = log.CreateOperatorAwareLogger("shell")
+var logger = log.Log.WithValues("type", "shell")
 
 // StreamOutput sets streaming of output instead of buffering it when running gocmd.Cmd.
 var StreamOutput = gocmd.Options{

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -13,7 +13,7 @@ import (
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
-var logger = log.CreateOperatorAwareLogger("watch")
+var logger = log.Log.WithValues("type", "watch")
 
 // Handler allows to define how to react on file changes event.
 type Handler func(events []fsnotify.Event) error

--- a/test/cmd/test-service/main.go
+++ b/test/cmd/test-service/main.go
@@ -14,8 +14,6 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log" //nolint:depguard //reason registers wrapper as logger
 )
 
 const (
@@ -42,10 +40,8 @@ type Config struct {
 	Call []*url.URL
 }
 
-var logger = log.CreateOperatorAwareLogger("test").WithValues("type", "test-service")
-
 func main() {
-	logf.SetLogger(logger)
+	log.SetLogger(log.CreateOperatorAwareLogger("test").WithValues("type", "test-service"))
 
 	c := Config{}
 	if v, b := os.LookupEnv(EnvServiceName); b {
@@ -76,7 +72,7 @@ func main() {
 		grpcAdr = v
 	}
 
-	logger := logf.Log.WithName("service").WithValues("name", c.Name)
+	logger := log.Log.WithName("service").WithValues("name", c.Name)
 
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/healthz", func(resp http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Instead of creating a new instance of Logger per subcommand, reuse the single instance
created in main.

Related #240 