### PR TITLE
fix(operator): avoid reusing version in clone name

### DIFF
--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-mutate")
-				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal("v1-test"))))
+				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
 			})
 
 			It("new subset only added once", func() {
@@ -142,7 +142,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 
 				dr := get.DestinationRule("test", "customer-mutate")
 				Expect(dr.Spec.Subsets).To(HaveLen(2))
-				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal("v1-test"))))
+				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
 			})
 		})
 	})
@@ -186,7 +186,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRule("test", "customer-revert")
-				Expect(dr.Spec.Subsets).ToNot(ContainElement(WithTransform(GetName, Equal("v1-test"))))
+				Expect(dr.Spec.Subsets).ToNot(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
 			})
 		})
 	})

--- a/pkg/istio/virtualservice_test.go
+++ b/pkg/istio/virtualservice_test.go
@@ -148,16 +148,16 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 					ref            model.Ref
 					targetV1       = model.NewLocatedResource("Deployment", "details-v1", map[string]string{"version": "v1"})
 					targetV1Host   = model.HostName{Name: "details"}
-					targetV1Subset = "v1-vs-test"
+					targetV1Subset = model.GetSha("v1") + "-vs-test"
 					targetV4       = model.NewLocatedResource("Deployment", "details-v4", map[string]string{"version": "v4"})
 					targetV4Host   = model.HostName{Name: "details"}
-					targetV4Subset = "v4-vs-test"
+					targetV4Subset = model.GetSha("v4") + "-vs-test"
 					targetV5       = model.NewLocatedResource("Deployment", "details-v5", map[string]string{"version": "v5"})
 					targetV5Host   = model.HostName{Name: "details"}
-					targetV5Subset = "v5-vs-test"
+					targetV5Subset = model.GetSha("v5") + "-vs-test"
 					targetV6       = model.NewLocatedResource("Deployment", "x-v5", map[string]string{"version": "v5"})
 					targetV6Host   = model.HostName{Name: "x"}
-					targetV6Subset = "v5-vs-test"
+					targetV6Subset = model.GetSha("v5") + "-vs-test"
 				)
 
 				BeforeEach(func() {
@@ -351,7 +351,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 										{
 											Destination: &istionetworkv1alpha3.Destination{
 												Host:   "details",
-												Subset: "v1-vs-test",
+												Subset: model.GetSha("v1") + "-vs-test",
 											},
 										},
 									},
@@ -368,7 +368,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 										{
 											Destination: &istionetworkv1alpha3.Destination{
 												Host:   "details",
-												Subset: "v1-vs-test",
+												Subset: model.GetSha("v1") + "-vs-test",
 											},
 										},
 									},
@@ -461,7 +461,7 @@ var _ = Describe("Operations for istio VirtualService kind", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					virtualService := get.VirtualService("test", "details")
-					Expect(virtualService.Spec.Http[0].Route[0].Destination.Subset).ToNot(Equal("v1-vs-test"))
+					Expect(virtualService.Spec.Http[0].Route[0].Destination.Subset).ToNot(Equal(model.GetSha("v1") + "-vs-test"))
 				})
 			})
 		})

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			d := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			d := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(reference.Get(&d)).To(HaveLen(1))
 		})
 
@@ -148,7 +148,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_ = get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_ = get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 		})
 
 		It("should remove liveness probe from cloned deployment", func() {
@@ -156,7 +156,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 		})
 
@@ -165,7 +165,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 		})
 
@@ -174,7 +174,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
@@ -184,7 +184,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &notMatchingRef)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, err := get.DeploymentWithError(ctx.Namespace, notMatchingRef.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, err := get.DeploymentWithError(ctx.Namespace, notMatchingRef.Name+"-"+notMatchingRef.GetNewVersion(ctx.Name))
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -195,20 +195,20 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 
 			// when Deployment is deleted
 			c.Delete(ctx, &deployment)
 
-			_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(err).To(HaveOccurred())
 
 			// then it should be recreated on next reconcile
 			mutatorErr = k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment = get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment = get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
@@ -219,7 +219,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+				deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("datawire/telepresence-k8s:"))
 			})
 
@@ -228,7 +228,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+				deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("TELEPRESENCE_CONTAINER_NAMESPACE"))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
@@ -244,7 +244,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+				_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
@@ -290,13 +290,13 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, mutatedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, mutatedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(mutatedFetchErr).ToNot(HaveOccurred())
 
 			revertorErr := k8s.DeploymentRevertor(ctx, &ref)
 			Expect(revertorErr).ToNot(HaveOccurred())
 
-			_, revertedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, revertedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(revertedFetchErr).To(HaveOccurred())
 			Expect(errors.IsNotFound(revertedFetchErr)).To(BeTrue())
 		})

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			d := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			d := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(reference.Get(&d)).To(HaveLen(1))
 		})
 
@@ -148,7 +148,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_ = get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_ = get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 		})
 
 		It("should remove liveness probe from cloned deployment", func() {
@@ -156,7 +156,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 		})
 
@@ -165,7 +165,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 		})
 
@@ -174,9 +174,9 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
-			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo("v1-test"))
+			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
 		It("should only mutate if Target is of kind Deployment", func() {
@@ -184,7 +184,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &notMatchingRef)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, err := get.DeploymentWithError(ctx.Namespace, notMatchingRef.Name+"-v1-"+ctx.Name)
+			_, err := get.DeploymentWithError(ctx.Namespace, notMatchingRef.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -195,21 +195,21 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
-			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo("v1-test"))
+			deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 
 			// when Deployment is deleted
 			c.Delete(ctx, &deployment)
 
-			_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(err).To(HaveOccurred())
 
 			// then it should be recreated on next reconcile
 			mutatorErr = k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment = get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
-			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo("v1-test"))
+			deployment = get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			Expect(deployment.Spec.Selector.MatchLabels["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
 		Context("telepresence mutation strategy", func() {
@@ -219,7 +219,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("datawire/telepresence-k8s:"))
 			})
 
@@ -228,7 +228,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.Deployment(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				deployment := get.Deployment(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("TELEPRESENCE_CONTAINER_NAMESPACE"))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
@@ -244,7 +244,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 				mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				_, err := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
@@ -290,13 +290,13 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 			mutatorErr := k8s.DeploymentMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, mutatedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_, mutatedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(mutatedFetchErr).ToNot(HaveOccurred())
 
 			revertorErr := k8s.DeploymentRevertor(ctx, &ref)
 			Expect(revertorErr).ToNot(HaveOccurred())
 
-			_, revertedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_, revertedFetchErr := get.DeploymentWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(revertedFetchErr).To(HaveOccurred())
 			Expect(errors.IsNotFound(revertedFetchErr)).To(BeTrue())
 		})

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -148,7 +149,7 @@ func (r *Ref) GetVersion() string {
 
 // GetNewVersion returns the new updated version name.
 func (r *Ref) GetNewVersion(sessionName string) string {
-	return r.GetVersion() + "-" + sessionName
+	return GetSha(r.GetVersion()) + "-" + sessionName
 }
 
 // AddTargetResource adds the status of an involved Resource to this ref.
@@ -197,6 +198,12 @@ func (r *Ref) GetResources(predicate Predicate) []ResourceStatus {
 		}
 	}
 	return refs
+}
+
+func GetSha(version string) string {
+	sum := sha256.Sum256([]byte(version))
+	sha := fmt.Sprintf("%x", sum)
+	return sha[:8]
 }
 
 // ResourceStatus holds information about the resources created/changed to fulfill a Ref.

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -200,6 +200,7 @@ func (r *Ref) GetResources(predicate Predicate) []ResourceStatus {
 	return refs
 }
 
+// GetSha computes a hash of the version and returns 8 characters substring of it.
 func GetSha(version string) string {
 	sum := sha256.Sum256([]byte(version))
 	sha := fmt.Sprintf("%x", sum)

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			dc := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			dc := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(reference.Get(&dc)).To(HaveLen(1))
 		})
 
@@ -157,7 +157,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_ = get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_ = get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 		})
 
 		It("should remove liveness probe from cloned deployment", func() {
@@ -165,7 +165,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 		})
 
@@ -174,7 +174,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 		})
 
@@ -183,7 +183,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
@@ -192,7 +192,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &notMatchingRef)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, err := get.DeploymentConfigWithError(ctx.Namespace, notMatchingRef.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, err := get.DeploymentConfigWithError(ctx.Namespace, notMatchingRef.Name+"-"+notMatchingRef.GetNewVersion(ctx.Name))
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -203,20 +203,20 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 
 			// when DeploymentConfig is deleted
 			c.Delete(ctx, &deployment)
 
-			_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(err).To(HaveOccurred())
 
 			// then it should be recreated on next reconcile
 			mutatorErr = openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment = get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			deployment = get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
@@ -227,7 +227,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("datawire/telepresence-k8s:"))
 			})
 
@@ -236,7 +236,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("TELEPRESENCE_CONTAINER_NAMESPACE"))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
@@ -252,7 +252,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+				_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
@@ -295,13 +295,13 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, mutatedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, mutatedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(mutatedFetchErr).ToNot(HaveOccurred())
 
 			revertorErr := openshift.DeploymentConfigRevertor(ctx, &ref)
 			Expect(revertorErr).ToNot(HaveOccurred())
 
-			_, revertedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			_, revertedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+ref.GetNewVersion(ctx.Name))
 			Expect(revertedFetchErr).To(HaveOccurred())
 			Expect(errors.IsNotFound(revertedFetchErr)).To(BeTrue())
 		})

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			dc := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			dc := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(reference.Get(&dc)).To(HaveLen(1))
 		})
 
@@ -157,7 +157,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_ = get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_ = get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 		})
 
 		It("should remove liveness probe from cloned deployment", func() {
@@ -165,7 +165,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 		})
 
@@ -174,7 +174,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
 		})
 
@@ -183,8 +183,8 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
-			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo("v1-test"))
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
 		It("should only mutate if Target is of kind DeploymentConfig", func() {
@@ -192,7 +192,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &notMatchingRef)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, err := get.DeploymentConfigWithError(ctx.Namespace, notMatchingRef.Name+"-v1-"+ctx.Name)
+			_, err := get.DeploymentConfigWithError(ctx.Namespace, notMatchingRef.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -203,21 +203,21 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
-			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo("v1-test"))
+			deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 
 			// when DeploymentConfig is deleted
 			c.Delete(ctx, &deployment)
 
-			_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(err).To(HaveOccurred())
 
 			// then it should be recreated on next reconcile
 			mutatorErr = openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			deployment = get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
-			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo("v1-test"))
+			deployment = get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
+			Expect(deployment.Spec.Selector["version"]).To(BeEquivalentTo(model.GetSha("v1") + "-test"))
 		})
 
 		Context("telepresence mutation strategy", func() {
@@ -227,7 +227,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("datawire/telepresence-k8s:"))
 			})
 
@@ -236,7 +236,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				deployment := get.DeploymentConfig(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("TELEPRESENCE_CONTAINER_NAMESPACE"))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom).ToNot(BeNil())
 			})
@@ -252,7 +252,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 				mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 				Expect(mutatorErr).ToNot(HaveOccurred())
 
-				_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+				_, err := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
@@ -295,13 +295,13 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 			mutatorErr := openshift.DeploymentConfigMutator(template.NewDefaultEngine())(ctx, &ref)
 			Expect(mutatorErr).ToNot(HaveOccurred())
 
-			_, mutatedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_, mutatedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(mutatedFetchErr).ToNot(HaveOccurred())
 
 			revertorErr := openshift.DeploymentConfigRevertor(ctx, &ref)
 			Expect(revertorErr).ToNot(HaveOccurred())
 
-			_, revertedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-v1-"+ctx.Name)
+			_, revertedFetchErr := get.DeploymentConfigWithError(ctx.Namespace, ref.Name+"-"+model.GetSha("v1")+"-"+ctx.Name)
 			Expect(revertedFetchErr).To(HaveOccurred())
 			Expect(errors.IsNotFound(revertedFetchErr)).To(BeTrue())
 		})


### PR DESCRIPTION
The version number could be very long so only expose
a short sha version of it in the clone name.

Fixes #683