### PR TITLE
Install cmd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,13 +193,13 @@ jobs:
       - run:
           name: Install official kubectl
           command: |
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0-rc.4/bin/linux/amd64/kubectl
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.9/bin/linux/amd64/kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - run:
           name: Launch Microk8s
           command: |
-            sudo snap install microk8s --classic --channel 1.19/stable
+            sudo snap install microk8s --classic --channel 1.18/stable
 
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig

--- a/README.adoc
+++ b/README.adoc
@@ -43,14 +43,14 @@ When logged in to the cluster run the following for a cluster wide operator:
 
 [source,bash]
 ----
-ike install-operator
+ike install
 ----
 
 or if you only want to install the operator for a single namespace run:
 
 [source,bash]
 ----
-ike install-operator -l
+ike install -l
 ----
 
 And you are all set!

--- a/docs/modules/ROOT/pages/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/cli_reference.adoc
@@ -2,8 +2,8 @@
 
 In this section you will learn about:
 
-* [x] ways to configure `ike` (through flags, files et al)
-* [x] complete list of commands and their available flags
+* [x] ways to configure `ike` (through flags, files et al.)
+* [x] complete list of commands, and their available flags
 
 [#completion]
 == Autocomplete
@@ -50,23 +50,24 @@ Main command, which holds global flags and prints the overall usage of the tool.
 
 include::cmd:ike[flags='--help --help-format=adoc']
 
-[#ike-install-operator]
-=== `ike install-operator`
+[#ike-install]
+=== `ike install`
 
-Simple installation process of the operator in the cluster. 
+Simple installation process of the istio-workspace in the cluster. 
 
 IMPORTANT: Connection configuration is taken from `KUBECONFIG` context. 
 It's important to have user with sufficient privileges. 
 In case of OpenShift you can add `cluster-user` role for your user by executing 
 `oc adm policy add-cluster-role-to-user cluster-admin USER`. 
 
-include::cmd:ike[flags='install-operator --help --help-format=adoc']
+include::cmd:ike[flags='install --help --help-format=adoc']
 
 [#ike-serve]
 === `ike serve`
 
-Starts the operator in the cluster.
-// TODO brief mention about operator and how it works + link to the dedicated docs
+Starts the controller in the cluster.
+
+// TODO briefly mention operator and how it works + link to the dedicated docs
 
 include::cmd:ike[flags='serve --help --help-format=adoc']
 

--- a/docs/modules/ROOT/pages/contribution_guide.adoc
+++ b/docs/modules/ROOT/pages/contribution_guide.adoc
@@ -55,7 +55,7 @@ TIP: Run `make help` to see what other targets are available.
 
 === Testing
 
-Unit tests are executed when using default `make` target. When developing you can also use https://onsi.github.io/ginkgo/#watching-for-changes[`ginkgo watch`] so they are ran whenever the change in the code occur. This makes feedback loop faster.
+The default `make` target executes unit tests. When developing you can also use https://onsi.github.io/ginkgo/#watching-for-changes[`ginkgo watch`] so they are ran whenever the change in the code occur. This makes feedback loop faster.
 
 We also have end-to-end tests (`make test-e2e`) for which you need to have Kubernetes cluster with Istio installed. 
 

--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -13,7 +13,7 @@ In this section we walk you through necessary steps to start using `ike`. It wil
 
 Run `curl -sL http://git.io/get-ike | bash` to get latest `ike` binary.
 
-TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.1 --dir=/usr/bin`
+TIP: You can also specify the version and directory before downloading `curl -sL http://git.io/get-ike | bash -s \-- --version=v0.0.3 --dir=/usr/bin`
 
 Here are all available flags of this installation script
 
@@ -29,14 +29,14 @@ If you want to install the operator cluster wide run:
 
 [source,bash]
 ----
-ike install-operator
+ike install
 ----
 
-Or if you only want to install it for a single Namespace:
+Or if you only want to install it for a single NAMESPACE:
 
 [source,bash]
 ----
-ike install-operator -l
+ike install -l -n NAMESPACE
 ----
 
 NOTE: The images are available in our Quay repository https://quay.io/repository/maistra/istio-workspace?tab=tags 
@@ -57,13 +57,13 @@ Now you have process based on your local code base which proxies connections fro
 
 Let's break it down to see what is going on under the hood:
 
-<1> Name of the `Deployment` or `DeploymentConfig` you want to work with
-<2> exposed port of the service
-<3> whether to watch changes in the file system and re-run the process when they occur
-<4> command to run 
-<5> route differentiation based on which the traffic will be directed to your forked service
+<1> Name of the `Deployment` or `DeploymentConfig` you want to work with.
+<2> Exposed port of the service.
+<3> Whether to watch changes in the file system and re-run the process when they occur.
+<4> Command to run. 
+<5> Route differentiation based on which the traffic will be directed to your forked service.
 
-// TIP: All command line flags can also be persisted in the configuration file and shared in the project. For more details jump to configuration section.
+TIP: All command line flags can also be persisted in the configuration file and shared as part of the project. Jump to xref:cli_reference.adoc#configuration[configuration section] for more details.
 
 
 // TODO add screencast showing the basic flow

--- a/docs/modules/ROOT/pages/release_notes/v0.0.2.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.2.adoc
@@ -18,7 +18,7 @@ a companion command `delete` to clean up when e.g. PR is merged.
 
 Now you also can deploy operator to your local namespace, so where your project lives. This way only your namespace is watched.
 
-Simply invoke `ike install-operator -l`
+Simply invoke `ike install -l`
 
 To learn more head over to the https://istio-workspace-docs.netlify.com/istio-workspace/v0.0.2/index.html[official docs].
 

--- a/e2e/bash_completion_test.go
+++ b/e2e/bash_completion_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Bash Completion Tests", func() {
 
 		It("should show all visible main commands", func() {
 			completionResults := completionFor("ike ")
-			Expect(completionResults).To(ConsistOf("completion", "develop", "install-operator", "serve", "version", "create", "delete"))
+			Expect(completionResults).To(ConsistOf("completion", "develop", "install", "serve", "version", "create", "delete"))
 		})
 
 		Context("develop", func() {
@@ -33,14 +33,14 @@ var _ = Describe("Bash Completion Tests", func() {
 			})
 		})
 
-		Context("install-operator", func() {
+		Context("install", func() {
 
 			It("should show matching command", func() {
-				Expect(completionFor("ike install-")).To(ConsistOf("install-operator"))
+				Expect(completionFor("ike ins")).To(ConsistOf("install"))
 			})
 
 			It("should show all flags inherited from root", func() {
-				Expect(completionFor("ike install-operator -")).To(ConsistOf(
+				Expect(completionFor("ike install -")).To(ConsistOf(
 					"--config", "--config=", "-c", "--local", "-l", "--namespace", "--namespace=", "-n"))
 			})
 		})

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -26,7 +26,7 @@ func BuildOperator() (registry string) {
 
 func InstallLocalOperator(namespace string) {
 	SetDockerRegistryInternal()
-	<-shell.Execute("ike install-operator -l -n " + namespace).Done()
+	<-shell.Execute("ike install -l -n " + namespace).Done()
 }
 
 func setOperatorNamespace() (namespace string) {

--- a/e2e/operator_installation_test.go
+++ b/e2e/operator_installation_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Operator Installation Tests", func() {
 
 		It("should install into specified namespace", func() {
 			// when
-			<-testshell.Execute("ike install-operator -l -n " + projectName).Done()
+			<-testshell.Execute("ike install -l -n " + projectName).Done()
 
 			// then
 			Eventually(AllPodsReady(projectName), 5*time.Minute, 5*time.Second).Should(BeTrue())
@@ -65,7 +65,7 @@ var _ = Describe("Operator Installation Tests", func() {
 			ChangeNamespace(projectName)
 
 			// when
-			<-testshell.Execute("ike install-operator --local").Done()
+			<-testshell.Execute("ike install --local").Done()
 
 			// then
 			Eventually(AllPodsReady(projectName), 5*time.Minute, 5*time.Second).Should(BeTrue())

--- a/pkg/cmd/install/install.go
+++ b/pkg/cmd/install/install.go
@@ -26,7 +26,7 @@ var logger = func() logr.Logger {
 // NewCmd takes care of deploying server-side components of istio-workspace.
 func NewCmd() *cobra.Command {
 	installCmd := &cobra.Command{
-		Use:          "install-operator",
+		Use:          "install",
 		Short:        "Takes care of deploying server-side components of istio-workspace",
 		SilenceUsage: true,
 		RunE:         installOperator,


### PR DESCRIPTION
#### Short description of what this resolves:

Renames `ike install-operator` to `ike install`.

#### Changes proposed in this pull request:

- Code changes 
- Docs adjustments
- Fixed version of `microk8s` to `1.18.9`, as `1.19/stable` is now on `1.19.2` causing our setup to fail

Fixes #541
