### PR TITLE
fix: do not ignore errors when outputting in json

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/maistra/istio-workspace/pkg/cmd/completion"
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	"github.com/maistra/istio-workspace/pkg/cmd/format"
@@ -36,8 +38,7 @@ func NewCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				if flag.Changed && strings.Join(flag.Annotations["silent"], "") == "true" {
-					//log.SetLogger(log.NilLog)
-					//cmd.SilenceErrors = true
+					log.SetLogger(log.CreateOperatorAwareLoggerWithLevel("root", zapcore.ErrorLevel))
 				}
 			})
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -36,8 +36,8 @@ func NewCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				if flag.Changed && strings.Join(flag.Annotations["silent"], "") == "true" {
-					log.SetLogger(log.NilLog)
-					cmd.SilenceErrors = true
+					//log.SetLogger(log.NilLog)
+					//cmd.SilenceErrors = true
 				}
 			})
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -29,60 +29,58 @@ func SetLogger(logger logr.Logger) {
 
 // CreateOperatorAwareLogger will set logging format to JSON when ran as operator or plain text when used as CLI.
 func CreateOperatorAwareLogger(name string) logr.Logger {
-	return CreateOperatorAwareLoggerWithLevel(name, zap.InfoLevel)
+	level := zap.InfoLevel
+	if isDebugModeEnabled() {
+		level = zap.DebugLevel
+	}
+	return CreateOperatorAwareLoggerWithLevel(name, level)
 }
 
 // CreateOperatorAwareLogger will set logging format to JSON when ran as operator or plain text when used as CLI.
 func CreateOperatorAwareLoggerWithLevel(name string, level zapcore.Level) logr.Logger {
 	var opts []zap.Option
 	var enc zapcore.Encoder
-	var lvl zap.AtomicLevel
 
 	operator := isRunningAsOperator()
 	sink := zapcore.AddSync(os.Stderr)
 
-	// TODO: move lvl to a single location
-	// TODO: support DEBUG level in both client & Operator
-
 	if operator {
-		enc, lvl, opts = configureOperatorLogging()
+		enc, opts = configureOperatorLogging()
 	} else {
-		enc, lvl, opts = configureCliLogging()
+		enc, opts = configureCliLogging()
 	}
 
 	opts = append(opts, zap.AddCaller(), zap.ErrorOutput(sink))
 
 	encoder := &zapr.KubeAwareEncoder{Encoder: enc, Verbose: !operator}
-	log := zap.New(zapcore.NewCore(encoder, sink, lvl))
+	log := zap.New(zapcore.NewCore(encoder, sink, zap.NewAtomicLevelAt(level)))
 	log = log.Named(name).WithOptions(opts...)
 
 	return zapr2.NewLogger(log)
 }
 
-func configureCliLogging() (enc zapcore.Encoder, lvl zap.AtomicLevel, opts []zap.Option) {
+func configureCliLogging() (zapcore.Encoder, []zap.Option) {
+	var enc zapcore.Encoder
+	var opts []zap.Option
 	encCfg := newCliEncoderConfig()
-	lvl = zap.NewAtomicLevelAt(zap.InfoLevel)
-	if debugLevel, found := os.LookupEnv("IKE_LOG_DEBUG"); found {
-		if debug, _ := strconv.ParseBool(debugLevel); debug {
-			zap.NewAtomicLevelAt(zap.DebugLevel)
-			enc = zapcore.NewConsoleEncoder(encCfg)
-		}
+	if isDebugModeEnabled() {
+		enc = zapcore.NewConsoleEncoder(encCfg)
 	} else {
 		enc = newFilteringEncoder(zapcore.NewConsoleEncoder(encCfg))
 	}
 	opts = append(opts, zap.Development(), zap.AddStacktrace(zap.ErrorLevel))
-	return
+	return enc, opts
 }
 
-func configureOperatorLogging() (enc zapcore.Encoder, lvl zap.AtomicLevel, opts []zap.Option) {
+func configureOperatorLogging() (zapcore.Encoder, []zap.Option) {
 	encCfg := zap.NewProductionEncoderConfig()
-	enc = zapcore.NewJSONEncoder(encCfg)
-	lvl = zap.NewAtomicLevelAt(zap.InfoLevel)
+	enc := zapcore.NewJSONEncoder(encCfg)
+	var opts []zap.Option
 	opts = append(opts, zap.AddStacktrace(zap.WarnLevel),
 		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
 		}))
-	return
+	return enc, opts
 }
 
 func newCliEncoderConfig() zapcore.EncoderConfig {
@@ -97,4 +95,9 @@ func newCliEncoderConfig() zapcore.EncoderConfig {
 func isRunningAsOperator() bool {
 	_, runningInCluster := os.LookupEnv("OPERATOR_NAME")
 	return runningInCluster
+}
+
+func isDebugModeEnabled() bool {
+	debug, _ := strconv.ParseBool(os.Getenv("IKE_LOG_DEBUG"))
+	return debug
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -29,12 +29,20 @@ func SetLogger(logger logr.Logger) {
 
 // CreateOperatorAwareLogger will set logging format to JSON when ran as operator or plain text when used as CLI.
 func CreateOperatorAwareLogger(name string) logr.Logger {
+	return CreateOperatorAwareLoggerWithLevel(name, zap.InfoLevel)
+}
+
+// CreateOperatorAwareLogger will set logging format to JSON when ran as operator or plain text when used as CLI.
+func CreateOperatorAwareLoggerWithLevel(name string, level zapcore.Level) logr.Logger {
 	var opts []zap.Option
 	var enc zapcore.Encoder
 	var lvl zap.AtomicLevel
 
 	operator := isRunningAsOperator()
 	sink := zapcore.AddSync(os.Stderr)
+
+	// TODO: move lvl to a single location
+	// TODO: support DEBUG level in both client & Operator
 
 	if operator {
 		enc, lvl, opts = configureOperatorLogging()


### PR DESCRIPTION
#### Short description of what this resolves:

Cleans up logging and error handling when using `--json` for `ike create`

#### Changes proposed in this pull request:

- general `log.go` cleanup (levels, creation)
- fixes error logging when using `--json` flag

Fixes #739
