### PR TITLE
fix: refers to PR head ref branch name for image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
               IKE_EXTERNAL_DOCKER_REGISTRY=quay.io
 
             if [ -z ${CIRCLE_PULL_REQUEST+x} ]; then
-              export IKE_IMAGE_TAG="${CIRCLE_BRANCH}"
+              export IKE_IMAGE_TAG="${CIRCLE_BRANCH##*/}"
             else
               export IKE_IMAGE_TAG="pr-${CIRCLE_PULL_REQUEST##*/}-circle"
             fi

--- a/.github/workflows/cleanup_pr_images.yml
+++ b/.github/workflows/cleanup_pr_images.yml
@@ -14,12 +14,14 @@ jobs:
           REPOSITORY: "https://quay.io/api/v1/repository/maistra"
           DEV_REPOSITORY: "https://quay.io/api/v1/repository/maistra-dev"
           TAG: "pr-${{ github.event.number }}"
+          HEAD_REF: "${{ github.event.pull_request.head.ref }}"
         run: |
           HEADER_TOKEN="Authorization: Bearer ${QUAY_OAUTH_TOKEN}"
-
+          TARGET_BRANCH=$(echo "${HEAD_REF}" | rev | cut -d'/' -f 1 | rev)
+          
           ## We create images for PRs on Prow and Circle, but Circle also runs builds when there's a branch only,
           ## thus we might need to clean-up images tagged after the branch
-          declare -a tags=("${TAG}-prow" "${TAG}-circle" "${{ github.event.ref }}")
+          declare -a tags=("${TAG}-prow" "${TAG}-circle" "${TARGET_BRANCH}")
           for t in "${tags[@]}"
           do
              curl -H "${HEADER_TOKEN}" -X DELETE ${REPOSITORY}/istio-workspace/tag/${t} || true

--- a/.github/workflows/cleanup_pr_images.yml
+++ b/.github/workflows/cleanup_pr_images.yml
@@ -17,11 +17,10 @@ jobs:
           HEAD_REF: "${{ github.event.pull_request.head.ref }}"
         run: |
           HEADER_TOKEN="Authorization: Bearer ${QUAY_OAUTH_TOKEN}"
-          TARGET_BRANCH=$(echo "${HEAD_REF}" | rev | cut -d'/' -f 1 | rev)
-          
+
           ## We create images for PRs on Prow and Circle, but Circle also runs builds when there's a branch only,
           ## thus we might need to clean-up images tagged after the branch
-          declare -a tags=("${TAG}-prow" "${TAG}-circle" "${TARGET_BRANCH}")
+          declare -a tags=("${TAG}-prow" "${TAG}-circle" "${HEAD_REF##*/}")
           for t in "${tags[@]}"
           do
              curl -H "${HEADER_TOKEN}" -X DELETE ${REPOSITORY}/istio-workspace/tag/${t} || true


### PR DESCRIPTION
#### Short description of what this resolves:

Uses branch name extracted from GH PR event on cleanup

#### Changes proposed in this pull request:

- yaml shenanigans 
