### PR TITLE
feat(gh-actions): enables /help cmd for releases

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -360,3 +360,23 @@ jobs:
 
                 core.setFailed('Release rebase failed!');
             });
+  help:
+    if: |
+      startsWith(github.event.comment.body, '/help')
+      && (contains(github.event.comment.author_association, 'MEMBER')
+          || contains(github.event.comment.author_association, 'OWNER')
+          || contains(github.event.comment.author_association, 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment with docs
+        id: comment-help
+        uses: actions/github-script@v3.1
+        with:
+          github-token: ${{secrets.GH_RELEASE_TOKEN}}
+          script: |
+            github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "#### 💁 ℹ️ Available commands\n\n * `/changelog vX.Y.Z` will append changelog based on the closed PRs since last release to provided release notes.\n\n * `/release vX.Y.Z` will add release-related commits to this PR on your behalf. \n\n * `/shipit` will rebase everything on master branch and trigger actual release process`"
+            });

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -378,5 +378,5 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "#### 💁 ℹ️ Available commands\n\n * `/changelog vX.Y.Z` will append changelog based on the closed PRs since last release to provided release notes.\n\n * `/release vX.Y.Z` will add release-related commits to this PR on your behalf. \n\n * `/shipit` will rebase everything on master branch and trigger actual release process`"
+                body: "### ℹ️ Available commands\n\n * `/changelog vX.Y.Z` will append changelog based on the closed PRs since last release to provided release notes.\n\n * `/release vX.Y.Z` will add release-related commits to this PR on your behalf. \n\n * `/shipit` will rebase everything on master branch and trigger actual release process"
             });


### PR DESCRIPTION
#### Short description of what this resolves:

`/help` will show possible actions for the release process

#### Changes proposed in this pull request:

- gh action reacting on `/help` comment
- see example here: https://github.com/bartoszmajsak/istio-workspace/pull/53#issuecomment-777784425
