### PR TITLE
fix: temp directory creation in get-ike for OSX

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -102,7 +102,13 @@ test -z "$version" && version="$(last_version)"
 test -z "$version" && {
   die "Unable to get ike version. You can still try to download it manually from $RELEASES_URL."
 }
-test -z "$dir" &&  dir="$(mktemp -d --suffix=-ike-${version})"
+test -z "$dir" && {
+  if [ "$(uname)" == "Darwin" ]; then
+    dir="$(mktemp -d -t ike-${version}-)"
+  else
+    dir="$(mktemp -d --suffix=-ike-${version})"
+  fi
+}
 
 download "${version}"
 tar -C "$dir" -xzf "$TAR_FILE" ike


### PR DESCRIPTION
#### Short description of what this resolves:
The get-ike script, when ran without the `--dir` option, doesn't seem to run on my OSX Mojave, and probably also not on Catalina, as it calls `mktemp --suffix`.
Instead of that `mktemp` on OSX takes an option `-t` that defines a prefix for the temporary name:

```
# curl -sL http://git.io/get-ike | bash
mktemp: illegal option -- -
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix
```


#### Changes proposed in this pull request:

This PR tries to fix this by calling `mktemp -t` instead of `mktemp --suffix` on Mac.


Fixes #
