### PR TITLE
feat(gh-action): cleans up pr images on pr close

### DIFF
--- a/.github/workflows/cleanup_pr_images.yml
+++ b/.github/workflows/cleanup_pr_images.yml
@@ -1,0 +1,19 @@
+name: cleanup-images
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  cleanup-images:
+    name: quay-image-cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete PR-related images
+        env:
+          QUAY_OAUTH_TOKEN: ${{ secrets.QUAY_OAUTH_TOKEN }}
+        run: |
+          curl -H "Authorization: Bearer ${QUAY_OAUTH_TOKEN}" -X DELETE https://quay.io/api/v1/repository/maistra/istio-workspace/tag/PR-${{ github.event.number }}
+          curl -H "Authorization: Bearer ${QUAY_OAUTH_TOKEN}" -X DELETE https://quay.io/api/v1/repository/maistra/istio-workspace-test/tag/PR-${{ github.event.number }}
+          curl -H "Authorization: Bearer ${QUAY_OAUTH_TOKEN}" -X DELETE https://quay.io/api/v1/repository/maistra/ istio-workspace-test-prepared-image-prepared/tag/PR-${{ github.event.number }}
+          curl -H "Authorization: Bearer ${QUAY_OAUTH_TOKEN}" -X DELETE https://quay.io/api/v1/repository/maistra/stio-workspace-test-prepared-prepared-image/tag/PR-${{ github.event.number }}
+        shell: bash


### PR DESCRIPTION
#### Short description of what this resolves:

When PR is merged/closed we don't need its images in quay any longer. This action will take care of the cleanup

Related to #563 
