### PR TITLE
fix(test-infra): updates github action commands in linter

### DIFF
--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -17,8 +17,8 @@ jobs:
           go-version: 1.14.4
       - name: Set $GOPATH
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}/go"
-          echo "::add-path::${{ github.workspace }}/go/bin"
+          echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
         shell: bash
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -11,10 +11,10 @@ jobs:
     env:
       REPOSITORY: ${{ github.repository }}
     steps:
-      - name: Set up Go 1.14.4
+      - name: Set up Go 1.15.2
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.2
       - name: Set $GOPATH
         run: |
           echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
@@ -37,7 +37,7 @@ jobs:
           cd $GOPATH/src/github.com/${{ env.REPOSITORY }}
           make lint-prepare
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.28
           working-directory: ${{ env.GOPATH }}/src/github.com/${{ env.REPOSITORY }}


### PR DESCRIPTION
Error: Unable to process command '::set-env name=GOPATH::/home/runner/work/istio-workspace/istio-workspace/go' successfully.
Error: Unable to process command '::add-path::/home/runner/work/istio-workspace/istio-workspace/go/bin' successfully.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/