### PR TITLE
fix(circle): updates executor machine to Ubuntu 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: "Install telepresence"
           command: |
             cd ~
-            pyenv global 3.5.2
+            pyenv global 3.9.1
             curl -s https://packagecloud.io/install/repositories/datawireio/telepresence/script.deb.sh | sudo bash
             sudo apt install --no-install-recommends telepresence
             telepresence --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults:
   docker:
     - image: &golang-img cimg/go:1.15.7
   machine-conf: &machine-conf
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202101-01
   skip-e2e-check: &skip-e2e-check
     name: "Check for /skip-e2e directive"
     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,12 +244,13 @@ jobs:
           name: "Configures PGP for signing commits in Git"
           command: |
             export GPG_PROGRAM="/usr/bin/gpg-passphrase"
-
-            echo -e $PGP_KEY | gpg --import
             sudo touch "${GPG_PROGRAM}"
             sudo chown $(whoami) "${GPG_PROGRAM}"
-            echo '/usr/bin/gpg --passphrase "${PGP_PASSPHRASE}" --batch --no-tty "$@"' > "${GPG_PROGRAM}"
+
             chmod +x "${GPG_PROGRAM}"
+            echo '/usr/bin/gpg --passphrase "${PGP_PASSPHRASE}" --batch --no-tty "$@"' > "${GPG_PROGRAM}"
+
+            echo -e $PGP_KEY | gpg --import --pinentry-mode loopback
             git config --global user.signingkey "${PGP_KEYID}"
             git config --global gpg.program "${GPG_PROGRAM}"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,9 +248,9 @@ jobs:
             sudo chown $(whoami) "${GPG_PROGRAM}"
 
             chmod +x "${GPG_PROGRAM}"
-            echo '/usr/bin/gpg --passphrase "${PGP_PASSPHRASE}" --batch --no-tty "$@"' > "${GPG_PROGRAM}"
+            echo '/usr/bin/gpg --passphrase "${PGP_PASSPHRASE}"  --pinentry-mode loopback --batch --no-tty "$@"' > "${GPG_PROGRAM}"
 
-            echo -e $PGP_KEY | gpg --import --pinentry-mode loopback
+            echo -e $PGP_KEY | gpg --import --pinentry-mode loopback --batch --no-tty
             git config --global user.signingkey "${PGP_KEYID}"
             git config --global gpg.program "${GPG_PROGRAM}"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,10 +220,12 @@ jobs:
       - run:
           <<: *node-install
       - run:
-          name: "Installs release tools prerequisites"
+          name: "Install release tools prerequisites"
           command: |
-            export PANDOC_VERSION=2.11.4
+            nvm use 10
             npm i -g asciidoctor @asciidoctor/core @asciidoctor/docbook-converter
+
+            export PANDOC_VERSION=2.11.4
             cd ~
             wget "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" -O "pandoc.tar.gz"
             tar xzfv pandoc.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,8 @@ jobs:
       - run:
           name: "Release client!"
           command: |
-            asciidoctor -b docbook -a leveloffset=+1 -o - docs/modules/ROOT/pages/release_notes/${CIRCLE_TAG}.adoc | pandoc --atx-headers --wrap=preserve -t markdown_strict -f docbook - 1> converted-release-notes.md
+            nvm use 10
+            asciidoctor --require @asciidoctor/docbook-converter -a leveloffset=+1 --backend docbook  -o - docs/modules/ROOT/pages/release_notes/${CIRCLE_TAG}.adoc |  pandoc --wrap=preserve --from docbook --to gfm - 1> converted-release-notes.md
             curl -sL https://git.io/goreleaser | bash -s -- release ${GORELEASER_OPTS} --rm-dist --release-notes=converted-release-notes.md
       - run:
           name: "Publish Operator Hub Catalog!"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,13 +212,20 @@ jobs:
     steps:
       - checkout
       - run:
+          <<: *golang-install
+      - run:
+          name: "Install Node"
+          command: |
+            sudo circleci-install nodejs 10
+      - run:
           name: "Installs release tools prerequisites"
           command: |
+            export PANDOC_VERSION=2.9
+            npm i -g asciidoctor @asciidoctor/core @asciidoctor/docbook-converter
             cd ~
-            gem install asciidoctor
-            wget "https://github.com/jgm/pandoc/releases/download/2.9/pandoc-2.9-linux-amd64.tar.gz" -O "pandoc.tar.gz"
+            wget "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" -O "pandoc.tar.gz"
             tar xzfv pandoc.tar.gz
-            sudo mv $PWD/pandoc-2.9/bin/pandoc /usr/local/bin/
+            sudo mv $PWD/pandoc-${PANDOC_VERSION}/bin/pandoc /usr/local/bin/
       - run:
           <<: *golang-install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,14 @@ defaults:
   golang-install: &golang-install
     name: "Install latest Golang"
     command: |
-      sudo rm -rf /usr/local/go
-      sudo circleci-install golang 1.15.7
+      sudo snap install go --classic --channel 1.15/stable
+  node-install: &node-install
+    name: "Install Node"
+    command: |
+      nvm install 10
+      nvm use 10
   docker:
-    - image: &golang-img cimg/go:1.15.7
+    - image: &golang-img cimg/go:1.15.8
   machine-conf: &machine-conf
     image: ubuntu-2004:202101-01
   skip-e2e-check: &skip-e2e-check
@@ -214,20 +218,16 @@ jobs:
       - run:
           <<: *golang-install
       - run:
-          name: "Install Node"
-          command: |
-            sudo circleci-install nodejs 10
+          <<: *node-install
       - run:
           name: "Installs release tools prerequisites"
           command: |
-            export PANDOC_VERSION=2.9
+            export PANDOC_VERSION=2.11.4
             npm i -g asciidoctor @asciidoctor/core @asciidoctor/docbook-converter
             cd ~
             wget "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" -O "pandoc.tar.gz"
             tar xzfv pandoc.tar.gz
             sudo mv $PWD/pandoc-${PANDOC_VERSION}/bin/pandoc /usr/local/bin/
-      - run:
-          <<: *golang-install
       - run:
           name: "Sets up Quay.io"
           command: |
@@ -253,19 +253,35 @@ jobs:
             git config --global user.signingkey "${PGP_KEYID}"
             git config --global gpg.program "${GPG_PROGRAM}"
       - run:
+          <<: *obtain-tree-hash
+          when: always
+      - restore_cache:
+          <<: *restore-tree-hash
+      - run:
           name: "Push it!"
           command: |
             make deps tools docker-build docker-push-versioned bundle bundle-build bundle-push
       - run:
-          name: "Publish it!"
-          command: |
-            OPERATOR_HUB="upstream-community-operators" make bundle-publish
-            OPERATOR_HUB="community-operators" make bundle-publish
-      - run:
-          name: "Release it!"
+          name: "Release client!"
           command: |
             asciidoctor -b docbook -a leveloffset=+1 -o - docs/modules/ROOT/pages/release_notes/${CIRCLE_TAG}.adoc | pandoc --atx-headers --wrap=preserve -t markdown_strict -f docbook - 1> converted-release-notes.md
             curl -sL https://git.io/goreleaser | bash -s -- release ${GORELEASER_OPTS} --rm-dist --release-notes=converted-release-notes.md
+      - run:
+          name: "Publish Operator Hub Catalog!"
+          command: |
+            if [[ -f ${BUILD_CACHE_FOLDER}/operatorhub.githash ]]; then
+              echo "This exact code base has been successfully pushed"
+            else
+              echo "New build - if succeeds build git hash will be cached"
+
+              OPERATOR_HUB="upstream-community-operators" make bundle-publish
+              OPERATOR_HUB="community-operators" make bundle-publish
+
+              echo "${TREE_SHA1}" > ${BUILD_CACHE_FOLDER}/operatorhub.githash
+            fi
+      - save_cache:
+          <<: *save-tree-hash
+          when: always
 
 workflows:
   version: 2.1


### PR DESCRIPTION
#### Short description of what this resolves:

Old 16.04 version wasn't even able to `apt-get curl` anymore as repos are unreachable. This PR bumps infra for e2e tests (and release process) to latest supported Ubuntu version.

#### Changes proposed in this pull request:

- bumps executor machine to ubuntu 20.04
- switches asciidoctor from gem to node module (and ensures node 10 is used)
- minor fix for gpg signing as the version update changed behaviour a bit (tty / passthrough options)
- bumps python to 3.9.1
- bumps pandoc to 2.11.4
