### PR TITLE
feat(client): make client wait condition configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
       - run:
           name: Launch Microk8s
           command: |
-            sudo snap install microk8s --classic --channel 1.19/candidate
+            sudo snap install microk8s --classic --channel 1.19/stable
 
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig

--- a/pkg/internal/session/session.go
+++ b/pkg/internal/session/session.go
@@ -43,10 +43,7 @@ func (o *Options) ConditionFound(res *istiov1alpha1.RefResource) bool {
 }
 
 func defaultWaitCondition(res *istiov1alpha1.RefResource) bool {
-	if *res.Kind == "Deployment" || *res.Kind == "DeploymentConfig" {
-		return true
-	}
-	return false
+	return *res.Kind == "Deployment" || *res.Kind == "DeploymentConfig" 
 }
 
 // State holds the new variables as presented by the creation of the session.

--- a/pkg/internal/session/session.go
+++ b/pkg/internal/session/session.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	istiov1alpha1 "github.com/maistra/istio-workspace/pkg/apis/maistra/v1alpha1"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/naming"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -43,7 +44,7 @@ func (o *Options) ConditionFound(res *istiov1alpha1.RefResource) bool {
 }
 
 func defaultWaitCondition(res *istiov1alpha1.RefResource) bool {
-	return *res.Kind == "Deployment" || *res.Kind == "DeploymentConfig" 
+	return *res.Kind == "Deployment" || *res.Kind == "DeploymentConfig"
 }
 
 // State holds the new variables as presented by the creation of the session.


### PR DESCRIPTION
In a normal cli setting, we're looking for a Deployment or a DeploymentConfig,
but with the che integration, the Deployment already exists so we need to be
able to wait for something else.

related to #528