### PR TITLE
fix(circle): tree hash propagates properly to avoid redundant job runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,12 @@ defaults:
   check-if-build-executed: &check-if-build-executed
     name: "Check if build with this content was already executed"
     command: |
-      if [[ -f ${CIRCLE_JOB}.githash ]]; then
+      if [[ -f "${CIRCLE_JOB}".githash ]]; then
         echo "This exact code base has been successfully built"
         circleci step halt
       else
         echo "New build - if succeeds build git hash will be cached"
-        echo "${TREE_SHA1}" > ${CIRCLE_JOB}.githash
+        echo "${TREE_SHA1}" > "${CIRCLE_JOB}".githash
       fi
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
@@ -83,11 +83,22 @@ jobs:
     steps:
       - checkout
       - run:
-          <<: *obtain-tree-hash
+          name: "Obtain git tree hash"
+          command: |
+            echo "export TREE_SHA1=$(git rev-parse HEAD:)" >> $BASH_ENV
+            echo ${TREE_SHA1} > /tmp/tree.sha1
       - restore_cache:
           <<: *restore-tree-hash
       - run:
-          <<: *check-if-build-executed
+          name: "Check if build with this content was already executed"
+          command: |
+            if [[ -f "${CIRCLE_JOB}".githash ]]; then
+              echo "This exact code base has been successfully built"
+              circleci step halt
+            else
+              echo "New build - if succeeds build git hash will be cached"
+              echo "${TREE_SHA1}" > "${CIRCLE_JOB}".githash
+            fi
       - run:
           <<: *skip-e2e-check
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,8 @@ jobs:
   build:
     docker:
       - image: *golang-img
+    environment:
+      BUILD_CACHE_FOLDER: ".circleci/cache"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ defaults:
   obtain-tree-hash: &obtain-tree-hash
     name: "Obtain git tree hash"
     command: |
+      mkdir -p .circleci/cache
       echo "export TREE_SHA1=$(git rev-parse HEAD:)" >> $BASH_ENV
       echo ${TREE_SHA1} > /tmp/tree.sha1
   restore-tree-hash: &restore-tree-hash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,17 +29,17 @@ defaults:
   check-if-build-executed: &check-if-build-executed
     name: "Check if build with this content was already executed"
     command: |
-      if [[ -f ${CIRCLE_JOB}.githash ]]; then
+      if [[ -f .circleci/cache/${CIRCLE_JOB}.githash ]]; then
         echo "This exact code base has been successfully built"
         circleci step halt
       else
         echo "New build - if succeeds build git hash will be cached"
-        echo "${TREE_SHA1}" > ${CIRCLE_JOB}.githash
+        echo "${TREE_SHA1}" > .circleci/cache/${CIRCLE_JOB}.githash
       fi
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:
-      - ./${CIRCLE_JOB}.githash
+      - ./.circleci/cache
   env-vars: &env-vars
     GOPATH: /home/circleci/.go_workspace
     IKE_E2E_KEEP_NS: "false"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,13 +85,15 @@ jobs:
       - run:
           name: "Obtain git tree hash"
           command: |
-            echo "export TREE_SHA1=$(git rev-parse HEAD:)" >> $BASH_ENV
-            echo ${TREE_SHA1} > /tmp/tree.sha1
+            export TREE_SHA1=$(git rev-parse HEAD:)
+            echo "export TREE_SHA1=${TREE_SHA1}" >> $BASH_ENV
+            echo "${TREE_SHA1}" > /tmp/tree.sha1
       - restore_cache:
           <<: *restore-tree-hash
       - run:
           name: "Check if build with this content was already executed"
           command: |
+            echo "${TREE_SHA1}"
             if [[ -f "${CIRCLE_JOB}".githash ]]; then
               echo "This exact code base has been successfully built"
               circleci step halt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,9 @@ defaults:
   obtain-tree-hash: &obtain-tree-hash
     name: "Obtain git tree hash"
     command: |
-      mkdir -p .circleci/cache
-      echo "export TREE_SHA1=$(git rev-parse HEAD:)" >> $BASH_ENV
+      mkdir -p ${BUILD_CACHE_FOLDER}
+      export TREE_SHA1=$(git rev-parse HEAD:)
+      echo "export TREE_SHA1=${TREE_SHA1}" >> $BASH_ENV
       echo ${TREE_SHA1} > /tmp/tree.sha1
   restore-tree-hash: &restore-tree-hash
       keys:
@@ -30,22 +31,25 @@ defaults:
   check-if-build-executed: &check-if-build-executed
     name: "Check if build with this content was already executed"
     command: |
-      if [[ -f .circleci/cache/${CIRCLE_JOB}.githash ]]; then
+      echo "retrieved content hash: ${TREE_SHA1}"
+      echo "location: ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash"
+      if [[ -f ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash ]]; then
         echo "This exact code base has been successfully built"
         circleci step halt
       else
         echo "New build - if succeeds build git hash will be cached"
-        echo "${TREE_SHA1}" > .circleci/cache/${CIRCLE_JOB}.githash
+        echo "${TREE_SHA1}" > ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash
       fi
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:
-      - ./.circleci/cache
+      - ./${BUILD_CACHE_FOLDER}
   env-vars: &env-vars
     GOPATH: /home/circleci/.go_workspace
     IKE_E2E_KEEP_NS: "false"
     IKE_E2E_MANAGE_CLUSTER: "false"
     IKE_LOG_DEBUG: "true"
+    BUILD_CACHE_FOLDER: ".circleci/cache"
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,6 @@ defaults:
   check-if-build-executed: &check-if-build-executed
     name: "Check if build with this content was already executed"
     command: |
-      echo "retrieved content hash: ${TREE_SHA1}"
-      echo "location: ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash"
-      ls ${BUILD_CACHE_FOLDER}
-      cat ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash || true
-
       if [[ -f ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash ]]; then
         echo "This exact code base has been successfully built"
         circleci step halt
@@ -43,12 +38,10 @@ defaults:
         echo "New build - if succeeds build git hash will be cached"
         echo "${TREE_SHA1}" > ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash
       fi
-
-      cat ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash || true
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:
-      - ./.circleci/cache
+      - ./.circleci/cache # Can't use env variable here - needs to be explicit value
   env-vars: &env-vars
     GOPATH: /home/circleci/.go_workspace
     IKE_E2E_KEEP_NS: "false"
@@ -94,6 +87,9 @@ jobs:
       <<: *env-vars
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
       - run:
           <<: *obtain-tree-hash
       - restore_cache:
@@ -170,10 +166,6 @@ jobs:
               sleep 10
             done
             echo "Istio enabled"
-
-      - restore_cache:
-          keys:
-            - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
       - run:
           name: "Run end-to-end tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,12 @@ defaults:
   check-if-build-executed: &check-if-build-executed
     name: "Check if build with this content was already executed"
     command: |
-      if [[ -f "${CIRCLE_JOB}".githash ]]; then
+      if [[ -f ${CIRCLE_JOB}.githash ]]; then
         echo "This exact code base has been successfully built"
         circleci step halt
       else
         echo "New build - if succeeds build git hash will be cached"
-        echo "${TREE_SHA1}" > "${CIRCLE_JOB}".githash
+        echo "${TREE_SHA1}" > ${CIRCLE_JOB}.githash
       fi
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
@@ -83,24 +83,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Obtain git tree hash"
-          command: |
-            export TREE_SHA1=$(git rev-parse HEAD:)
-            echo "export TREE_SHA1=${TREE_SHA1}" >> $BASH_ENV
-            echo "${TREE_SHA1}" > /tmp/tree.sha1
+          <<: *obtain-tree-hash
       - restore_cache:
           <<: *restore-tree-hash
       - run:
-          name: "Check if build with this content was already executed"
-          command: |
-            echo "${TREE_SHA1}"
-            if [[ -f "${CIRCLE_JOB}".githash ]]; then
-              echo "This exact code base has been successfully built"
-              circleci step halt
-            else
-              echo "New build - if succeeds build git hash will be cached"
-              echo "${TREE_SHA1}" > "${CIRCLE_JOB}".githash
-            fi
+          <<: *check-if-build-executed
       - run:
           <<: *skip-e2e-check
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,9 @@ jobs:
           <<: *restore-tree-hash
       - run:
           <<: *check-if-build-executed
+      - save_cache:
+          <<: *save-tree-hash
+
       - run:
           <<: *skip-e2e-check
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ defaults:
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:
-      - ./${BUILD_CACHE_FOLDER}
+      - ./.circleci/cache
   env-vars: &env-vars
     GOPATH: /home/circleci/.go_workspace
     IKE_E2E_KEEP_NS: "false"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,6 @@ jobs:
           <<: *restore-tree-hash
       - run:
           <<: *check-if-build-executed
-      - save_cache:
-          <<: *save-tree-hash
-
       - run:
           <<: *skip-e2e-check
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ defaults:
     command: |
       echo "retrieved content hash: ${TREE_SHA1}"
       echo "location: ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash"
+      ls ${BUILD_CACHE_FOLDER}
+      cat ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash || true
+
       if [[ -f ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash ]]; then
         echo "This exact code base has been successfully built"
         circleci step halt
@@ -40,6 +43,8 @@ defaults:
         echo "New build - if succeeds build git hash will be cached"
         echo "${TREE_SHA1}" > ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash
       fi
+
+      cat ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash || true
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ vendor/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+### CI build folders ###
+.circleci/cache
+
 ### Operator SDK ###
 bundle/
 


### PR DESCRIPTION
#### Short description of what this resolves:

Stores build cache the right way to avoid excessive e2e re-runs (on master ;))

#### Changes proposed in this pull request:

- improved circleci script

Fixes #654 
