### PR TITLE
feat(operator): add 'existing' strategy

### DIFF
--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -56,6 +56,10 @@ func DeploymentMutator(ctx model.SessionContext, ref *model.Ref) error {
 	}
 	ctx.Log.Info("Found Deployment", "name", deployment.Name)
 
+	if ref.Strategy == model.StrategyExisting {
+		return nil
+	}
+
 	deploymentClone, err := cloneDeployment(deployment.DeepCopy(), ref, ref.GetNewVersion(ctx.Name))
 	if err != nil {
 		ctx.Log.Info("Failed to clone Deployment", "name", deployment.Name)

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		Context("telepresence mutations", func() {
+		Context("telepresence mutation strategy", func() {
 
 			It("should change container to telepresence", func() {
 				ref := CreateTestRef()
@@ -198,6 +198,21 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
 
+		})
+
+		Context("existing mutation strategy", func() {
+
+			It("should not create a clone", func() {
+				ref := CreateTestRef()
+				ref.Strategy = model.StrategyExisting
+
+				mutatorErr := k8s.DeploymentMutator(ctx, &ref)
+				Expect(mutatorErr).ToNot(HaveOccurred())
+
+				_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
 		})
 
 	})

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -8,6 +8,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// StrategyExisting holds the name of the existing strategy
+	StrategyExisting = "existing"
+)
+
 // SessionContext holds the context for a single session object, giving access to key things like REST Client and target Namespace.
 type SessionContext struct {
 	context.Context

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -60,6 +60,10 @@ func DeploymentConfigMutator(ctx model.SessionContext, ref *model.Ref) error {
 	}
 	ctx.Log.Info("Found DeploymentConfig", "name", deployment.Name)
 
+	if ref.Strategy == model.StrategyExisting {
+		return nil
+	}
+
 	deploymentClone, err := cloneDeployment(deployment.DeepCopy(), ref, ref.GetNewVersion(ctx.Name))
 	if err != nil {
 		ctx.Log.Info("Failed to clone DeploymentConfig", "name", deployment.Name)

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		Context("telepresence mutations", func() {
+		Context("telepresence mutation strategy", func() {
 
 			It("should change container to telepresence", func() {
 				ref := CreateTestRef()
@@ -206,6 +206,21 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
 
+		})
+
+		Context("existing mutation strategy", func() {
+
+			It("should not create a clone", func() {
+				ref := CreateTestRef()
+				ref.Strategy = model.StrategyExisting
+
+				mutatorErr := openshift.DeploymentConfigMutator(ctx, &ref)
+				Expect(mutatorErr).ToNot(HaveOccurred())
+
+				_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
 		})
 
 	})


### PR DESCRIPTION
A strategy to bypass the 'clone' operation. Intended to be used to route
traffic directly to an existing deployment.

Fixes #527