### PR TITLE
release: add bundle push step to release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
       - run:
           name: "Push it!"
           command: |
-            make deps tools docker-build docker-push-versioned
+            make deps tools docker-build docker-push-versioned bundle-build bundle-push
       - run:
           name: "Release it!"
           command: |

--- a/.github/actions/release.sh
+++ b/.github/actions/release.sh
@@ -59,6 +59,9 @@ fi
 sed -i "/version:/c\version: ${version}" docs/antora.yml
 sed -i "/^= Releases.*/a include::release_notes\/${version}.adoc[]\n" docs/modules/ROOT/pages/release_notes.adoc
 
+## Bumps bundle
+make bundle
+
 git add . && git commit -F- <<EOF
 release: ${version}
 

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	k8s.io/code-generator v0.20.2
 	sigs.k8s.io/controller-runtime v0.7.0
 	sigs.k8s.io/controller-tools v0.4.1
-	sigs.k8s.io/kustomize/kustomize/v3 v3.8.7
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/tools.go
+++ b/tools.go
@@ -12,5 +12,4 @@ import (
 	_ "github.com/mikefarah/yq/v3"
 	_ "github.com/kisielk/errcheck"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
-	_ "sigs.k8s.io/kustomize/kustomize/v3"
 )


### PR DESCRIPTION
/skip-e2e

`make bundle` will update `config/manager/kustomization.yaml` with the new v. In theory, this should be committed, but is it really needed as it will be regenerated on each run anyway?