### PR TITLE
fix(cli): add k8s auth package

### DIFF
--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/maistra/istio-workspace/pkg/cmd/execute"
 	"github.com/maistra/istio-workspace/pkg/cmd/serve"
 	"github.com/maistra/istio-workspace/pkg/cmd/version"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func main() {


### PR DESCRIPTION
#### Short description of what this resolves:

Trying to point the `ike` tool to our k8s cluster running in gcp gave this error:

```
failed to create default client	{"error": "no Auth Provider found for name \"gcp\""}
```

#### Changes proposed in this pull request:

I've found that the `ike` command does not import the `k8s.io/client-go/plugin/pkg/client/auth` package which claims to fix this issue (https://github.com/kubernetes/client-go/issues/242).

I am unsure if where I have added it makes sense for this project so happy to move to a more sensible place! This allows the tool to connect to our cluster successfully.

