### PR TITLE
fix: sets registry to internal before running operator tests

### DIFF
--- a/e2e/infra/image_registry.go
+++ b/e2e/infra/image_registry.go
@@ -10,7 +10,7 @@ import (
 
 const ImageRepo = "istio-workspace-images"
 
-func setDockerRegistryExternal() string {
+func SetDockerRegistryExternal() string {
 	registry := "default-route-openshift-image-registry." + GetClusterHost()
 	if externalRegistry, found := os.LookupEnv("IKE_EXTERNAL_DOCKER_REGISTRY"); found {
 		registry = externalRegistry
@@ -19,7 +19,7 @@ func setDockerRegistryExternal() string {
 	return registry
 }
 
-func setDockerRegistryInternal() {
+func SetDockerRegistryInternal() {
 	setDockerRegistry(GetDockerRegistryInternal())
 }
 

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -13,7 +13,7 @@ import (
 func BuildOperator() (registry string) {
 	projectDir := shell.GetProjectDir()
 	namespace := setOperatorNamespace()
-	registry = setDockerRegistryExternal()
+	registry = SetDockerRegistryExternal()
 	setDockerRepository(ImageRepo)
 	<-shell.Execute(NewProjectCmd(namespace)).Done()
 	EnablePullingImages(namespace)
@@ -25,7 +25,7 @@ func BuildOperator() (registry string) {
 }
 
 func InstallLocalOperator(namespace string) {
-	setDockerRegistryInternal()
+	SetDockerRegistryInternal()
 	<-shell.Execute("ike install-operator -l -n " + namespace).Done()
 }
 

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -15,7 +15,7 @@ import (
 func BuildTestService() (registry string) {
 	projectDir := shell.GetProjectDir()
 	setTestNamespace(ImageRepo)
-	registry = setDockerRegistryExternal()
+	registry = SetDockerRegistryExternal()
 	if RunsAgainstOpenshift {
 		<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u "+user+" -p $(oc whoami -t) "+registry).Done()
 	}
@@ -27,7 +27,7 @@ func BuildTestService() (registry string) {
 func BuildTestServicePreparedImage(callerName string) (registry string) {
 	projectDir := shell.GetProjectDir()
 	setTestNamespace(ImageRepo)
-	registry = setDockerRegistryExternal()
+	registry = SetDockerRegistryExternal()
 
 	os.Setenv("IKE_TEST_PREPARED_NAME", callerName)
 	if RunsAgainstOpenshift {
@@ -40,7 +40,7 @@ func BuildTestServicePreparedImage(callerName string) (registry string) {
 // DeployTestScenario deploys a test scenario into the specified namespace.
 func DeployTestScenario(scenario, namespace string) {
 	projectDir := shell.GetProjectDir()
-	setDockerRegistryInternal()
+	SetDockerRegistryInternal()
 	setDockerEnvForTestServiceDeploy(namespace)
 	if RunsAgainstOpenshift {
 		<-shell.ExecuteInDir(".", "bash", "-c",

--- a/e2e/operator_installation_test.go
+++ b/e2e/operator_installation_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Operator Installation Tests", func() {
 			projectName = strings.ReplaceAll(projectName, "should", "ike")
 			<-testshell.Execute(NewProjectCmd(projectName)).Done()
 			EnablePullingImages(projectName)
+			SetDockerRegistryInternal()
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
#### Short description of what this resolves:

Depending on the tests order it might happen that repo we pull images from points to the wrong one, as it's based on ENV var which we set during the build and test execution from external URL to internal one.

#### Changes proposed in this pull request:

- Sets internal repo before operator tests
