### PR TITLE
fix(release): avoid triggering e2e tests on release changes

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -107,7 +107,7 @@ jobs:
                 }));
                 core.setFailed('Failed generating changelog');
             } else {
-              const pushCmd = `git add . && git commit -m"release: adds changelog for ${version}" && git push && git rev-parse --short HEAD`;
+              const pushCmd = `git add . && git commit -m"release: adds changelog for ${version}" -m"/skip-e2e" && git push && git rev-parse --short HEAD`;
               const { status, stderr, stdout } = spawnSync(pushCmd, {shell: true});
               if (status != 0) {
                   core.exportVariable("STATUS", JSON.stringify({ sha: prHead,

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -65,6 +65,7 @@ IKE_VERSION="${version}" make bundle
 git add . && git commit -F- <<EOF
 release: ${version}
 
+/skip-e2e
 /tag ${version}
 EOF
 
@@ -72,6 +73,6 @@ EOF
 sed -i "/version:/c\version: latest" docs/antora.yml
 IKE_VERSION="${version}-next" make bundle
 
-git commit -am"release: next iteration"
+git commit -am"release: next iteration" -m"/skip-e2e"
 
 git push


### PR DESCRIPTION
#### Short description of what this resolves:

Avoids triggering e2e tests on the automated release related commits

#### Changes proposed in this pull request:

Add /skip-e2e to commit message 

/skip-e2e