### PR TITLE
fix(test): propagate the default route header

### DIFF
--- a/test/cmd/test-service/propagation.go
+++ b/test/cmd/test-service/propagation.go
@@ -8,4 +8,5 @@ var propagationHeaders = []string{
 	"x-b3-sampled",
 	"x-b3-flags",
 	"x-ot-span-context",
-	"x-test-suite"}
+	"x-test-suite",
+	"x-workspace-route"}


### PR DESCRIPTION
The testservice should support to propagate the default header name used
by the operator if no route is given on cli.