### PR TITLE
fix(operator): add route to status

### DIFF
--- a/api/maistra/v1alpha1/session_types.go
+++ b/api/maistra/v1alpha1/session_types.go
@@ -46,6 +46,7 @@ type Route struct {
 // SessionStatus defines the observed state of Session.
 type SessionStatus struct {
 	State *string      `json:"state,omitempty"`
+	Route *Route       `json:"route,omitempty"`
 	Refs  []*RefStatus `json:"refs,omitempty"`
 }
 

--- a/api/maistra/v1alpha1/zz_generated.deepcopy.go
+++ b/api/maistra/v1alpha1/zz_generated.deepcopy.go
@@ -233,6 +233,11 @@ func (in *SessionStatus) DeepCopyInto(out *SessionStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Route != nil {
+		in, out := &in.Route, &out.Route
+		*out = new(Route)
+		**out = **in
+	}
 	if in.Refs != nil {
 		in, out := &in.Refs, &out.Refs
 		*out = make([]*RefStatus, len(*in))

--- a/config/crd/bases/maistra.io_sessions.yaml
+++ b/config/crd/bases/maistra.io_sessions.yaml
@@ -120,6 +120,17 @@ spec:
                       type: array
                   type: object
                 type: array
+              route:
+                description: Route defines the strategy for how the traffic is routed
+                  to the Ref.
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  value:
+                    type: string
+                type: object
               state:
                 type: string
             type: object

--- a/controllers/session/model_convert.go
+++ b/controllers/session/model_convert.go
@@ -97,12 +97,22 @@ func ConvertAPIRefToModelRef(ref istiov1alpha1.Ref, namespace string) model.Ref 
 	return model.Ref{Name: ref.Name, Namespace: namespace, Strategy: ref.Strategy, Args: ref.Args}
 }
 
+// ConvertModelRouteToAPIRoute returns Model route as a session Route.
+func ConvertModelRouteToAPIRoute(route model.Route) *istiov1alpha1.Route {
+	return &istiov1alpha1.Route{
+		Type:  route.Type,
+		Name:  route.Name,
+		Value: route.Value,
+	}
+}
+
 // ConvertAPIRouteToModelRoute returns the defined route from the session or the Default.
 func ConvertAPIRouteToModelRoute(session *istiov1alpha1.Session) model.Route {
 	if session.Spec.Route.Type == "" {
 		return model.Route{
-			Type:  RouteStrategyHeader,
-			Name:  DefaultRouteHeaderName,
+			Type: RouteStrategyHeader,
+			Name: DefaultRouteHeaderName,
+			//Value: uuid.New().String(),
 			Value: session.Name,
 		}
 	}

--- a/controllers/session/session_controller_test.go
+++ b/controllers/session/session_controller_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/maistra/istio-workspace/api/maistra/v1alpha1"
@@ -143,6 +144,17 @@ var _ = Describe("Basic session manipulation", func() {
 				Expect(modified.Status).ToNot(BeNil())
 				Expect(modified.Status.Refs).To(HaveLen(1))
 				Expect(modified.Status.Refs[0].Name).To(Equal("details"))
+			})
+			It("status is updated with route", func() {
+				res, err := controller.Reconcile(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Requeue).To(BeFalse())
+
+				modified := GetSession("test", "test-session")
+				fmt.Println(modified.Status.Route)
+				Expect(modified.Status.Route).ToNot(BeNil())
+				Expect(modified.Status.Route.Type).To(Equal(session.RouteStrategyHeader))
+				Expect(modified.Status.Route.Name).To(Equal(session.DefaultRouteHeaderName))
 			})
 		})
 	})

--- a/pkg/cmd/develop/cmd.go
+++ b/pkg/cmd/develop/cmd.go
@@ -9,7 +9,6 @@ import (
 	"github.com/maistra/istio-workspace/pkg/cmd/execute"
 
 	internal "github.com/maistra/istio-workspace/pkg/cmd/internal/session"
-	"github.com/maistra/istio-workspace/pkg/internal/session"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/shell"
 	"github.com/maistra/istio-workspace/pkg/telepresence"
@@ -41,7 +40,7 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sessionState, options, sessionClose, err := internal.Sessions(cmd)
+			sessionState, _, sessionClose, err := internal.Sessions(cmd)
 			if err != nil {
 				return err
 			}
@@ -65,8 +64,7 @@ func NewCmd() *cobra.Command {
 				shell.Start(tp, done)
 			}()
 
-			routeExp, _ := session.ParseRoute(options.RouteExp)
-			if hint, err := Hint(&sessionState.RefStatus, routeExp); err == nil {
+			if hint, err := Hint(&sessionState.RefStatus, &sessionState.Route); err == nil {
 				logger().Info(hint)
 			}
 

--- a/pkg/internal/session/session.go
+++ b/pkg/internal/session/session.go
@@ -51,6 +51,7 @@ func defaultWaitCondition(res *istiov1alpha1.RefResource) bool {
 type State struct {
 	DeploymentName string                  // name of the resource to target within the cloned route.
 	RefStatus      istiov1alpha1.RefStatus // the current ref status object
+	Route          istiov1alpha1.Route     // the curret route configuration
 }
 
 // Handler is a function to setup a server session before attempting to connect. Returns a 'cleanup' function.
@@ -101,6 +102,7 @@ func CreateOrJoinHandler(opts Options, client *Client) (State, func(), error) {
 	return State{
 			DeploymentName: serviceName,
 			RefStatus:      getCurrentRef(opts.DeploymentName, *session),
+			Route:          *session.Status.Route,
 		}, func() {
 			h.removeOrLeaveSession()
 		}, nil

--- a/pkg/internal/session/session_test.go
+++ b/pkg/internal/session/session_test.go
@@ -232,6 +232,11 @@ func addSessionRefStatus(c *session.Client, sessionName string) func() {
 			if err != nil {
 				continue
 			}
+			sess.Status.Route = &istiov1alpha1.Route{
+				Type:  "header",
+				Name:  "x-workspace-route",
+				Value: "xxxx",
+			}
 			for _, ref := range sess.Spec.Refs {
 				found := false
 				for _, status := range sess.Status.Refs {


### PR DESCRIPTION
#### Short description of what this resolves:

If no Route is provided by the Client a default type of route is created. This route is never exposed in the Session object so a client can't know what parameters to use.

#### Changes proposed in this pull request:

Expose the Route used as part of the Session.Status object.

Fixes #691
