### PR TITLE
feat(operator): watch manipulated resources for reconcile on change

### DIFF
--- a/config/crd/bases/maistra.io_sessions.yaml
+++ b/config/crd/bases/maistra.io_sessions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: sessions.maistra.io
 spec:
@@ -22,14 +22,10 @@ spec:
         description: Session controls the creation of the specialized hidden routes.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -50,15 +46,12 @@ spec:
                       description: Deployment or DeploymentConfig name
                       type: string
                     strategy:
-                      description: How this deployment should be handled, e.g. telepresence
-                        or prepared-image
+                      description: How this deployment should be handled, e.g. telepresence or prepared-image
                       type: string
                   type: object
                 type: array
               route:
-                description: How to route the given Session. A header based route
-                  using x-workspace-route with the Session name as value will be used
-                  if not provided.
+                description: How to route the given Session. A header based route using x-workspace-route with the Session name as value will be used if not provided.
                 properties:
                   name:
                     description: Name of the key, e.g. http header
@@ -88,15 +81,12 @@ spec:
                       description: Deployment or DeploymentConfig name
                       type: string
                     resources:
-                      description: A list of the Resources involved in maintaining
-                        this route
+                      description: A list of the Resources involved in maintaining this route
                       items:
-                        description: An external Resource that has been manipulated
-                          in some way.
+                        description: An external Resource that has been manipulated in some way.
                         properties:
                           action:
-                            description: The Action that was performed, e.g. created,
-                              failed, manipulated
+                            description: The Action that was performed, e.g. created, failed, manipulated
                             type: string
                           kind:
                             description: The Resource Kind
@@ -107,14 +97,12 @@ spec:
                           prop:
                             additionalProperties:
                               type: string
-                            description: Additional properties for special Resources,
-                              e.g. hosts for Gateways
+                            description: Additional properties for special Resources, e.g. hosts for Gateways
                             type: object
                         type: object
                       type: array
                     strategy:
-                      description: How this deployment should be handled, e.g. telepresence
-                        or prepared-image
+                      description: How this deployment should be handled, e.g. telepresence or prepared-image
                       type: string
                     targets:
                       description: A lit of the Object used as source
@@ -122,8 +110,7 @@ spec:
                         description: LabeledRefResource is a RefResource with Labels.
                         properties:
                           action:
-                            description: The Action that was performed, e.g. created,
-                              failed, manipulated
+                            description: The Action that was performed, e.g. created, failed, manipulated
                             type: string
                           kind:
                             description: The Resource Kind
@@ -138,8 +125,7 @@ spec:
                           prop:
                             additionalProperties:
                               type: string
-                            description: Additional properties for special Resources,
-                              e.g. hosts for Gateways
+                            description: Additional properties for special Resources, e.g. hosts for Gateways
                             type: object
                         required:
                         - labels

--- a/controllers/session/enque_annotations.go
+++ b/controllers/session/enque_annotations.go
@@ -1,0 +1,163 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	crtHandler "sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// NamespacedNameAnnotation is an annotation whose value encodes the name and namespace of a resource to
+	// reconcile when a resource containing this annotation changes. Valid values are of the form
+	// `<namespace>/<name>` for namespace-scoped owners and `<name>` for cluster-scoped owners.
+	NamespacedNameAnnotation = "operator-sdk/primary-resource"
+	// TypeAnnotation is an annotation whose value encodes the group and kind of a resource to reconcil when a
+	// resource containing this annotation changes. Valid values are of the form `<Kind>` for resource in the
+	// core group, and `<Kind>.<group>` for all other resources.
+	TypeAnnotation = "operator-sdk/primary-resource-type"
+)
+
+// EnqueueRequestForAnnotation enqueues Request containing the Name and Namespace specified in the
+// annotations of the object that is the source of the Event. The source of the event triggers reconciliation
+// of the parent resource which is identified by annotations. `NamespacedNameAnnotation` and
+// `TypeAnnotation` together uniquely identify an owner resource to reconcile.
+//
+// handler.EnqueueRequestForAnnotation can be used to trigger reconciliation of resources which are
+// cross-referenced.  This allows a namespace-scoped dependent to trigger reconciliation of an owner
+// which is in a different namespace, and a cluster-scoped dependent can trigger the reconciliation
+// of a namespace(scoped)-owner.
+//
+// As an example, consider the case where we would like to watch clusterroles based on which we reconcile
+// namespace-scoped replicasets. With native owner references, this would not be possible since the
+// cluster-scoped dependent (clusterroles) is trying to specify a namespace-scoped owner (replicasets).
+// Whereas in case of annotations-based handlers, we could implement the following:
+//
+//	if err := c.Watch(&source.Kind{
+//		// Watch clusterroles
+//		Type: &rbacv1.ClusterRole{}},
+//
+//		// Enqueue ReplicaSet reconcile requests using the namespacedName annotation value in the request.
+//		&handler.EnqueueRequestForAnnotation{schema.GroupKind{Group:"apps", Kind:"ReplicaSet"}}); err != nil {
+//			entryLog.Error(err, "unable to watch ClusterRole")
+//			os.Exit(1)
+//		}
+//	}
+//
+// With this watch, the ReplicaSet reconciler would receive a request to reconcile
+// "my-namespace/my-replicaset" based on a change to a ClusterRole that has the following annotations:
+//
+//	annotations:
+//		operator-sdk/primary-resource:"my-namespace/my-replicaset"
+//		operator-sdk/primary-resource-type:"ReplicaSet.apps"
+//
+// Though an annotation-based watch handler removes the boundaries set by native owner reference implementation,
+// the garbage collector still respects the scope restrictions. For example,
+// if a parent creates a child resource across scopes not supported by owner references, it becomes the
+// responsibility of the reconciler to clean up the child resource. Hence, the resource utilizing this handler
+// SHOULD ALWAYS BE IMPLEMENTED WITH A FINALIZER.
+type EnqueueRequestForAnnotation struct {
+	Type schema.GroupKind
+}
+
+var _ crtHandler.EventHandler = &EnqueueRequestForAnnotation{}
+
+// Create implements EventHandler
+func (e *EnqueueRequestForAnnotation) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.Object); ok {
+		q.Add(req)
+	}
+}
+
+// Update implements EventHandler
+func (e *EnqueueRequestForAnnotation) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.ObjectOld); ok {
+		q.Add(req)
+	}
+	if ok, req := e.getAnnotationRequests(evt.ObjectNew); ok {
+		q.Add(req)
+	}
+}
+
+// Delete implements EventHandler
+func (e *EnqueueRequestForAnnotation) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.Object); ok {
+		q.Add(req)
+	}
+}
+
+// Generic implements EventHandler
+func (e *EnqueueRequestForAnnotation) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.Object); ok {
+		q.Add(req)
+	}
+}
+
+// getAnnotationRequests checks if the provided object has the annotations so as to enqueue the reconcile request.
+func (e *EnqueueRequestForAnnotation) getAnnotationRequests(object metav1.Object) (bool, reconcile.Request) {
+	if len(object.GetAnnotations()) == 0 {
+		return false, reconcile.Request{}
+	}
+
+	if typeString, ok := object.GetAnnotations()[TypeAnnotation]; ok && typeString == e.Type.String() {
+		namespacedNameString, ok := object.GetAnnotations()[NamespacedNameAnnotation]
+		if !ok {
+			logger().Info("Unable to find namespaced name annotation for resource", "resource", object)
+		}
+		if strings.TrimSpace(namespacedNameString) == "" {
+			return false, reconcile.Request{}
+		}
+		nsn := parseNamespacedName(namespacedNameString)
+		return true, reconcile.Request{NamespacedName: nsn}
+	}
+	return false, reconcile.Request{}
+}
+
+// parseNamespacedName parses the provided string to extract the namespace and name into a
+// types.NamespacedName. The edge case of empty string is handled prior to calling this function.
+func parseNamespacedName(namespacedNameString string) types.NamespacedName {
+	values := strings.SplitN(namespacedNameString, "/", 2)
+
+	switch len(values) {
+	case 1:
+		return types.NamespacedName{Name: values[0]}
+	default:
+		return types.NamespacedName{Namespace: values[0], Name: values[1]}
+	}
+}
+
+// SetOwnerAnnotations helps in adding 'NamespacedNameAnnotation' and 'TypeAnnotation' to object based on
+// the values obtained from owner. The object gets the annotations from owner's namespace, name, group
+// and kind. In other terms, object can be said to be the dependent having annotations from the owner.
+// When a watch is set on the object, the annotations help to identify the owner and trigger reconciliation.
+// Annotations are ALWAYS overwritten.
+func SetOwnerAnnotations(owner, object client.Object) error {
+	if owner.GetName() == "" {
+		return fmt.Errorf("%T does not have a name, cannot call SetOwnerAnnotations", owner)
+	}
+
+	ownerGK := owner.GetObjectKind().GroupVersionKind().GroupKind()
+
+	if ownerGK.Kind == "" {
+		return fmt.Errorf("Owner %s Kind not found, cannot call SetOwnerAnnotations", owner.GetName())
+	}
+
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[NamespacedNameAnnotation] = fmt.Sprintf("%s/%s", owner.GetNamespace(), owner.GetName())
+	annotations[TypeAnnotation] = ownerGK.String()
+
+	object.SetAnnotations(annotations)
+
+	return nil
+}

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, r *ReconcileSession) error {
 	}
 
 	for _, object := range r.WatchTypes() {
-		if _, err := mgr.GetCache().GetInformer(context.Background(), object); err != nil {
+		if _, err = mgr.GetCache().GetInformer(context.Background(), object); err != nil {
 			if !meta.IsNoMatchError(err) {
 				logger().Error(err, "error checking for type Kind availability")
 			}

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -97,10 +97,11 @@ func add(mgr manager.Manager, r *ReconcileSession) error {
 	}
 
 	for _, object := range r.WatchTypes() {
-		if _, err := mgr.GetCache().GetInformer(context.Background(), object); meta.IsNoMatchError(err) {
+		if _, err := mgr.GetCache().GetInformer(context.Background(), object); err != nil {
+			if !meta.IsNoMatchError(err) {
+				logger().Error(err, "error checking for type Kind availability")
+			}
 			continue
-		} else if err != nil {
-			logger().Error(err, "error checking for type Kind availability")
 		}
 
 		// Watch for changes to secondary resources

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -18,10 +18,8 @@ import (
 	"github.com/go-logr/logr"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -98,11 +96,10 @@ func add(mgr manager.Manager, r *ReconcileSession) error {
 	}
 
 	for _, object := range r.WatchTypes() {
-		err := mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, object)
-		if err != nil && meta.IsNoMatchError(err) {
+		_, err := mgr.GetRESTMapper().RESTMapping(schema.GroupKind{Group: "apps.openshift.io/v1", Kind: "DeploymentConfig"})
+		if err != nil {
+			logger().Error(err, "error checking for type DeploymentConfig")
 			continue
-		} else if err != nil {
-			logger().Error(err, "other error checking for type")
 		}
 		// Watch for changes to secondary resources
 		err = c.Watch(&source.Kind{Type: object}, &reference.EnqueueRequestForAnnotation{

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -187,7 +187,6 @@ func (r *ReconcileSession) Reconcile(c context.Context, request reconcile.Reques
 		Context:   c,
 		Name:      request.Name,
 		Namespace: request.Namespace,
-		UID:       session.UID,
 		Route:     route,
 		Log:       reqLogger,
 		Client:    r.client,

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -106,26 +106,26 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to secondary resources
 	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &reference.EnqueueRequestForAnnotation{
-		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
+		Type: schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
 
 	err = c.Watch(&source.Kind{Type: &istionetwork.VirtualService{}}, &reference.EnqueueRequestForAnnotation{
-		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
+		Type: schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
 	err = c.Watch(&source.Kind{Type: &istionetwork.DestinationRule{}}, &reference.EnqueueRequestForAnnotation{
-		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
+		Type: schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
 	err = c.Watch(&source.Kind{Type: &istionetwork.Gateway{}}, &reference.EnqueueRequestForAnnotation{
-		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
+		Type: schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
@@ -308,7 +308,7 @@ func (r *ReconcileSession) sync(ctx model.SessionContext, session *istiov1alpha1
 				ctx.Log.Error(err, "Mutate", "name", ref.Name)
 			}
 			ConvertModelRefToAPIStatus(*ref, session)
-			ctx.Client.Status().Update(ctx, session)
+			_ = ctx.Client.Status().Update(ctx, session)
 		}
 	}
 

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -252,8 +252,8 @@ func (r *ReconcileSession) delete(ctx model.SessionContext, session *istiov1alph
 	ctx.Log.Info("Remove ref", "name", ref.Name)
 
 	ConvertAPIStatusToModelRef(*session, ref)
-	for _, revertor := range r.manipulators.Handlers {
-		err := revertor.Revert()(ctx, ref)
+	for _, handler := range r.manipulators.Handlers {
+		err := handler.Revert()(ctx, ref)
 		if err != nil {
 			ctx.Log.Error(err, "Revert", "name", ref.Name)
 		}
@@ -291,8 +291,8 @@ func (r *ReconcileSession) sync(ctx model.SessionContext, session *istiov1alpha1
 		}
 	}
 	if located {
-		for _, mutator := range r.manipulators.Handlers {
-			err := mutator.Mutate()(ctx, ref)
+		for _, handler := range r.manipulators.Handlers {
+			err := handler.Mutate()(ctx, ref)
 			if err != nil {
 				ctx.Log.Error(err, "Mutate", "name", ref.Name)
 			}

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -306,8 +306,6 @@ func (r *ReconcileSession) sync(ctx model.SessionContext, session *istiov1alpha1
 			if err != nil {
 				ctx.Log.Error(err, "Mutate", "name", ref.Name)
 			}
-			ConvertModelRefToAPIStatus(*ref, session)
-			_ = ctx.Client.Status().Update(ctx, session)
 		}
 	}
 

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -125,9 +125,9 @@ type ReconcileSession struct {
 	manipulators Manipulators
 }
 
-// WatchTypes returns a list of client.Objects to watch for changes
+// WatchTypes returns a list of client.Objects to watch for changes.
 func (r ReconcileSession) WatchTypes() []client.Object {
-	var objects []client.Object
+	objects := []client.Object{}
 	for _, handler := range r.manipulators.Handlers {
 		objects = append(objects, handler.TargetResourceType())
 	}

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -18,8 +18,10 @@ import (
 	"github.com/go-logr/logr"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -96,6 +98,12 @@ func add(mgr manager.Manager, r *ReconcileSession) error {
 	}
 
 	for _, object := range r.WatchTypes() {
+		err := mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, object)
+		if err != nil && meta.IsNoMatchError(err) {
+			continue
+		} else if err != nil {
+			logger().Error(err, "other error checking for type")
+		}
 		// Watch for changes to secondary resources
 		err = c.Watch(&source.Kind{Type: object}, &reference.EnqueueRequestForAnnotation{
 			Type: schema.GroupKind{Group: "maistra.io", Kind: "Session"},

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -101,7 +101,7 @@ func add(mgr manager.Manager, r *ReconcileSession) error {
 			Type: schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 		}, predicate.GenerationChangedPredicate{})
 		if err != nil {
-			return err
+			logger().Error(err, "could not add watch on crd")
 		}
 	}
 

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/openshift"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
 
 	"github.com/operator-framework/operator-lib/handler"
@@ -104,26 +105,26 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to secondary resources
-	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &EnqueueRequestForAnnotation{
+	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &reference.EnqueueRequestForAnnotation{
 		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &istionetwork.VirtualService{}}, &EnqueueRequestForAnnotation{
+	err = c.Watch(&source.Kind{Type: &istionetwork.VirtualService{}}, &reference.EnqueueRequestForAnnotation{
 		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &istionetwork.DestinationRule{}}, &EnqueueRequestForAnnotation{
+	err = c.Watch(&source.Kind{Type: &istionetwork.DestinationRule{}}, &reference.EnqueueRequestForAnnotation{
 		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &istionetwork.Gateway{}}, &EnqueueRequestForAnnotation{
+	err = c.Watch(&source.Kind{Type: &istionetwork.Gateway{}}, &reference.EnqueueRequestForAnnotation{
 		schema.GroupKind{Group: "maistra.io", Kind: "Session"},
 	}, predicate.GenerationChangedPredicate{})
 	if err != nil {

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -99,8 +99,8 @@ func add(mgr manager.Manager, r *ReconcileSession) error {
 	for _, object := range r.WatchTypes() {
 		if _, err := mgr.GetCache().GetInformer(context.Background(), object); meta.IsNoMatchError(err) {
 			continue
-		} else {
-			logger().Error(err, "error checking for type DeploymentConfig")
+		} else if err != nil {
+			logger().Error(err, "error checking for type Kind availability")
 		}
 
 		// Watch for changes to secondary resources

--- a/controllers/session/session_controller_int_test.go
+++ b/controllers/session/session_controller_int_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Complete session manipulation", func() {
 		scenario   func(io.Writer)
 		get        *testclient.Getters
 	)
+
 	JustBeforeEach(func() {
 		log.SetLogger(log.CreateOperatorAwareLogger("test").WithValues("type", "session_controller_int_test"))
 
@@ -101,7 +102,8 @@ var _ = Describe("Complete session manipulation", func() {
 		})
 
 		Context("when a ref is updated", func() {
-			It("it should update the image", func() {
+
+			It("should update the image", func() {
 				req := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name:      "test-session1",
@@ -131,7 +133,8 @@ var _ = Describe("Complete session manipulation", func() {
 		})
 
 		Context("when there are multiple sessions", func() {
-			It("shared resources should still be in sync on delete", func() {
+
+			It("should sync resources on delete", func() {
 				req1 := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name:      "test-session1",
@@ -185,7 +188,7 @@ var _ = Describe("Complete session manipulation", func() {
 		})
 
 		Context("when there are multiple refs in a session", func() {
-			It("shared resources should be in sync on delete", func() {
+			It("should sync shared resources on delete", func() {
 				req1 := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name:      "test-session1",
@@ -325,7 +328,7 @@ var _ = Describe("Complete session manipulation", func() {
 			test.CleanUpTmpFiles(GinkgoT())
 		})
 
-		It("ensure template was called", func() {
+		It("should ensure template was called", func() {
 			req1 := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "test-session1",

--- a/controllers/session/session_controller_test.go
+++ b/controllers/session/session_controller_test.go
@@ -57,9 +57,10 @@ var _ = Describe("Basic session manipulation", func() {
 		mutator = &trackedMutator{Action: noOp}
 		revertor = &trackedRevertor{Action: noOp}
 		manipulators := session.Manipulators{
-			Locators:  []model.Locator{locator.Do},
-			Mutators:  []model.Mutator{mutator.Do},
-			Revertors: []model.Revertor{revertor.Do},
+			Locators: []model.Locator{locator.Do},
+			Handlers: []model.Manipulator{
+				trackedManipulator{mutator: mutator.Do, revertor: revertor.Do},
+			},
 		}
 
 		schema, _ = v1alpha1.SchemeBuilder.Build()
@@ -495,6 +496,21 @@ func addResourceStatus(status model.ResourceStatus) func(ctx model.SessionContex
 		ref.AddResourceStatus(status)
 		return nil
 	}
+}
+
+type trackedManipulator struct {
+	mutator  model.Mutator
+	revertor model.Revertor
+}
+
+func (t trackedManipulator) Mutate() model.Mutator {
+	return t.mutator
+}
+func (t trackedManipulator) Revert() model.Revertor {
+	return t.revertor
+}
+func (t trackedManipulator) TargetResourceType() client.Object {
+	return nil
 }
 
 type trackedMutator struct {

--- a/controllers/session/session_controller_test.go
+++ b/controllers/session/session_controller_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Basic session manipulation", func() {
 										Name:     "locations",
 										Strategy: "prepared-image",
 										Args: map[string]string{
-											"image": "x",
+											"image":                       "x",
 											"should-be-removed-on-update": "true",
 										}},
 									Resources: []*v1alpha1.RefResource{{Kind: &kind, Name: &name, Action: &action}},

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 			Context("http protocol", func() {
 
 				BeforeEach(func() {
-					scenario = "scenario-1"
+					scenario = "scenario-1" //nolint:goconst //reason no need for constant (yet)
 					registry = GetDockerRegistryInternal()
 				})
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -238,14 +238,14 @@ var _ = Describe("Smoke End To End Tests - against OpenShift Cluster with Istio 
 				EnsureProdRouteIsReachable(namespace, ContainSubstring("ratings-v1"), Not(ContainSubstring(PreparedImageV1)))
 
 				// when we start ike to create
-				ike1 := RunIke(tmpDir, "create",
+				ikeCreate := RunIke(tmpDir, "create",
 					"--deployment", "ratings-v1",
 					"-n", namespace,
 					"--route", "header:x-test-suite=smoke",
 					"--image", registry+"/"+GetDevRepositoryName()+"/istio-workspace-test-prepared-"+PreparedImageV1+":"+GetImageTag(),
 					"--session", sessionName,
 				)
-				Eventually(ike1.Done(), 1*time.Minute).Should(BeClosed())
+				Eventually(ikeCreate.Done(), 1*time.Minute).Should(BeClosed())
 
 				// ensure the new service is running
 				EnsureAllDeploymentPodsAreReady(namespace)

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -3,15 +3,15 @@ package istio
 import (
 	"strings"
 
-	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
 
 	"istio.io/api/networking/v1alpha3"
+	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -23,7 +23,7 @@ var _ model.Mutator = DestinationRuleMutator
 var _ model.Revertor = DestinationRuleRevertor
 var _ model.Manipulator = destinationRuleManipulator{}
 
-// DestinationRuleManipulator represents a model.Manipulator implementation for handling DestinationRule objects
+// DestinationRuleManipulator represents a model.Manipulator implementation for handling DestinationRule objects.
 func DestinationRuleManipulator() model.Manipulator {
 	return destinationRuleManipulator{}
 }

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -21,6 +21,25 @@ const (
 
 var _ model.Mutator = DestinationRuleMutator
 var _ model.Revertor = DestinationRuleRevertor
+var _ model.Manipulator = destinationRuleManipulator{}
+
+// DestinationRuleManipulator represents a model.Manipulator implementation for handling DestinationRule objects
+func DestinationRuleManipulator() model.Manipulator {
+	return destinationRuleManipulator{}
+}
+
+type destinationRuleManipulator struct {
+}
+
+func (d destinationRuleManipulator) TargetResourceType() client.Object {
+	return &istionetwork.DestinationRule{}
+}
+func (d destinationRuleManipulator) Mutate() model.Mutator {
+	return DestinationRuleMutator
+}
+func (d destinationRuleManipulator) Revert() model.Revertor {
+	return DestinationRuleRevertor
+}
 
 // DestinationRuleMutator creates destination rule mutator which is responsible for alternating the traffic for development
 // of the forked service.

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 
 		Context("existing rule", func() {
 
-			It("reference removed", func() {
+			It("should remove reference", func() {
 				err := istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
@@ -107,6 +108,14 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				}
 			})
 
+			It("reference added", func() {
+				err := istio.DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				dr := get.DestinationRule("test", "customer-mutate")
+				Expect(reference.Get(&dr)).To(HaveLen(1))
+			})
+
 			It("new subset added", func() {
 				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
@@ -155,6 +164,14 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 		})
 
 		Context("existing rule", func() {
+
+			It("reference removed", func() {
+				err := istio.DestinationRuleRevertor(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				dr := get.DestinationRule("test", "customer-revert")
+				Expect(reference.Get(&dr)).To(BeEmpty())
+			})
 
 			It("new subset removed", func() {
 				err := istio.DestinationRuleRevertor(ctx, ref)

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				}
 			})
 
-			It("reference added", func() {
+			It("should add reference", func() {
 				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -30,6 +30,9 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error {
 
 		ctx.Log.Info("Found Gateway", "name", gw.Name)
 		mutatedGw, addedHosts := mutateGateway(ctx, *gw)
+
+		mutatedGw.OwnerReferences = append(mutatedGw.OwnerReferences, ctx.ToOwnerReference())
+
 		err = ctx.Client.Update(ctx, &mutatedGw)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedGw.Name, Action: model.ActionFailed})

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -22,7 +23,7 @@ var _ model.Mutator = GatewayMutator
 var _ model.Revertor = GatewayRevertor
 var _ model.Manipulator = gatewayManipulator{}
 
-// GatewayManipulator represents a model.Manipulator implementation for handling Gateway objects
+// GatewayManipulator represents a model.Manipulator implementation for handling Gateway objects.
 func GatewayManipulator() model.Manipulator {
 	return gatewayManipulator{}
 }

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 
@@ -19,6 +20,25 @@ const (
 
 var _ model.Mutator = GatewayMutator
 var _ model.Revertor = GatewayRevertor
+var _ model.Manipulator = gatewayManipulator{}
+
+// GatewayManipulator represents a model.Manipulator implementation for handling Gateway objects
+func GatewayManipulator() model.Manipulator {
+	return gatewayManipulator{}
+}
+
+type gatewayManipulator struct {
+}
+
+func (d gatewayManipulator) TargetResourceType() client.Object {
+	return &istionetwork.Gateway{}
+}
+func (d gatewayManipulator) Mutate() model.Mutator {
+	return GatewayMutator
+}
+func (d gatewayManipulator) Revert() model.Revertor {
+	return GatewayRevertor
+}
 
 // GatewayMutator attempts to expose a external host on the gateway.
 func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error {

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -32,7 +32,9 @@ func GatewayMutator(ctx model.SessionContext, ref *model.Ref) error {
 		ctx.Log.Info("Found Gateway", "name", gw.Name)
 		mutatedGw, addedHosts := mutateGateway(ctx, *gw)
 
-		reference.Add(ctx.ToNamespacedName(), &mutatedGw)
+		if err = reference.Add(ctx.ToNamespacedName(), &mutatedGw); err != nil {
+			ctx.Log.Error(err, "failed to add relation reference", "kind", mutatedGw.Kind, "name", mutatedGw.Name)
+		}
 		err = ctx.Client.Update(ctx, &mutatedGw)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: mutatedGw.Name, Action: model.ActionFailed})
@@ -66,7 +68,9 @@ func GatewayRevertor(ctx model.SessionContext, ref *model.Ref) error {
 
 		ctx.Log.Info("Found Gateway", "name", resource.Name)
 		mutatedGw := revertGateway(ctx, *gw)
-		reference.Remove(ctx.ToNamespacedName(), &mutatedGw)
+		if err = reference.Remove(ctx.ToNamespacedName(), &mutatedGw); err != nil {
+			ctx.Log.Error(err, "failed to remove relation reference", "kind", mutatedGw.Kind, "name", mutatedGw.Name)
+		}
 		err = ctx.Client.Update(ctx, &mutatedGw)
 		if err != nil {
 			ref.AddResourceStatus(model.ResourceStatus{Kind: GatewayKind, Name: resource.Name, Action: model.ActionFailed})

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -159,7 +159,7 @@ func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) istion
 		server.Hosts = hosts
 	}
 	for _, toBeRemoved := range toBeRemovedHosts {
-		removeFromList(existingHosts, toBeRemoved)
+		existingHosts = removeFromList(existingHosts, toBeRemoved)
 	}
 	if len(existingHosts) == 0 {
 		delete(source.Annotations, LabelIkeHosts)

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -124,6 +124,16 @@ var _ = Describe("Operations for istio gateway kind", func() {
 										"domain.com",
 									},
 								},
+								{
+									Port: &v1alpha3.Port{
+										Protocol: "HTTP",
+										Name:     "http",
+										Number:   80,
+									},
+									Hosts: []string{
+										"other-domain.com",
+									},
+								},
 							},
 						},
 					},
@@ -150,7 +160,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test.domain.com"))
 			})
 
 			It("add single session - verify ref", func() {
@@ -169,7 +179,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test.domain.com"))
 
 				ctx2 := model.SessionContext{
 					Name:      "test2",
@@ -187,7 +197,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(3))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com", "test2.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test.domain.com", "test2.domain.com"))
 			})
 
 			It("add multiple refs", func() {
@@ -196,14 +206,14 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test.domain.com"))
 
 				err = istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test.domain.com"))
 			})
 
 			It("should only return added hosts once", func() {
@@ -221,7 +231,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				Expect(status.Prop["hosts"]).To(Equal("test.domain.com"))
 			})
 
-			It("should reapply found ike hsots if gateway out of sync", func() {
+			It("should reapply found ike hosts if gateway out of sync", func() {
 				ref.Targets = []model.LocatedResourceStatus{
 					model.NewLocatedResource("Gateway", "gateway-force-updated", nil),
 				}
@@ -230,7 +240,8 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				gw := get.Gateway("test", "gateway-force-updated")
-				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test.domain.com"))
+				Expect(gw.Spec.Servers[1].Hosts).To(ConsistOf("other-domain.com", "test.other-domain.com"))
 			})
 		})
 
@@ -254,6 +265,18 @@ var _ = Describe("Operations for istio gateway kind", func() {
 										Protocol: "HTTP",
 										Name:     "http",
 										Number:   80,
+									},
+									Hosts: []string{
+										"domain.com",
+										"test.domain.com",
+										"test2.domain.com",
+									},
+								},
+								{
+									Port: &v1alpha3.Port{
+										Protocol: "HTTP",
+										Name:     "http",
+										Number:   81,
 									},
 									Hosts: []string{
 										"domain.com",
@@ -287,6 +310,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
+				Expect(gw.Spec.Servers[1].Hosts).To(HaveLen(2))
 			})
 
 			It("multiple remove sessions", func() {
@@ -295,7 +319,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw := get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(2))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com", "test2.domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com", "test2.domain.com"))
 
 				ctx2 := model.SessionContext{
 					Name:      "test2",
@@ -315,7 +339,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 
 				gw = get.Gateway("test", "gateway")
 				Expect(gw.Spec.Servers[0].Hosts).To(HaveLen(1))
-				Expect(gw.Spec.Servers[0].Hosts).To(ContainElements("domain.com"))
+				Expect(gw.Spec.Servers[0].Hosts).To(ConsistOf("domain.com"))
 				Expect(gw.Labels).ToNot(HaveKey(istio.LabelIkeHosts))
 			})
 		})

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
@@ -135,6 +136,14 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				}
 			})
 
+			It("add reference", func() {
+				err := istio.GatewayMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				gw := get.Gateway("test", "gateway")
+				Expect(reference.Get(&gw)).To(HaveLen(1))
+			})
+
 			It("add single session", func() {
 				err := istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
@@ -262,6 +271,14 @@ var _ = Describe("Operations for istio gateway kind", func() {
 						{Kind: "Gateway", Name: "gateway", Action: model.ActionModified},
 					},
 				}
+			})
+
+			It("remove reference", func() {
+				err := istio.GatewayRevertor(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				gw := get.Gateway("test", "gateway")
+				Expect(reference.Get(&gw)).To(BeEmpty())
 			})
 
 			It("single remove session", func() {

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 				}
 			})
 
-			It("add reference", func() {
+			It("should add reference", func() {
 				err := istio.GatewayMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -28,6 +28,25 @@ const (
 
 var _ model.Mutator = VirtualServiceMutator
 var _ model.Revertor = VirtualServiceRevertor
+var _ model.Manipulator = virtualServiceManipulator{}
+
+// VirtualServiceManipulator represents a model.Manipulator implementation for handling VirtualService objects
+func VirtualServiceManipulator() model.Manipulator {
+	return virtualServiceManipulator{}
+}
+
+type virtualServiceManipulator struct {
+}
+
+func (d virtualServiceManipulator) TargetResourceType() client.Object {
+	return &istionetwork.VirtualService{}
+}
+func (d virtualServiceManipulator) Mutate() model.Mutator {
+	return VirtualServiceMutator
+}
+func (d virtualServiceManipulator) Revert() model.Revertor {
+	return VirtualServiceRevertor
+}
 
 // VirtualServiceMutator attempts to create a virtual service for forked service.
 func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //nolint:gocyclo //reason it is what it is :D

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -30,7 +30,7 @@ var _ model.Mutator = VirtualServiceMutator
 var _ model.Revertor = VirtualServiceRevertor
 var _ model.Manipulator = virtualServiceManipulator{}
 
-// VirtualServiceManipulator represents a model.Manipulator implementation for handling VirtualService objects
+// VirtualServiceManipulator represents a model.Manipulator implementation for handling VirtualService objects.
 func VirtualServiceManipulator() model.Manipulator {
 	return virtualServiceManipulator{}
 }

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/maistra/istio-workspace/api/maistra/v1alpha1"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/test/testclient"
 
 	. "github.com/onsi/ginkgo"
@@ -164,6 +165,17 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 						Name:      "details-v1",
 						Namespace: "test",
 					}
+				})
+
+				It("reference added", func() {
+					ref.AddTargetResource(targetV1)
+					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
+
+					err := VirtualServiceMutator(ctx, &ref)
+					Expect(err).ToNot(HaveOccurred())
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(reference.Get(&virtualService)).To(HaveLen(1))
 				})
 
 				It("route added", func() {
@@ -426,6 +438,14 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 						},
 					}
 
+				})
+
+				It("reference removed", func() {
+					err := VirtualServiceRevertor(ctx, &ref)
+					Expect(err).ToNot(HaveOccurred())
+
+					virtualService := get.VirtualService("test", "details")
+					Expect(reference.Get(&virtualService)).To(BeEmpty())
 				})
 
 				It("route removed", func() {

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 					}
 				})
 
-				It("reference added", func() {
+				It("should add reference", func() {
 					ref.AddTargetResource(targetV1)
 					ref.AddTargetResource(model.NewLocatedResource("Service", "details", map[string]string{}))
 

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -440,7 +440,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 
 				})
 
-				It("reference removed", func() {
+				It("should remove reference", func() {
 					err := VirtualServiceRevertor(ctx, &ref)
 					Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"encoding/json"
 
-	"github.com/maistra/istio-workspace/controllers/session"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/template"
 
@@ -66,7 +65,7 @@ func DeploymentMutator(engine template.Engine) model.Mutator {
 			ctx.Log.Info("Failed to clone Deployment", "name", deployment.Name)
 			return err
 		}
-		session.SetOwnerAnnotations(ctx.ToOwnerReference(), deploymentClone)
+		//session.SetOwnerAnnotations(ctx.ToOwnerReference(), deploymentClone)
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -6,10 +6,10 @@ import (
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ var _ model.Locator = DeploymentLocator
 var _ model.Revertor = DeploymentRevertor
 var _ model.Manipulator = deploymentManipulator{}
 
-// DeploymentManipulator represents a model.Manipulator implementation for handling Deployment objects
+// DeploymentManipulator represents a model.Manipulator implementation for handling Deployment objects.
 func DeploymentManipulator(engine template.Engine) model.Manipulator {
 	return deploymentManipulator{engine: engine}
 }

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"encoding/json"
 
+	"github.com/maistra/istio-workspace/controllers/session"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/template"
 
@@ -65,6 +66,7 @@ func DeploymentMutator(engine template.Engine) model.Mutator {
 			ctx.Log.Info("Failed to clone Deployment", "name", deployment.Name)
 			return err
 		}
+		session.SetOwnerAnnotations(ctx.ToOwnerReference(), deploymentClone)
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -21,6 +22,26 @@ const (
 
 var _ model.Locator = DeploymentLocator
 var _ model.Revertor = DeploymentRevertor
+var _ model.Manipulator = deploymentManipulator{}
+
+// DeploymentManipulator represents a model.Manipulator implementation for handling Deployment objects
+func DeploymentManipulator(engine template.Engine) model.Manipulator {
+	return deploymentManipulator{engine: engine}
+}
+
+type deploymentManipulator struct {
+	engine template.Engine
+}
+
+func (d deploymentManipulator) TargetResourceType() client.Object {
+	return &appsv1.Deployment{}
+}
+func (d deploymentManipulator) Mutate() model.Mutator {
+	return DeploymentMutator(d.engine)
+}
+func (d deploymentManipulator) Revert() model.Revertor {
+	return DeploymentRevertor
+}
 
 // DeploymentLocator attempts to locate a Deployment kind based on Ref name.
 func DeploymentLocator(ctx model.SessionContext, ref *model.Ref) bool {

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -39,9 +39,6 @@ func DeploymentLocator(ctx model.SessionContext, ref *model.Ref) bool {
 // DeploymentMutator attempts to clone the located Deployment.
 func DeploymentMutator(engine template.Engine) model.Mutator {
 	return func(ctx model.SessionContext, ref *model.Ref) error {
-		if len(ref.GetResources(model.Kind(DeploymentKind))) > 0 {
-			return nil
-		}
 		targets := ref.GetTargets(model.Kind(DeploymentKind))
 		if len(targets) == 0 {
 			return nil
@@ -69,6 +66,10 @@ func DeploymentMutator(engine template.Engine) model.Mutator {
 		if err = reference.Add(ctx.ToNamespacedName(), deploymentClone); err != nil {
 			ctx.Log.Error(err, "failed to add relation reference", "kind", deploymentClone.Kind, "name", deploymentClone.Name)
 		}
+		if _, err = getDeployment(ctx, deploymentClone.Namespace, deploymentClone.Name); err == nil {
+			return nil
+		}
+
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -65,7 +66,7 @@ func DeploymentMutator(engine template.Engine) model.Mutator {
 			ctx.Log.Info("Failed to clone Deployment", "name", deployment.Name)
 			return err
 		}
-		//session.SetOwnerAnnotations(ctx.ToOwnerReference(), deploymentClone)
+		reference.Add(ctx.ToNamespacedName(), deploymentClone)
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -66,7 +66,9 @@ func DeploymentMutator(engine template.Engine) model.Mutator {
 			ctx.Log.Info("Failed to clone Deployment", "name", deployment.Name)
 			return err
 		}
-		reference.Add(ctx.ToNamespacedName(), deploymentClone)
+		if err = reference.Add(ctx.ToNamespacedName(), deploymentClone); err != nil {
+			ctx.Log.Error(err, "failed to add relation reference", "kind", deploymentClone.Kind, "name", deploymentClone.Name)
+		}
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -179,6 +179,29 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
+		It("should recreate cloned Deployment if deleted externally", func() {
+			// given a normal setup
+			ref := CreateTestRef()
+			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo("v1-test"))
+
+			// when Deployment is deleted
+			c.Delete(ctx, &deployment)
+
+			_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(err).To(HaveOccurred())
+
+			// then it should be recreated on next reconcile
+			mutatorErr = k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			deployment = get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo("v1-test"))
+		})
+
 		Context("telepresence mutation strategy", func() {
 
 			It("should change container to telepresence", func() {

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/k8s"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
 	"github.com/maistra/istio-workspace/test/testclient"
 
@@ -131,6 +132,15 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 					},
 				},
 			}
+		})
+
+		It("should add reference to cloned deployment", func() {
+			ref := CreateTestRef()
+			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			d := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(reference.Get(&d)).To(HaveLen(1))
 		})
 
 		It("should add suffix to the cloned deployment", func() {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,9 +21,20 @@ type SessionContext struct {
 
 	Name      string
 	Namespace string
+	UID       types.UID
 	Route     Route
 	Client    client.Client
 	Log       logr.Logger
+}
+
+// ToOwnerReference returns a OwnerReference object that represents this Session
+func (s *SessionContext) ToOwnerReference() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "maistra.io/v1alpha1",
+		Kind:       "Session",
+		Name:       s.Name,
+		UID:        s.UID,
+	}
 }
 
 // Route references the strategy used to route to the target Refs.

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -27,13 +26,11 @@ type SessionContext struct {
 	Log       logr.Logger
 }
 
-// ToOwnerReference returns a OwnerReference object that represents this Session.
-func (s *SessionContext) ToOwnerReference() metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: "maistra.io/v1alpha1",
-		Kind:       "Session",
-		Name:       s.Name,
-		UID:        s.UID,
+// ToNamespacedName returns a types.NamespaceName object that represents this Session.
+func (s *SessionContext) ToNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: s.Namespace,
+		Name:      s.Name,
 	}
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -20,7 +20,6 @@ type SessionContext struct {
 
 	Name      string
 	Namespace string
-	UID       types.UID
 	Route     Route
 	Client    client.Client
 	Log       logr.Logger

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -252,3 +252,16 @@ type Mutator func(SessionContext, *Ref) error
 // Revertor should delete/modify a target Kind to return to the original state after a Mutator
 // * Remove status from Ref unless there is a failure that requires retry.
 type Revertor func(SessionContext, *Ref) error
+
+// Manipulator is a joint interface between a Mutator and Revertor function combined with their target Object.
+type Manipulator interface {
+	// Mutate is called to manipulate/mutate the TargetResource
+	Mutate() Mutator
+
+	// Revert is called to undo the manipulated/mutated TargetResource
+	Revert() Revertor
+
+	// TargetResourceType should return a empty version of the Type of Resource this manipulator targets.
+	// Used to register Watch for changes to the Type.
+	TargetResourceType() client.Object
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -27,7 +27,7 @@ type SessionContext struct {
 	Log       logr.Logger
 }
 
-// ToOwnerReference returns a OwnerReference object that represents this Session
+// ToOwnerReference returns a OwnerReference object that represents this Session.
 func (s *SessionContext) ToOwnerReference() metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: "maistra.io/v1alpha1",

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -70,7 +70,9 @@ func DeploymentConfigMutator(engine template.Engine) model.Mutator {
 			ctx.Log.Info("Failed to clone DeploymentConfig", "name", deployment.Name)
 			return err
 		}
-		reference.Add(ctx.ToNamespacedName(), deploymentClone)
+		if err = reference.Add(ctx.ToNamespacedName(), deploymentClone); err != nil {
+			ctx.Log.Error(err, "failed to add relation reference", "kind", deploymentClone.Kind, "name", deploymentClone.Name)
+		}
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned DeploymentConfig", "name", deploymentClone.Name)

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/maistra/istio-workspace/api"
 	"github.com/maistra/istio-workspace/pkg/model"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -69,6 +70,7 @@ func DeploymentConfigMutator(engine template.Engine) model.Mutator {
 			ctx.Log.Info("Failed to clone DeploymentConfig", "name", deployment.Name)
 			return err
 		}
+		reference.Add(ctx.ToNamespacedName(), deploymentClone)
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned DeploymentConfig", "name", deploymentClone.Name)

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -28,7 +29,7 @@ var _ model.Locator = DeploymentConfigLocator
 var _ model.Revertor = DeploymentConfigRevertor
 var _ model.Manipulator = deploymentConfigManipulator{}
 
-// DeploymentConfigManipulator represents a model.Manipulator implementation for handling DeploymentConfig objects
+// DeploymentConfigManipulator represents a model.Manipulator implementation for handling DeploymentConfig objects.
 func DeploymentConfigManipulator(engine template.Engine) model.Manipulator {
 	return deploymentConfigManipulator{engine: engine}
 }

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +26,26 @@ const (
 
 var _ model.Locator = DeploymentConfigLocator
 var _ model.Revertor = DeploymentConfigRevertor
+var _ model.Manipulator = deploymentConfigManipulator{}
+
+// DeploymentConfigManipulator represents a model.Manipulator implementation for handling DeploymentConfig objects
+func DeploymentConfigManipulator(engine template.Engine) model.Manipulator {
+	return deploymentConfigManipulator{engine: engine}
+}
+
+type deploymentConfigManipulator struct {
+	engine template.Engine
+}
+
+func (d deploymentConfigManipulator) TargetResourceType() client.Object {
+	return &appsv1.DeploymentConfig{}
+}
+func (d deploymentConfigManipulator) Mutate() model.Mutator {
+	return DeploymentConfigMutator(d.engine)
+}
+func (d deploymentConfigManipulator) Revert() model.Revertor {
+	return DeploymentConfigRevertor
+}
 
 // DeploymentConfigLocator attempts to locate a DeploymentConfig kind based on Ref name.
 func DeploymentConfigLocator(ctx model.SessionContext, ref *model.Ref) bool {

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -187,6 +187,29 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
+		It("should recreate cloned DeploymentConfig if deleted externally", func() {
+			// given a normal setup
+			ref := CreateTestRef()
+			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo("v1-test"))
+
+			// when DeploymentConfig is deleted
+			c.Delete(ctx, &deployment)
+
+			_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(err).To(HaveOccurred())
+
+			// then it should be recreated on next reconcile
+			mutatorErr = openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			deployment = get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo("v1-test"))
+		})
+
 		Context("telepresence mutation strategy", func() {
 
 			It("should change container to telepresence", func() {

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
 	"github.com/maistra/istio-workspace/pkg/openshift"
+	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/pkg/template"
 	"github.com/maistra/istio-workspace/test/testclient"
 
@@ -140,6 +141,15 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 					},
 				},
 			}
+		})
+
+		It("should add reference to cloned deployment", func() {
+			ref := CreateTestRef()
+			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
+			Expect(mutatorErr).ToNot(HaveOccurred())
+
+			dc := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			Expect(reference.Get(&dc)).To(HaveLen(1))
 		})
 
 		It("should add suffix to the cloned deploymentconfig", func() {

--- a/pkg/reference/enqueue_annotations.go
+++ b/pkg/reference/enqueue_annotations.go
@@ -64,14 +64,14 @@ type EnqueueRequestForAnnotation struct {
 
 var _ crtHandler.EventHandler = &EnqueueRequestForAnnotation{}
 
-// Create implements EventHandler
+// Create implements EventHandler.
 func (e *EnqueueRequestForAnnotation) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	if ok, req := e.getAnnotationRequests(evt.Object); ok {
 		q.Add(req)
 	}
 }
 
-// Update implements EventHandler
+// Update implements EventHandler.
 func (e *EnqueueRequestForAnnotation) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	if ok, req := e.getAnnotationRequests(evt.ObjectOld); ok {
 		q.Add(req)
@@ -81,14 +81,14 @@ func (e *EnqueueRequestForAnnotation) Update(evt event.UpdateEvent, q workqueue.
 	}
 }
 
-// Delete implements EventHandler
+// Delete implements EventHandler.
 func (e *EnqueueRequestForAnnotation) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	if ok, req := e.getAnnotationRequests(evt.Object); ok {
 		q.Add(req)
 	}
 }
 
-// Generic implements EventHandler
+// Generic implements EventHandler.
 func (e *EnqueueRequestForAnnotation) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	if ok, req := e.getAnnotationRequests(evt.Object); ok {
 		q.Add(req)

--- a/pkg/reference/enqueue_annotations.go
+++ b/pkg/reference/enqueue_annotations.go
@@ -148,7 +148,9 @@ func Add(owner types.NamespacedName, object client.Object) error {
 	return nil
 }
 
-// Remove.
+// Remove helps in removing 'NamespacedNameAnnotation' from object based on
+// the NamespaceName. The object gets the annotations from owner's namespace, name, group
+// and kind. Annotations are accumulated as a comma-separated list, thus removal will change the content of the list.
 func Remove(owner types.NamespacedName, object client.Object) error {
 	if owner.Namespace == "" {
 		return fmt.Errorf("%T does not have a namespace, cannot call Remove", owner)
@@ -179,7 +181,7 @@ func Remove(owner types.NamespacedName, object client.Object) error {
 	return nil
 }
 
-// Get.
+// Get converts annotations defined for NamespacedNameAnnotation as comma-separated list to a slice.
 func Get(object client.Object) []types.NamespacedName {
 	var typeNames []types.NamespacedName
 	annotations := object.GetAnnotations()
@@ -199,7 +201,7 @@ func Get(object client.Object) []types.NamespacedName {
 // addToQueue adds a slice of Reconcile Requests to the queue.
 func (e *EnqueueRequestForAnnotation) addToQueue(q workqueue.RateLimitingInterface, requests []reconcile.Request) {
 	for _, request := range requests {
-		q.Add((request))
+		q.Add(request)
 	}
 }
 

--- a/pkg/reference/enqueue_annotations.go
+++ b/pkg/reference/enqueue_annotations.go
@@ -1,3 +1,19 @@
+// Based on https://github.com/operator-framework/operator-lib/blob/8c3d48f55639528bcee4432b570bc6671900b75d/handler/enqueue_annotation.go
+// Main changes are about allowing to store multiple values of a given annotation as comma-separated list.
+//
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package reference
 
 import (

--- a/pkg/reference/enqueue_annotations_test.go
+++ b/pkg/reference/enqueue_annotations_test.go
@@ -1,0 +1,36 @@
+package reference_test
+
+import (
+	"github.com/maistra/istio-workspace/pkg/reference"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Enqueue Annotations", func() {
+
+	var deployment *appsv1.Deployment
+
+	BeforeEach(func() {
+		deployment = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ref",
+				Namespace: "test",
+			},
+		}
+	})
+
+	It("should add single reference when single session exist", func() {
+
+		reference.SetOwnerAnnotations(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+
+		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To((Equal("test/session1")))
+
+	})
+	PIt("should add multiple reference when multiple session exist", func() {})
+	PIt("should remove single reference when multiple session exist", func() {})
+	PIt("should remove reference when no session exist", func() {})
+
+})

--- a/pkg/reference/enqueue_annotations_test.go
+++ b/pkg/reference/enqueue_annotations_test.go
@@ -24,6 +24,17 @@ var _ = Describe("Enqueue Annotations", func() {
 		}
 	})
 
+	It("should fail to add when missing namespace", func() {
+		// when
+		err := reference.Add(types.NamespacedName{Name: "session1"}, deployment)
+		Expect(err).To((HaveOccurred()))
+	})
+	It("should fail to add when missing name", func() {
+		// when
+		err := reference.Add(types.NamespacedName{Namespace: "test"}, deployment)
+		Expect(err).To((HaveOccurred()))
+	})
+
 	It("should add single reference when single session exist", func() {
 		// when
 		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
@@ -52,6 +63,17 @@ var _ = Describe("Enqueue Annotations", func() {
 		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session1,test/session2"))
 	})
 
+	It("should fail to remove when missing namespace", func() {
+		// when
+		err := reference.Remove(types.NamespacedName{Name: "session1"}, deployment)
+		Expect(err).To((HaveOccurred()))
+	})
+	It("should fail to remove when missing name", func() {
+		// when
+		err := reference.Remove(types.NamespacedName{Namespace: "test"}, deployment)
+		Expect(err).To((HaveOccurred()))
+	})
+
 	It("should remove reference when no reference exist", func() {
 		// given
 		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
@@ -75,4 +97,27 @@ var _ = Describe("Enqueue Annotations", func() {
 		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session2"))
 	})
 
+	It("should get references when one reference exist", func() {
+		// given
+		Expect(reference.Get(deployment)).To(HaveLen(0))
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+
+		// then
+		typeNames := reference.Get(deployment)
+		Expect(typeNames).To(HaveLen(1))
+		Expect(typeNames[0].String()).To(Equal("test/session1"))
+	})
+
+	It("should get references when multiple reference exist", func() {
+		// given
+		Expect(reference.Get(deployment)).To(HaveLen(0))
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session2"}, deployment)
+
+		// then
+		typeNames := reference.Get(deployment)
+		Expect(typeNames).To(HaveLen(2))
+		Expect(typeNames[0].String()).To(Equal("test/session1"))
+		Expect(typeNames[1].String()).To(Equal("test/session2"))
+	})
 })

--- a/pkg/reference/enqueue_annotations_test.go
+++ b/pkg/reference/enqueue_annotations_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Enqueue Annotations", func() {
 		err := reference.Add(types.NamespacedName{Name: "session1"}, deployment)
 		Expect(err).To((HaveOccurred()))
 	})
+
 	It("should fail to add when missing name", func() {
 		// when
 		err := reference.Add(types.NamespacedName{Namespace: "test"}, deployment)

--- a/pkg/reference/enqueue_annotations_test.go
+++ b/pkg/reference/enqueue_annotations_test.go
@@ -1,12 +1,14 @@
 package reference_test
 
 import (
-	"github.com/maistra/istio-workspace/pkg/reference"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/maistra/istio-workspace/pkg/reference"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Enqueue Annotations", func() {
@@ -26,7 +28,7 @@ var _ = Describe("Enqueue Annotations", func() {
 
 		reference.SetOwnerAnnotations(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
 
-		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To((Equal("test/session1")))
+		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session1"))
 
 	})
 	PIt("should add multiple reference when multiple session exist", func() {})

--- a/pkg/reference/enqueue_annotations_test.go
+++ b/pkg/reference/enqueue_annotations_test.go
@@ -66,12 +66,12 @@ var _ = Describe("Enqueue Annotations", func() {
 	It("should fail to remove when missing namespace", func() {
 		// when
 		err := reference.Remove(types.NamespacedName{Name: "session1"}, deployment)
-		Expect(err).To((HaveOccurred()))
+		Expect(err).To(HaveOccurred())
 	})
 	It("should fail to remove when missing name", func() {
 		// when
 		err := reference.Remove(types.NamespacedName{Namespace: "test"}, deployment)
-		Expect(err).To((HaveOccurred()))
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should remove reference when no reference exist", func() {

--- a/pkg/reference/enqueue_annotations_test.go
+++ b/pkg/reference/enqueue_annotations_test.go
@@ -25,14 +25,54 @@ var _ = Describe("Enqueue Annotations", func() {
 	})
 
 	It("should add single reference when single session exist", func() {
+		// when
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
 
-		reference.SetOwnerAnnotations(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
-
+		// then
 		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session1"))
 
 	})
-	PIt("should add multiple reference when multiple session exist", func() {})
-	PIt("should remove single reference when multiple session exist", func() {})
-	PIt("should remove reference when no session exist", func() {})
+
+	It("should add multiple reference when multiple session exist", func() {
+		// when
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session2"}, deployment)
+
+		// then
+		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session1,test/session2"))
+	})
+
+	It("should prevent from having duplicate annotations", func() {
+		// when
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session2"}, deployment)
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+
+		// then
+		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session1,test/session2"))
+	})
+
+	It("should remove reference when no reference exist", func() {
+		// given
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+
+		// when
+		reference.Remove(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+
+		// then
+		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(BeEmpty())
+	})
+
+	It("should remove single reference when multiple reference exist", func() {
+		// given
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+		reference.Add(types.NamespacedName{Namespace: "test", Name: "session2"}, deployment)
+
+		// when
+		reference.Remove(types.NamespacedName{Namespace: "test", Name: "session1"}, deployment)
+
+		// then
+		Expect(deployment.Annotations[reference.NamespacedNameAnnotation]).To(Equal("test/session2"))
+	})
 
 })

--- a/pkg/reference/reference_suite_test.go
+++ b/pkg/reference/reference_suite_test.go
@@ -1,0 +1,24 @@
+package reference_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+
+	. "github.com/maistra/istio-workspace/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSessionController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecWithJUnitReporter(t, "Reference Enqueue Suite")
+}
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	goleak.VerifyNone(GinkgoT(),
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"),
+	)
+})


### PR DESCRIPTION
#### Short description of what this resolves:

Any of the manipulated Resource can be changed externally at any time and break the Session, either via manual or redeploys scripts etc.

#### Changes proposed in this pull request:

Watch all manipulated Resources for possible change and reconcile if needed.

Fixes #618