### PR TITLE
fix(cli): return structural response on cli

### DIFF
--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -32,7 +32,8 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	rootCmd := cmd.NewCmd()
-	rootCmd.AddCommand(version.NewCmd(),
+	rootCmd.AddCommand(
+		version.NewCmd(),
 		create.NewCmd(),
 		delete.NewCmd(),
 		develop.NewCmd(),

--- a/pkg/cmd/config/env_vars.go
+++ b/pkg/cmd/config/env_vars.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/assets"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/openshift/parser"
 
+	"github.com/go-logr/logr"
 	openshiftApi "github.com/openshift/api/template/v1"
 )
 

--- a/pkg/cmd/config/env_vars.go
+++ b/pkg/cmd/config/env_vars.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/assets"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/openshift/parser"
@@ -17,7 +18,9 @@ const (
 )
 
 var (
-	logger     = log.Log.WithValues("type", "handler")
+	logger = func() logr.Logger {
+		return log.Log.WithValues("type", "handler")
+	}
 	Parameters []openshiftApi.Parameter
 )
 
@@ -30,12 +33,12 @@ func init() {
 func collectTplParams(resource string) {
 	tpl, err := parser.Load(resource)
 	if err != nil {
-		logger.Error(err, "failed parsing "+resource+"template")
+		logger().Error(err, "failed parsing "+resource+"template")
 	}
 
 	tplParams, err := parser.ParseParameters(tpl)
 	if err != nil {
-		logger.Error(err, "failed parsing parameters in the template "+resource)
+		logger().Error(err, "failed parsing parameters in the template "+resource)
 	}
 	Parameters = append(Parameters, tplParams...)
 }

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			state, _, _, err := internal.Sessions(cmd)
 			if outputJSON, _ := cmd.Flags().GetBool("json"); outputJSON {
-				b, _ := json.MarshalIndent(&state.Session, "", "  ")
+				b, _ := json.MarshalIndent(&state.RefStatus, "", "  ")
 				fmt.Println(string(b))
 			}
 			return err
@@ -46,7 +46,11 @@ func NewCmd() *cobra.Command {
 		logger().Error(err, "failed while trying to hide a flag")
 	}
 	createCmd.Flags().Bool("json", false, "return result in json")
-	createCmd.Flag("json").Annotations["silent"] = []string{"true"}
+	jsonFlag := createCmd.Flag("json")
+	if jsonFlag.Annotations == nil {
+		jsonFlag.Annotations = map[string][]string{}
+	}
+	jsonFlag.Annotations["silent"] = []string{"true"}
 
 	createCmd.Flags().VisitAll(config.BindFullyQualifiedFlag(createCmd))
 

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -21,13 +21,6 @@ func NewCmd() *cobra.Command {
 		Use:          "create",
 		Short:        "Creates a new Session",
 		SilenceUsage: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			/*
-				if json, _ := cmd.Flags().GetBool("json"); json {
-					cmd.Flags().Set("silent", "true")
-				}
-			*/
-		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return config.SyncFullyQualifiedFlags(cmd)
 		},
@@ -53,6 +46,7 @@ func NewCmd() *cobra.Command {
 		logger().Error(err, "failed while trying to hide a flag")
 	}
 	createCmd.Flags().Bool("json", false, "return result in json")
+	createCmd.Flag("json").Annotations["silent"] = []string{"true"}
 
 	createCmd.Flags().VisitAll(config.BindFullyQualifiedFlag(createCmd))
 

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
 	"github.com/maistra/istio-workspace/pkg/log"
+
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -1,11 +1,11 @@
 package delete
 
 import (
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
 	"github.com/maistra/istio-workspace/pkg/log"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
 	"github.com/maistra/istio-workspace/pkg/log"
@@ -8,7 +9,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.Log.WithValues("type", "delete")
+var logger = func() logr.Logger {
+	return log.Log.WithValues("type", "delete")
+}
 
 // NewCmd creates instance of "create" Cobra Command with flags and execution logic defined.
 func NewCmd() *cobra.Command {
@@ -34,7 +37,7 @@ func NewCmd() *cobra.Command {
 		"(defaults to default for the current context)")
 	deleteCmd.Flags().Bool("offline", false, "avoid calling external sources")
 	if err := deleteCmd.Flags().MarkHidden("offline"); err != nil {
-		logger.Error(err, "failed while trying to hide a flag")
+		logger().Error(err, "failed while trying to hide a flag")
 	}
 
 	deleteCmd.Flags().VisitAll(config.BindFullyQualifiedFlag(deleteCmd))

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/internal/session"
 
 	"github.com/maistra/istio-workspace/pkg/log"
@@ -25,7 +26,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.Log.WithValues("type", "develop")
+var logger = func() logr.Logger {
+	return log.Log.WithValues("type", "develop")
+}
 
 const urlHint = `Knowing your application url you can now access your new version by using
 
@@ -81,7 +84,7 @@ func NewCmd() *cobra.Command {
 			}()
 
 			if route, _ := session.ParseRoute(options.RouteExp); route != nil {
-				logger.Info(fmt.Sprintf(urlHint, route.Name, route.Value))
+				logger().Info(fmt.Sprintf(urlHint, route.Name, route.Value))
 			}
 
 			finalStatus := <-done
@@ -99,11 +102,11 @@ func NewCmd() *cobra.Command {
 	developCmd.Flags().StringSlice("watch-exclude", DefaultExclusions, fmt.Sprintf("list of patterns to exclude (always excludes %v)", DefaultExclusions))
 	developCmd.Flags().Int64("watch-interval", 500, "watch interval (in ms)")
 	if err := developCmd.Flags().MarkHidden("watch-interval"); err != nil {
-		logger.Error(err, "failed while trying to hide a flag")
+		logger().Error(err, "failed while trying to hide a flag")
 	}
 	developCmd.Flags().Bool("offline", false, "avoid calling external sources")
 	if err := developCmd.Flags().MarkHidden("offline"); err != nil {
-		logger.Error(err, "failed while trying to hide a flag")
+		logger().Error(err, "failed while trying to hide a flag")
 	}
 	developCmd.Flags().StringP("method", "m", "inject-tcp", "telepresence proxying mode - see https://www.telepresence.io/reference/methods")
 	developCmd.Flags().StringP("session", "s", "", "create or join an existing session")

--- a/pkg/cmd/develop/develop.go
+++ b/pkg/cmd/develop/develop.go
@@ -5,25 +5,18 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-logr/logr"
+	"github.com/maistra/istio-workspace/pkg/cmd/config"
+	"github.com/maistra/istio-workspace/pkg/cmd/internal/build"
+	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
 	"github.com/maistra/istio-workspace/pkg/internal/session"
-
 	"github.com/maistra/istio-workspace/pkg/log"
-
+	"github.com/maistra/istio-workspace/pkg/shell"
 	"github.com/maistra/istio-workspace/pkg/telepresence"
 
-	"github.com/maistra/istio-workspace/pkg/cmd/internal/build"
-
-	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
-
-	"github.com/spf13/pflag"
-
-	"github.com/maistra/istio-workspace/pkg/shell"
-
-	"github.com/maistra/istio-workspace/pkg/cmd/config"
-
 	gocmd "github.com/go-cmd/cmd"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var logger = func() logr.Logger {

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -5,24 +5,18 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-logr/logr"
+	"github.com/maistra/istio-workspace/pkg/client/dynclient"
 	"github.com/maistra/istio-workspace/pkg/log"
-
-	"k8s.io/client-go/tools/clientcmd"
-
+	"github.com/maistra/istio-workspace/pkg/openshift/parser"
 	"github.com/maistra/istio-workspace/version"
 
-	"github.com/maistra/istio-workspace/pkg/openshift/parser"
-
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"k8s.io/apimachinery/pkg/api/meta"
-
-	"github.com/maistra/istio-workspace/pkg/client/dynclient"
-
+	"github.com/go-logr/logr"
 	openshiftApi "github.com/openshift/api/template/v1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var logger = func() logr.Logger {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/completion"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	"github.com/maistra/istio-workspace/pkg/cmd/format"
@@ -17,7 +18,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-var logger = log.Log.WithValues("type", "root")
+var logger = func() logr.Logger {
+	return log.Log.WithValues("type", "root")
+}
 
 // NewCmd creates instance of root "ike" Cobra Command with flags and execution logic defined.
 func NewCmd() *cobra.Command {
@@ -30,6 +33,10 @@ func NewCmd() *cobra.Command {
 			"For detailed documentation please visit https://istio-workspace-docs.netlify.com/\n\n",
 		BashCompletionFunction: completion.BashCompletionFunc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if json, _ := cmd.Flags().GetBool("json"); json {
+				log.SetLogger(log.NilLog)
+				cmd.SilenceErrors = true
+			}
 			if v.Released() {
 				go func() {
 					latestRelease, _ := version.LatestRelease()
@@ -60,7 +67,7 @@ func NewCmd() *cobra.Command {
 				timer := time.NewTimer(2 * time.Second)
 				select {
 				case release := <-releaseInfo:
-					logger.Info(release)
+					logger().Info(release)
 				case <-timer.C:
 					// do nothing, just timeout
 				}
@@ -73,9 +80,10 @@ func NewCmd() *cobra.Command {
 		StringVarP(&configFile, "config", "c", ".ike.config.yaml",
 			fmt.Sprintf("config file (supported formats: %s)", strings.Join(config.SupportedExtensions(), ", ")))
 	rootCmd.Flags().Bool("version", false, "prints the version number of ike cli")
+	//rootCmd.PersistentFlags().Bool("silent", false, "silences the logger")
 	rootCmd.PersistentFlags().String("help-format", "standard", "prints help in asciidoc table")
 	if err := rootCmd.PersistentFlags().MarkHidden("help-format"); err != nil {
-		logger.Error(err, "failed while trying to hide a flag")
+		logger().Error(err, "failed while trying to hide a flag")
 	}
 
 	config.SetupConfig()

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/completion"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	"github.com/maistra/istio-workspace/pkg/cmd/format"
@@ -14,6 +13,7 @@ import (
 
 	v "github.com/maistra/istio-workspace/version"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -34,7 +34,6 @@ func NewCmd() *cobra.Command {
 			"For detailed documentation please visit https://istio-workspace-docs.netlify.com/\n\n",
 		BashCompletionFunction: completion.BashCompletionFunc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				if flag.Changed && strings.Join(flag.Annotations["silent"], "") == "true" {
 					log.SetLogger(log.NilLog)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -85,7 +85,6 @@ func NewCmd() *cobra.Command {
 		StringVarP(&configFile, "config", "c", ".ike.config.yaml",
 			fmt.Sprintf("config file (supported formats: %s)", strings.Join(config.SupportedExtensions(), ", ")))
 	rootCmd.Flags().Bool("version", false, "prints the version number of ike cli")
-	//rootCmd.PersistentFlags().Bool("silent", false, "silences the logger")
 	rootCmd.PersistentFlags().String("help-format", "standard", "prints help in asciidoc table")
 	if err := rootCmd.PersistentFlags().MarkHidden("help-format"); err != nil {
 		logger().Error(err, "failed while trying to hide a flag")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	v "github.com/maistra/istio-workspace/version"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -33,10 +34,14 @@ func NewCmd() *cobra.Command {
 			"For detailed documentation please visit https://istio-workspace-docs.netlify.com/\n\n",
 		BashCompletionFunction: completion.BashCompletionFunc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if json, _ := cmd.Flags().GetBool("json"); json {
-				log.SetLogger(log.NilLog)
-				cmd.SilenceErrors = true
-			}
+
+			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+				if flag.Changed && strings.Join(flag.Annotations["silent"], "") == "true" {
+					log.SetLogger(log.NilLog)
+					cmd.SilenceErrors = true
+				}
+			})
+
 			if v.Released() {
 				go func() {
 					latestRelease, _ := version.LatestRelease()

--- a/pkg/cmd/version/releases.go
+++ b/pkg/cmd/version/releases.go
@@ -17,7 +17,7 @@ func LatestRelease() (string, error) {
 	latestRelease, _, err := client.Repositories.
 		GetLatestRelease(context.Background(), "maistra", "istio-workspace")
 	if err != nil {
-		logger.Error(err, "unable to determine latest released version")
+		logger().Error(err, "unable to determine latest released version")
 		return "", err
 	}
 	return *latestRelease.Name, nil

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/version"
 
@@ -11,7 +12,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.Log.WithValues("type", "version")
+var logger = func() logr.Logger {
+	return log.Log.WithValues("type", "version")
+}
 
 // NewCmd creates version cmd which prints version and Build details of the executed binary.
 func NewCmd() *cobra.Command {
@@ -39,14 +42,14 @@ func NewCmd() *cobra.Command {
 }
 
 func logShortVersion() {
-	logger.Info(version.Version)
+	logger().Info(version.Version)
 }
 
 func LogVersion() {
-	logger.Info(fmt.Sprintf("Ike Version: %s", version.Version))
-	logger.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	logger.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	logger.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
-	logger.Info(fmt.Sprintf("Build Commit: %v", version.Commit))
-	logger.Info(fmt.Sprintf("Build Time: %v", version.BuildTime))
+	logger().Info(fmt.Sprintf("Ike Version: %s", version.Version))
+	logger().Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	logger().Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	logger().Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	logger().Info(fmt.Sprintf("Build Commit: %v", version.Commit))
+	logger().Info(fmt.Sprintf("Build Time: %v", version.BuildTime))
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/version"
 
+	"github.com/go-logr/logr"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/cobra"
 )

--- a/pkg/cmd/watch/watch.go
+++ b/pkg/cmd/watch/watch.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	"github.com/maistra/istio-workspace/pkg/cmd/develop"
 	"github.com/maistra/istio-workspace/pkg/cmd/internal/build"
@@ -15,7 +16,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger = log.Log.WithValues("type", "watch")
+var logger = func() logr.Logger {
+	return log.Log.WithValues("type", "watch")
+}
 
 // NewCmd creates watch command which observes file system changes in the defined set of directories
 // and re-runs build and run command when they occur.
@@ -38,7 +41,7 @@ func NewCmd() *cobra.Command {
 	watchCmd.Flags().StringSlice("exclude", develop.DefaultExclusions, "list of patterns to exclude (defaults to telepresence.log which is always excluded)")
 	watchCmd.Flags().Int64("interval", 500, "watch interval (in ms)")
 	if err := watchCmd.Flags().MarkHidden("interval"); err != nil {
-		logger.Error(err, "failed while trying to hide a flag")
+		logger().Error(err, "failed while trying to hide a flag")
 	}
 
 	return watchCmd

--- a/pkg/cmd/watch/watch.go
+++ b/pkg/cmd/watch/watch.go
@@ -3,7 +3,6 @@ package watch
 import (
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	"github.com/maistra/istio-workspace/pkg/cmd/develop"
 	"github.com/maistra/istio-workspace/pkg/cmd/internal/build"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	gocmd "github.com/go-cmd/cmd"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/log"
 
 	istiov1alpha1 "github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
@@ -28,7 +29,9 @@ const (
 )
 
 var (
-	logger = log.Log.WithValues("type", "controller")
+	logger = func() logr.Logger {
+		return log.Log.WithValues("type", "controller")
+	}
 )
 
 // DefaultManipulators contains the default config for the reconciler.
@@ -111,7 +114,7 @@ type ReconcileSession struct {
 // Reconcile reads that state of the cluster for a Session object and makes changes based on the state read
 // and what is in the Session.Spec.
 func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := logger.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger := logger().WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Session")
 
 	// Fetch the Session instance

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -3,15 +3,14 @@ package session
 import (
 	"context"
 
-	"github.com/go-logr/logr"
-	"github.com/maistra/istio-workspace/pkg/log"
-
 	istiov1alpha1 "github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
 	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/k8s"
+	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/openshift"
 
+	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/internal/session/session.go
+++ b/pkg/internal/session/session.go
@@ -6,14 +6,13 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/go-logr/logr"
 	istiov1alpha1 "github.com/maistra/istio-workspace/pkg/apis/istio/v1alpha1"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/naming"
 
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (

--- a/pkg/internal/session/session_client.go
+++ b/pkg/internal/session/session_client.go
@@ -42,26 +42,26 @@ func createDefaultClient(namespace string) (*client, error) {
 	var err error
 	restCfg, err := kubeCfg.ClientConfig()
 	if err != nil {
-		logger.Error(err, "failed to create default client")
+		logger().Error(err, "failed to create default client")
 		return nil, err
 	}
 
 	c, err := versioned.NewForConfig(restCfg)
 	if err != nil {
-		logger.Error(err, "failed to create default client")
+		logger().Error(err, "failed to create default client")
 		return nil, err
 	}
 
 	if namespace == "" {
 		namespace, _, err = kubeCfg.Namespace()
 		if err != nil {
-			logger.Error(err, "failed to create default client")
+			logger().Error(err, "failed to create default client")
 			return nil, err
 		}
 	}
 	defaultClient, err = NewClient(c, namespace)
 	if err != nil {
-		logger.Error(err, "failed to create default client")
+		logger().Error(err, "failed to create default client")
 		return nil, err
 	}
 	return defaultClient, nil

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,8 +15,11 @@ import (
 	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+// NilLog is an non logger logger
+var NilLog = zapr2.NewLogger(zap.New(zapcore.NewNopCore()))
+
 // Log is the central logger for this program.
-var Log = zapr2.NewLogger(zap.New(zapcore.NewNopCore()))
+var Log = NilLog
 
 // SetLogger sets the central logger to use.
 func SetLogger(logger logr.Logger) {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,7 +15,7 @@ import (
 	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// NilLog is an non logger logger.
+// NilLog is a no-op logger.
 var NilLog = zapr2.NewLogger(zap.New(zapcore.NewNopCore()))
 
 // Log is the central logger for this program.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,7 +15,7 @@ import (
 	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// NilLog is an non logger logger
+// NilLog is an non logger logger.
 var NilLog = zapr2.NewLogger(zap.New(zapcore.NewNopCore()))
 
 // Log is the central logger for this program.

--- a/pkg/shell/funcs.go
+++ b/pkg/shell/funcs.go
@@ -8,10 +8,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/log"
 
 	gocmd "github.com/go-cmd/cmd"
+	"github.com/go-logr/logr"
 )
 
 var logger = func() logr.Logger {

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/log"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
 	ignore "github.com/sabhiram/go-gitignore"
 )
 

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -7,13 +7,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/maistra/istio-workspace/pkg/log"
 
 	"github.com/fsnotify/fsnotify"
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
-var logger = log.Log.WithValues("type", "watch")
+var logger = func() logr.Logger {
+	return log.Log.WithValues("type", "watch")
+}
 
 // Handler allows to define how to react on file changes event.
 type Handler func(events []fsnotify.Event) error
@@ -43,25 +46,25 @@ func (w *Watch) Start() {
 					return
 				}
 				if w.Excluded(event.Name) {
-					logger.V(1).Info("file excluded. skipping change handling", "file", event.Name)
+					logger().V(1).Info("file excluded. skipping change handling", "file", event.Name)
 					continue
 				}
-				logger.V(1).Info("file changed", "file", event.Name, "op", event.Op.String())
+				logger().V(1).Info("file changed", "file", event.Name, "op", event.Op.String())
 				events[event.Name] = event
 			case err, ok := <-w.watcher.Errors:
 				if !ok {
 					return
 				}
-				logger.Error(err, "failed while watching")
+				logger().Error(err, "failed while watching")
 			case <-tick.C:
 				if len(events) == 0 {
 					continue
 				}
-				logger.V(1).Info("firing change event")
+				logger().V(1).Info("firing change event")
 				changes := extractEvents(events)
 				for _, handler := range w.handlers {
 					if err := handler(changes); err != nil {
-						logger.Error(err, "failed to handle file change!")
+						logger().Error(err, "failed to handle file change!")
 					}
 				}
 				events = make(map[string]fsnotify.Event)
@@ -96,7 +99,7 @@ func (w *Watch) Excluded(path string) bool {
 func (w *Watch) Close() {
 	w.done <- struct{}{}
 	if e := w.watcher.Close(); e != nil {
-		logger.Error(e, "failed closing watch")
+		logger().Error(e, "failed closing watch")
 	}
 }
 
@@ -129,7 +132,7 @@ func (w *Watch) addRecursiveWatch(filePath string) error {
 	}
 
 	for _, v := range folders {
-		logger.V(1).Info(fmt.Sprintf("adding watch on filePath %s", v))
+		logger().V(1).Info(fmt.Sprintf("adding watch on filePath %s", v))
 		err = w.addPath(v)
 		if err != nil {
 			// "no space left on device" issues are usually resolved via

--- a/pkg/watch/watch_builder.go
+++ b/pkg/watch/watch_builder.go
@@ -40,7 +40,7 @@ func (wb *Builder) Excluding(exclusions ...string) *Builder {
 func (wb *Builder) OnPaths(paths ...string) (watch *Watch, err error) {
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		logger.Error(err, "failed creating fs watch")
+		logger().Error(err, "failed creating fs watch")
 		return nil, err
 	}
 


### PR DESCRIPTION

`ike create -i x::z -d reviews-v1 --json`
```json
{
  "name": "reviews-v1",
  "strategy": "prepared-image",
  "args": {
    "image": "x::z"
  },
  "targets": [
    {
      "kind": "Deployment",
      "name": "reviews-v1",
      "action": "located",
      "labels": {
        "app": "reviews",
        "version": "v1"
      }
    },
    {
      "kind": "Service",
      "name": "reviews",
      "action": "located",
      "labels": {
        "app": "reviews"
      }
    },
    {
      "kind": "Gateway",
      "name": "test-gateway",
      "action": "located",
      "labels": {
        "ike.hosts": "aslak.test.io"
      }
    }
  ],
  "resources": [
    {
      "kind": "Deployment",
      "name": "reviews-v1-v1-aslak-iphps",
      "action": "created"
    },
    {
      "kind": "DestinationRule",
      "name": "reviews",
      "action": "modified"
    },
    {
      "kind": "Gateway",
      "name": "test-gateway",
      "action": "modified",
      "prop": {
        "hosts": "aslak-iphps.aslak.test.io"
      }
    },
    {
      "kind": "VirtualService",
      "name": "reviews",
      "action": "modified"
    },
    {
      "kind": "VirtualService",
      "name": "productpage-aslak-iphps",
      "action": "created"
    }
  ]
}
```

`ike version`
```
Ike Version: v0.0.3-next-e1cc2c2
Go Version: go1.13
Go OS/Arch: linux/amd64
operator-sdk Version: v0.17.1
Build Commit: e1cc2c2
Build Time: 2020-07-06T12:46:36Z
```
Related to #240