### PR TITLE
fix(script): do not require GITHUB_TOKEN in dryRun mode

### DIFF
--- a/scripts/release/operatorhub.sh
+++ b/scripts/release/operatorhub.sh
@@ -99,7 +99,7 @@ if [[ $runTests -ne 0 ]]; then
   "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"
 fi
 
-if [[ -z $GITHUB_TOKEN ]]; then
+if [[ ! $dryRun && -z $GITHUB_TOKEN ]]; then
   echo "Please provide GITHUB_TOKEN" && exit 1
 fi
 

--- a/scripts/release/tektoncatalog.sh
+++ b/scripts/release/tektoncatalog.sh
@@ -117,7 +117,7 @@ git commit -sS -m"${TITLE}
 
 ${COMMIT_MESSAGE}"
 
-if [[ -z $GITHUB_TOKEN ]]; then
+if [[ ! $dryRun && -z $GITHUB_TOKEN ]]; then
   echo "Please provide GITHUB_TOKEN" && exit 1
 fi
 


### PR DESCRIPTION
/skip-e2e

Signed-off-by: Aslak Knutsen <aslak@4fs.no>
