### PR TITLE
feat(operator): add description for crd in csv

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,10 +1,10 @@
-domain: maistra.io
+domain: io
 layout: go.kubebuilder.io/v3
 projectName: istio-workspace-operator
 repo: github.com/maistra/istio-workspace
 resources:
 - crdVersion: v1
-  group: maistra.io
+  group: maistra
   kind: Session
   version: v1alpha1
 version: 3-alpha

--- a/api/maistra/v1alpha1/session_types.go
+++ b/api/maistra/v1alpha1/session_types.go
@@ -82,7 +82,7 @@ type LabeledRefResource struct {
 // +kubebuilder:resource:path=sessions,scope=Namespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Session is the Schema for the sessions API.
+// Session controls the creation of the specialized hidden routes.
 type Session struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/manifests/bases/istio-workspace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/istio-workspace-operator.clusterserviceversion.yaml
@@ -16,10 +16,10 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Session is the Schema for the sessions API.
+    - description: Session controls the developer routes.
       displayName: Session
       kind: Session
-      name: sessions.maistra.io.maistra.io
+      name: sessions.maistra.io
       version: v1alpha1
   description: |
     Testing on production sounds scary and dangerous because a lot of things can go wrong.


### PR DESCRIPTION
#### Short description of what this resolves:

Missing CRD description in CSV provided to Operator Hub

#### Changes proposed in this pull request:

Correct the domain vs group naming in PROJECT so Operator SDK correctly joins the data.

Fixes #702
