### PR TITLE
chore: sets err buffer to be captured for tests

### DIFF
--- a/test/cmd.go
+++ b/test/cmd.go
@@ -37,6 +37,7 @@ func executeCommand(cmd *cobra.Command, args ...string) (output string, err erro
 func executeCommandC(cmd *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
+	cmd.SetErr(buf)
 	cmd.Root().SetArgs(append(strings.Split(cmd.CommandPath(), " ")[1:], args...))
 	c, err = cmd.ExecuteC()
 	return c, buf.String(), err


### PR DESCRIPTION
#### Short description of what this resolves:

Conclusion: we won't use logging instead of printing to cmd output as we set our own writer for further inspection while running cmd in tests. In the current solution, we pass buffer which then returns the whole content for further inspection in tests. With logger that would make it a bit more ugly than necessary/


#### Changes proposed in this pull request:

- sets buffer to capture cmd.Err stream as well as Out

Fixes #39 
