### PR TITLE
fix(docs): inserts release notes placeholder to aggregated page

### DIFF
--- a/.github/actions/release.sh
+++ b/.github/actions/release.sh
@@ -57,7 +57,7 @@ fi
 
 ## Replace antora version for docs build
 sed -i "/version:/c\version: ${version}" docs/antora.yml
-sed -i "/^= Releases.*/a include::release_notes\/${version}.adoc[]\n" docs/modules/ROOT/pages/release_notes.adoc
+sed -i "/append:release_notes/a include::release_notes\/${version}.adoc[]\n" docs/modules/ROOT/pages/release_notes.adoc
 
 ## Bumps bundle
 make bundle

--- a/docs/modules/ROOT/pages/release_notes.adoc
+++ b/docs/modules/ROOT/pages/release_notes.adoc
@@ -1,5 +1,7 @@
 = Releases
 
+// append:release_notes
+
 include::release_notes/v0.0.5.adoc[]
 
 include::release_notes/v0.0.4.adoc[]


### PR DESCRIPTION
#### Short description of what this resolves:

Reworks release notes insertion to the aggregated page by changing the way we use sed
