### PR TITLE
feat(operator): support MultiNamespace install mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ bundle-run-multi:		## Run the bundle image in MultiNamespace(OPERATOR_NAMESPACE)
 .PHONY: bundle-run-all
 bundle-run-all:		## Run the bundle image in AllNamespace(OPERATOR_NAMESPACE) install mode
 	$(k8s) create namespace $(OPERATOR_NAMESPACE) || true
-	operator-sdk run bundle $(BUNDLE_IMG) -n $(OPERATOR_NAMESPACE) --install-mode AllNamespace
+	operator-sdk run bundle $(BUNDLE_IMG) -n $(OPERATOR_NAMESPACE) --install-mode AllNamespaces
 
 
 .PHONY: bundle-clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME:=istio-workspace
 PACKAGE_NAME:=github.com/maistra/istio-workspace
 
 OPERATOR_NAMESPACE?=istio-workspace-operator
-OPERATOR_WATCH_NAMESPACE=""
+OPERATOR_WATCH_NAMESPACE?=""
 TEST_NAMESPACE?=bookinfo
 
 PROJECT_DIR:=$(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -382,9 +382,25 @@ bundle-push:	## Push the bundle image
 	$(IMG_BUILDER) push $(BUNDLE_IMG)
 
 .PHONY: bundle-run
-bundle-run:		## Run the bundle image
+bundle-run:		## Run the bundle image in OwnNamespace(OPERATOR_NAMESPACE) install mode
 	$(k8s) create namespace $(OPERATOR_NAMESPACE) || true
 	operator-sdk run bundle $(BUNDLE_IMG) -n $(OPERATOR_NAMESPACE) --install-mode OwnNamespace
+
+.PHONY: bundle-run-single
+bundle-run-single:		## Run the bundle image in SingleNamespace(OPERATOR_NAMESPACE) install mode targeting OPERATOR_WATCH_NAMESPACE
+	$(k8s) create namespace $(OPERATOR_NAMESPACE) || true
+	operator-sdk run bundle $(BUNDLE_IMG) -n $(OPERATOR_NAMESPACE) --install-mode SingleNamespace=${OPERATOR_WATCH_NAMESPACE}
+
+.PHONY: bundle-run-multi
+bundle-run-multi:		## Run the bundle image in MultiNamespace(OPERATOR_NAMESPACE) install mode targeting OPERATOR_WATCH_NAMESPACE
+	$(k8s) create namespace $(OPERATOR_NAMESPACE) || true
+	operator-sdk run bundle $(BUNDLE_IMG) -n $(OPERATOR_NAMESPACE) --install-mode MultiNamespace=${OPERATOR_WATCH_NAMESPACE}
+
+.PHONY: bundle-run-all
+bundle-run-all:		## Run the bundle image in AllNamespace(OPERATOR_NAMESPACE) install mode
+	$(k8s) create namespace $(OPERATOR_NAMESPACE) || true
+	operator-sdk run bundle $(BUNDLE_IMG) -n $(OPERATOR_NAMESPACE) --install-mode AllNamespace
+
 
 .PHONY: bundle-clean
 bundle-clean:	## Clean the bundle image

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/maistra/istio-workspace
-  newTag: v0.0.4-next
+  newTag: v0.0.5-next

--- a/config/manifests/bases/istio-workspace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/istio-workspace-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("Operator installation", func() {
 
-	Context("using install mode", func() {
+	Context("on bare k8s", func() {
 
 		var (
 			operatorNamepace string

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -24,6 +24,10 @@ var _ = Describe("Operator End to End Tests", func() {
 			cleanEnvVariable func()
 		)
 		BeforeEach(func() {
+			if RunsAgainstOpenshift {
+				Skip("Only run on microk8s cluster for complete isolation")
+			}
+
 			namespaces = []string{}
 			operatorNamepace = generateNamespaceName()
 			cleanEnvVariable = test.TemporaryEnvVars("OPERATOR_NAMESPACE", operatorNamepace)
@@ -75,10 +79,6 @@ var _ = Describe("Operator End to End Tests", func() {
 
 		}
 		XIt("OwnNamespace", func() {
-			if RunsAgainstOpenshift {
-				Skip("Only run on microk8s cluster for complete isolation")
-			}
-
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run")
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(Equal((0)))
@@ -89,10 +89,6 @@ var _ = Describe("Operator End to End Tests", func() {
 		})
 
 		It("SingleNamespace", func() {
-			if RunsAgainstOpenshift {
-				Skip("Only run on microk8s cluster for complete isolation")
-			}
-
 			namespaces = append(namespaces, generateNamespaceName())
 			CreateNamespace()
 
@@ -108,10 +104,6 @@ var _ = Describe("Operator End to End Tests", func() {
 		})
 
 		It("MultiNamespace", func() {
-			if RunsAgainstOpenshift {
-				Skip("Only run on microk8s cluster for complete isolation")
-			}
-
 			namespaces = append(namespaces, generateNamespaceName(), generateNamespaceName())
 			CreateNamespace()
 
@@ -126,10 +118,6 @@ var _ = Describe("Operator End to End Tests", func() {
 			VerifyWatchList(namespaces...)
 		})
 		It("AllNamespace", func() {
-			if RunsAgainstOpenshift {
-				Skip("Only run on microk8s cluster for complete isolation")
-			}
-
 			namespaces = append(namespaces, generateNamespaceName(), generateNamespaceName())
 			CreateNamespace()
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Operator installation", func() {
 			VerifyWatchList(operatorNamepace)
 		})
 
-		It("SingleNamespace", func() {
+		It("should install to the single namespace", func() {
 			namespaces = append(namespaces, generateNamespaceName())
 			CreateNamespace()
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Operator installation", func() {
 
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-single")
 			<-bundle.Done()
-			Expect(bundle.Status().Exit).To(Equal((0)))
+			Expect(bundle.Status().Exit).To(BeZero())
 
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Operator End to End Tests", func() {
 			}
 
 		}
-		It("OwnNamespace", func() {
+		XIt("OwnNamespace", func() {
 			if RunsAgainstOpenshift {
 				Skip("Only run on microk8s cluster for complete isolation")
 			}

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Operator installation", func() {
 			}
 			cleanupNamespace(operatorNamepace)
 		})
+
 		CreateNamespace := func() {
 			for _, namespace := range namespaces {
 				<-shell.Execute(NewProjectCmd(namespace)).Done()

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Operator installation", func() {
 		It("should install to its own namespace", func() {
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run")
 			<-bundle.Done()
-			Expect(bundle.Status().Exit).To(Equal((0)))
+			Expect(bundle.Status().Exit).To(BeZero())
 
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Operator installation", func() {
 
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-multi")
 			<-bundle.Done()
-			Expect(bundle.Status().Exit).To(Equal((0)))
+			Expect(bundle.Status().Exit).To(BeZero())
 
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -63,6 +64,8 @@ var _ = Describe("Operator End to End Tests", func() {
 						<-operatorLog.Done()
 
 						log := strings.Join(operatorLog.Status().Stdout, "")
+						fmt.Println(">>>>>>CONTAINS ", contain)
+						fmt.Println(">>>>>>LOG  ", log)
 						return strings.Contains(log, contain)
 					}
 				}(watchNs), 1*time.Minute, 5*time.Second).Should(BeTrue())

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Operator installation", func() {
 				<-shell.Execute(NewProjectCmd(namespace)).Done()
 			}
 		}
+
 		WatchListExpression := func() string {
 			return strings.Join(namespaces, ",")
 		}

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Operator End to End Tests", func() {
 
 						operatorLog := shell.ExecuteInDir(".",
 							"kubectl", "logs",
-							"istio-operator",
+							"deployment/istio-workspace-operator-controller-manager",
 							"-n", operatorNamepace,
 						)
 						<-operatorLog.Done()
@@ -68,7 +68,7 @@ var _ = Describe("Operator End to End Tests", func() {
 					}
 				}(watchNs), 1*time.Minute, 5*time.Second)
 
-				Eventually(ikeCreate.Done(), 1*time.Minute).Should(BeClosed())
+				ikeCreate.Stop()
 			}
 
 		}

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Operator End to End Tests", func() {
 			VerifyWatchList(namespaces...)
 		})
 
-		It("MultiNamespace", func() {
+		PIt("MultiNamespace", func() { // require Operator SDK update
 			namespaces = append(namespaces, generateNamespaceName(), generateNamespaceName())
 			CreateNamespace()
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Operator installation", func() {
 			VerifyWatchList(namespaces...)
 		})
 
-		PIt("MultiNamespace", func() { // require Operator SDK update
+		PIt("should install to multiple namespaces", func() { // require Operator SDK update, see: https://github.com/operator-framework/operator-sdk/issues/4512
 			namespaces = append(namespaces, generateNamespaceName(), generateNamespaceName())
 			CreateNamespace()
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Operator installation", func() {
 			}
 
 		}
-		It("OwnNamespace", func() {
+		It("should install to its own namespace", func() {
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run")
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(Equal((0)))

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Operator End to End Tests", func() {
+var _ = Describe("Operator installation", func() {
 
 	Context("using install mode", func() {
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Operator End to End Tests", func() {
 						log := strings.Join(operatorLog.Status().Stdout, "")
 						return strings.Contains(log, contain)
 					}
-				}, 1*time.Minute, 5*time.Second)
+				}(watchNs), 1*time.Minute, 5*time.Second)
 
 				Eventually(ikeCreate.Done(), 1*time.Minute).Should(BeClosed())
 			}

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -55,7 +55,6 @@ var _ = Describe("Operator End to End Tests", func() {
 
 				Eventually(func(contain string) func() bool {
 					return func() bool {
-
 						operatorLog := shell.ExecuteInDir(".",
 							"kubectl", "logs",
 							"deployment/istio-workspace-operator-controller-manager",
@@ -66,7 +65,7 @@ var _ = Describe("Operator End to End Tests", func() {
 						log := strings.Join(operatorLog.Status().Stdout, "")
 						return strings.Contains(log, contain)
 					}
-				}(watchNs), 1*time.Minute, 5*time.Second)
+				}(watchNs), 1*time.Minute, 5*time.Second).Should(BeTrue())
 
 				ikeCreate.Stop()
 			}
@@ -76,7 +75,11 @@ var _ = Describe("Operator End to End Tests", func() {
 			if RunsAgainstOpenshift {
 				Skip("Only run on microk8s cluster for complete isolation")
 			}
-			<-shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run").Done()
+
+			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run")
+			<-bundle.Done()
+			Expect(bundle.Status().Exit).To(Equal((0)))
+
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(operatorNamepace)
@@ -92,7 +95,10 @@ var _ = Describe("Operator End to End Tests", func() {
 
 			defer test.TemporaryEnvVars("OPERATOR_WATCH_NAMESPACE", WatchListExpression())()
 
-			<-shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-single").Done()
+			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-single")
+			<-bundle.Done()
+			Expect(bundle.Status().Exit).To(Equal((0)))
+
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(namespaces...)
@@ -108,7 +114,10 @@ var _ = Describe("Operator End to End Tests", func() {
 
 			defer test.TemporaryEnvVars("OPERATOR_WATCH_NAMESPACE", WatchListExpression())()
 
-			<-shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-multi").Done()
+			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-multi")
+			<-bundle.Done()
+			Expect(bundle.Status().Exit).To(Equal((0)))
+
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(namespaces...)
@@ -121,7 +130,10 @@ var _ = Describe("Operator End to End Tests", func() {
 			namespaces = append(namespaces, generateNamespaceName(), generateNamespaceName())
 			CreateNamespace()
 
-			<-shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-all").Done()
+			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-all")
+			<-bundle.Done()
+			Expect(bundle.Status().Exit).To(Equal((0)))
+
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(namespaces...)

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Operator installation", func() {
 
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-all")
 			<-bundle.Done()
-			Expect(bundle.Status().Exit).To(Equal((0)))
+			Expect(bundle.Status().Exit).To(BeZero())
 
 			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -14,6 +14,21 @@ import (
 
 var _ = Describe("Operator installation", func() {
 
+	/*
+
+		Test scenario overview:
+
+		Given N namespaces
+
+		When Operator is installed in X install-mode targeting the namespaces
+
+		Then
+			For each target namespace
+				Create a dummy Session object(the content is of no importance)
+				Verify that the Operator reacted to the Session object creation by checking the log
+				Delete the dummy Session
+
+	*/
 	Context("on bare k8s", func() {
 
 		var (

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Operator installation", func() {
 		WatchListExpression := func() string {
 			return strings.Join(namespaces, ",")
 		}
+
 		VerifyWatchList := func(validateNamespaces ...string) {
 			for _, watchNs := range validateNamespaces {
 				ikeCreate := RunIke(shell.GetProjectDir(), "create",

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -68,17 +67,16 @@ var _ = Describe("Operator End to End Tests", func() {
 						<-operatorLog.Done()
 
 						log := strings.Join(operatorLog.Status().Stdout, "")
-						fmt.Println(">>>>>>CONTAINS ", contain)
-						fmt.Println(">>>>>>LOG  ", log)
 						return strings.Contains(log, contain)
 					}
 				}(watchNs), 1*time.Minute, 5*time.Second).Should(BeTrue())
 
 				ikeCreate.Stop()
+				<-shell.ExecuteInDir(".", "kubectl", "delete", "session", watchNs, "-n", watchNs).Done()
 			}
 
 		}
-		XIt("OwnNamespace", func() {
+		It("OwnNamespace", func() {
 			bundle := shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run")
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(Equal((0)))

--- a/pkg/cmd/serve/cmd.go
+++ b/pkg/cmd/serve/cmd.go
@@ -71,12 +71,18 @@ func startOperator(cmd *cobra.Command, args []string) error {
 		return e
 	}
 
-	// Create a new Cmd to provide shared dependencies and Start components
-	mgr, err := manager.New(cfg, manager.Options{
+	managerOptions := manager.Options{
 		MetricsBindAddress:     fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		HealthProbeBindAddress: "0.0.0.0:8282",
-		NewCache:               cache.MultiNamespacedCacheBuilder(namespaces),
-	})
+	}
+	if len(namespaces) == 1 {
+		managerOptions.Namespace = namespaces[0]
+	} else {
+		managerOptions.NewCache = cache.MultiNamespacedCacheBuilder(namespaces)
+	}
+
+	// Create a new Cmd to provide shared dependencies and Start components
+	mgr, err := manager.New(cfg, managerOptions)
 	if err != nil {
 		logger().Error(err, "")
 		return err


### PR DESCRIPTION
#### Short description of what this resolves:

Allow for selecting Multi Namespace install mode in OLM.

#### Changes proposed in this pull request:

Move away from `Namespace`field on Manager and adjust the Cache directly.

Fixes #644

MultiNamespace tests are disabled for now due to https://github.com/operator-framework/operator-sdk/issues/4512