### PR TITLE
feat(test-infra): support running test suit on prebuilt images

### DIFF
--- a/e2e/error_path_test.go
+++ b/e2e/error_path_test.go
@@ -38,10 +38,7 @@ var _ = Describe("Smoke End To End Tests - Faulty scenarios", func() {
 
 			<-testshell.Execute(NewProjectCmd(namespace)).Done()
 
-			if RunsAgainstOpenshift {
-				UpdateSecurityConstraintsFor(namespace)
-				EnablePullingImages(namespace)
-			}
+			PrepareEnv(namespace)
 			InstallLocalOperator(namespace)
 		})
 

--- a/e2e/infra/cluster_setup.go
+++ b/e2e/infra/cluster_setup.go
@@ -24,8 +24,8 @@ func UpdateSecurityConstraintsFor(namespace string) {
 }
 
 func EnablePullingImages(namespace string) {
-	<-shell.Execute("oc policy add-role-to-user system:image-puller system:serviceaccount:" + namespace + ":default -n " + ImageRepo).Done()
-	<-shell.Execute("oc policy add-role-to-user system:image-puller system:serviceaccount:" + namespace + ":istio-workspace -n " + ImageRepo).Done()
+	<-shell.Execute("oc policy add-role-to-user system:image-puller system:serviceaccount:" + namespace + ":default -n " + GetRepositoryName()).Done()
+	<-shell.Execute("oc policy add-role-to-user system:image-puller system:serviceaccount:" + namespace + ":istio-workspace -n " + GetRepositoryName()).Done()
 }
 
 var (
@@ -47,7 +47,7 @@ func LoginAsTestPowerUser() {
 		srv = server
 	}
 
-	<-shell.ExecuteInDir(".", "bash", "-c", "oc login "+srv+" -u "+user+" -p "+pwd+" --insecure-skip-tls-verify=true").Done()
+	<-shell.ExecuteInDir(".", "oc", "login", srv, "-u", user, "-p", pwd, "--insecure-skip-tls-verify=true").Done()
 }
 
 // GetEvents returns all events which occurred for a given namespace.
@@ -67,5 +67,20 @@ func DumpTelepresenceLog(dir string) {
 	_, err = io.Copy(os.Stdout, fh)
 	if err != nil {
 		fmt.Println(err)
+	}
+}
+
+// UsePrebuiltImages returns true if test suite should use images that are built outside of the test execution flow.
+func UsePrebuiltImages() bool {
+	return os.Getenv("PRE_BUILT_IMAGES") != ""
+}
+
+// PrepareEnv sets up a enviromental specific things.
+func PrepareEnv(namespace string) {
+	if RunsAgainstOpenshift {
+		UpdateSecurityConstraintsFor(namespace)
+		if !UsePrebuiltImages() {
+			EnablePullingImages(namespace)
+		}
 	}
 }

--- a/e2e/infra/cluster_setup.go
+++ b/e2e/infra/cluster_setup.go
@@ -75,7 +75,7 @@ func UsePrebuiltImages() bool {
 	return os.Getenv("PRE_BUILT_IMAGES") != ""
 }
 
-// PrepareEnv sets up a enviromental specific things.
+// PrepareEnv sets up a environmental specific things.
 func PrepareEnv(namespace string) {
 	if RunsAgainstOpenshift {
 		UpdateSecurityConstraintsFor(namespace)

--- a/e2e/infra/image_registry.go
+++ b/e2e/infra/image_registry.go
@@ -8,7 +8,14 @@ import (
 	"github.com/onsi/gomega"
 )
 
-const ImageRepo = "istio-workspace-images"
+// GetRepositoryName returns the name of the repository http://host/repository-name/image-name:tag
+func GetRepositoryName() string {
+	if UsePrebuiltImages() {
+		return os.Getenv("IKE_DOCKER_REPOSITORY")
+	}
+	// used to reuse images pushed to a single namespace to avoid rebuilding pr test
+	return "istio-workspace-images"
+}
 
 func SetDockerRegistryExternal() string {
 	registry := "default-route-openshift-image-registry." + GetClusterHost()

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -14,7 +14,7 @@ func BuildOperator() (registry string) {
 	projectDir := shell.GetProjectDir()
 	namespace := setOperatorNamespace()
 	registry = SetDockerRegistryExternal()
-	setDockerRepository(ImageRepo)
+	setDockerRepository(GetRepositoryName())
 	<-shell.Execute(NewProjectCmd(namespace)).Done()
 	EnablePullingImages(namespace)
 	if RunsAgainstOpenshift {

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -14,7 +14,7 @@ import (
 // BuildTestService builds istio-workspace-test service and pushes it to specified registry.
 func BuildTestService() (registry string) {
 	projectDir := shell.GetProjectDir()
-	setTestNamespace(ImageRepo)
+	setTestNamespace(GetRepositoryName())
 	registry = SetDockerRegistryExternal()
 	if RunsAgainstOpenshift {
 		<-shell.ExecuteInDir(".", "bash", "-c", "docker login -u "+user+" -p $(oc whoami -t) "+registry).Done()
@@ -26,7 +26,7 @@ func BuildTestService() (registry string) {
 // BuildTestServicePreparedImage builds istio-workspace-test-prepared service and pushes it to specified registry.
 func BuildTestServicePreparedImage(callerName string) (registry string) {
 	projectDir := shell.GetProjectDir()
-	setTestNamespace(ImageRepo)
+	setTestNamespace(GetRepositoryName())
 	registry = SetDockerRegistryExternal()
 
 	os.Setenv("IKE_TEST_PREPARED_NAME", callerName)

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -38,10 +38,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 
 			<-testshell.Execute(NewProjectCmd(namespace)).Done()
 
-			if RunsAgainstOpenshift {
-				UpdateSecurityConstraintsFor(namespace)
-				EnablePullingImages(namespace)
-			}
+			PrepareEnv(namespace)
 
 			InstallLocalOperator(namespace)
 			DeployTestScenario(scenario, namespace)
@@ -110,7 +107,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--deployment", "ratings-v1",
 							"-n", namespace,
 							"--route", "header:x-test-suite=smoke",
-							"--image", registry+"/"+ImageRepo+"/istio-workspace-test-prepared-"+PreparedImageV1+":latest",
+							"--image", registry+"/"+GetRepositoryName()+"/istio-workspace-test-prepared-"+PreparedImageV1+":latest",
 							"--session", sessionName,
 						)
 						Eventually(ike1.Done(), 1*time.Minute).Should(BeClosed())
@@ -130,7 +127,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 							"--deployment", "ratings-v1",
 							"-n", namespace,
 							"--route", "header:x-test-suite=smoke",
-							"--image", registry+"/"+ImageRepo+"/istio-workspace-test-prepared-"+PreparedImageV2+":latest",
+							"--image", registry+"/"+GetRepositoryName()+"/istio-workspace-test-prepared-"+PreparedImageV2+":latest",
 							"--session", sessionName,
 						)
 						Eventually(ike2.Done(), 1*time.Minute).Should(BeClosed())


### PR DESCRIPTION
Set `PRE_BUILT_IMAGES` to non-empty to control this behavior.

Control where the images are found by setting
* `IKE_INTERNAL_DOCKER_REGISTRY`
* `IKE_EXTERNAL_DOCKER_REGISTRY`
* `IKE_IMAGE_TAG`
* `IKE_DOCKER_REPOSITORY`
* `IKE_IMAGE_NAME`, `IKE_TEST_IMAGE_NAME`, `IKE_TEST_PREPARED_IMAGE_NAME`, `IKE_TEST_PREPARED_NAME`

Fixes #568 