### PR TITLE
fix: improves readability of section headers in release notes

### DIFF
--- a/docs/modules/ROOT/pages/release_notes/release_notes_template.adoc
+++ b/docs/modules/ROOT/pages/release_notes/release_notes_template.adoc
@@ -6,6 +6,6 @@ Summary - focus of the release
 
 Why is that cool and important?
 
-== All changes in this release
+=== All changes in this release
 
 // changelog:generate

--- a/docs/modules/ROOT/pages/release_notes/v0.0.5.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.5.adoc
@@ -4,39 +4,39 @@ The main focus of this release was to move to the new version of the `Operator S
 
 image::operator_all_the_things.jpg[Operator All the Things]
 
-== All changes in this release
+=== All changes in this release
 
 // changelog:generate content will be appended below
-=== Command line
+==== Command line
 
 
-==== Bugs
+===== Bugs
 * fix(cli): watch run command status and log errors (https://github.com/maistra/istio-workspace/pull/650[#650]), by https://github.com/aslakknutsen[@aslakknutsen]
 * fix(cli): print full url to image being used for install (https://github.com/maistra/istio-workspace/pull/638[#638]), by https://github.com/aslakknutsen[@aslakknutsen]
 
-=== Operator
+==== Operator
 
-==== New features
+===== New features
 * fix(log): add log caller to structured logger (https://github.com/maistra/istio-workspace/pull/651[#651]), by https://github.com/aslakknutsen[@aslakknutsen]
 * feat(operator): introduces operator-sdk bundle creation (https://github.com/maistra/istio-workspace/pull/648[#648]), by https://github.com/aslakknutsen[@aslakknutsen]
 
 
-=== Project infrastructure
+==== Project infrastructure
 
-==== New features
+===== New features
 * chore: moves dev images to rely on maistra-dev repo (https://github.com/maistra/istio-workspace/pull/652[#652]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 
 
-=== Testing
+==== Testing
 
-==== New features
+===== New features
 * chore: moves dev images to rely on maistra-dev repo (https://github.com/maistra/istio-workspace/pull/652[#652]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 * fix(e2e): replace usage of ruby with python to limit dev container size (https://github.com/maistra/istio-workspace/pull/640[#640]), by https://github.com/aslakknutsen[@aslakknutsen]
 
-==== Bugs
+===== Bugs
 * fix(circle): tree hash propagates properly to avoid redundant job runs (https://github.com/maistra/istio-workspace/pull/657[#657]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 
-== Latest dependencies update
+=== Latest dependencies update
 
  * github.com/go-logr/logr to 0.4.0 (https://github.com/maistra/istio-workspace/pull/647[#647]), by https://github.com/dependabot[@dependabot]
  * github.com/go-logr/zapr to 0.4.0 (https://github.com/maistra/istio-workspace/pull/645[#645]), by https://github.com/dependabot[@dependabot]

--- a/docs/modules/ROOT/pages/release_notes/v0.0.6.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.6.adoc
@@ -11,39 +11,39 @@ In this release we've been so lucky to get a little help from our new friend htt
 
 Thank you! :)
 
-== All changes in this release
+=== All changes in this release
 
 // changelog:generate
-=== Command line
+==== Command line
 
-==== New features
+===== New features
 * feat(cli): print usage hint including exposed hosts (https://github.com/maistra/istio-workspace/pull/692[#692]), by https://github.com/aslakknutsen[@aslakknutsen]
 * fix(cli): add k8s auth package (https://github.com/maistra/istio-workspace/pull/682[#682]), by https://github.com/Humpheh[@Humpheh]
 
 
-=== Operator
+==== Operator
 
-==== New features
+===== New features
 * feat(operator): support MultiNamespace install mode (https://github.com/maistra/istio-workspace/pull/680[#680]), by https://github.com/aslakknutsen[@aslakknutsen]
 
 
-=== Project infrastructure
+==== Project infrastructure
 
-==== New features
+===== New features
 * feat(gh-actions): enables /help cmd for releases (https://github.com/maistra/istio-workspace/pull/690[#690]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 * feat(operator): automates operator bundle submission (https://github.com/maistra/istio-workspace/pull/685[#685]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 
-==== Bugs
+===== Bugs
 * fix(release): enables operatorhub signed commits (https://github.com/maistra/istio-workspace/pull/689[#689]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 * fix(circle): uses custom gpg program to sign commits (https://github.com/maistra/istio-workspace/pull/687[#687]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 
-=== Testing
+==== Testing
 
-==== New features
+===== New features
 * chore: sets err buffer to be captured for tests (https://github.com/maistra/istio-workspace/pull/693[#693]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 
 
-== Latest dependencies update
+=== Latest dependencies update
 
  * github.com/onsi/ginkgo to 1.15.0 (https://github.com/maistra/istio-workspace/pull/669[#669]), by https://github.com/dependabot[@dependabot]
  * github.com/onsi/gomega to 1.10.5 (https://github.com/maistra/istio-workspace/pull/668[#668]), by https://github.com/dependabot[@dependabot]

--- a/docs/modules/ROOT/pages/release_notes/v0.0.7.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.7.adoc
@@ -10,25 +10,25 @@ You can now find the currently used Route reflected in `Session.Status.Route`.
 
 We've added better descriptions and some field-level documentation to the `CustomResourceDefintion` and the `ClusterServiceVersion`
 
-== All changes in this release
+=== All changes in this release
 
 // changelog:generate
-=== Documentation
+==== Documentation
 
-==== New features
+===== New features
 * fix(doc): add better description to the crd (https://github.com/maistra/istio-workspace/pull/704[#704]), by https://github.com/aslakknutsen[@aslakknutsen]
 
 
-=== Operator
+==== Operator
 
-==== New features
+===== New features
 * feat(operator): add description for crd in csv (https://github.com/maistra/istio-workspace/pull/703[#703]), by https://github.com/aslakknutsen[@aslakknutsen]
 * fix(operator): add route to status (https://github.com/maistra/istio-workspace/pull/701[#701]), by https://github.com/aslakknutsen[@aslakknutsen]
 
 
-=== Project infrastructure
+==== Project infrastructure
 
-==== New features
+===== New features
 * chore(images): move pr builds to maistra-dev org (https://github.com/maistra/istio-workspace/pull/700[#700]), by https://github.com/aslakknutsen[@aslakknutsen]
 
 

--- a/docs/modules/ROOT/pages/release_notes/v0.0.8.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.8.adoc
@@ -7,30 +7,28 @@ and reconcile the `Session` on any change.
 
 This means that even if a third-party tool reconfigures the current state, overwrites it, or pushes new releases, the operator will ensure that the special route is still operational.
 
-== All changes in this release
+=== All changes in this release
 
 // changelog:generate
-=== Command line
+==== Command line
 
-
-==== Bugs
+===== Bugs
 * fix(cli): guard against possible nil Route (https://github.com/maistra/istio-workspace/pull/717[#717]), by https://github.com/aslakknutsen[@aslakknutsen]
 
-=== Documentation
+==== Documentation
 
-==== New features
+===== New features
 * feat: automates sourcing CSV description from README (https://github.com/maistra/istio-workspace/pull/718[#718]), by https://github.com/bartoszmajsak[@bartoszmajsak]
 
+==== Operator
 
-=== Operator
-
-==== New features
+===== New features
 * feat(operator): watch manipulated resources for reconcile on change (https://github.com/maistra/istio-workspace/pull/719[#719]), by https://github.com/aslakknutsen[@aslakknutsen]
 
-==== Bugs
+===== Bugs
 * fix(operator): move to use leader election by lease (https://github.com/maistra/istio-workspace/pull/715[#715]), by https://github.com/aslakknutsen[@aslakknutsen]
 
-== Latest dependencies update
+=== Latest dependencies update
 
  * k8s.io/apimachinery to 0.20.4 (https://github.com/maistra/istio-workspace/pull/710[#710]), by https://github.com/dependabot[@dependabot]
  * k8s.io/client-go to 0.20.4 (https://github.com/maistra/istio-workspace/pull/713[#713]), by https://github.com/dependabot[@dependabot]


### PR DESCRIPTION
related fix: https://github.com/bartoszmajsak/github-changelog-generator/commit/7964493de9c97f91b88cec747a5ba39db007a332 (already released)

/skip-e2e


![image](https://user-images.githubusercontent.com/719616/109942019-0db7ea80-7cd4-11eb-87f5-395b428d82cb.png)

