### PR TITLE
feat(circleci): caches snap deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: "Obtain snap cache version"
           command: |
-            echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 2 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 2 )" > /tmp/snap_version
+            echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snap_version
             cat /tmp/snap_version
       - run:
           <<: *obtain-tree-hash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,8 @@ jobs:
             - snap-cache-tar-{{ checksum "/tmp/snap_version" }}
       - run:
           name: "Restoring snap cache"
-          command: [[ -f ~/snap.tar ]] && sudo tar xzfv ~/snap.tar -C /
+          command: |
+            [[ -f ~/snap.tar ]] && sudo tar xzfv ~/snap.tar -C /
 
       - run:
           <<: *golang-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: "Restoring snap cache"
           command: |
-            [[ -f ~/snap.tar ]] && sudo tar xzfv ~/snap.tar -C /
+            [[ -f ~/snap.tar ]] && sudo tar xzfv ~/snap.tar -C / || true
 
       - run:
           <<: *golang-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
             - snap-cache-tar-{{ checksum "/tmp/snap_version" }}
       - run:
           name: "Restoring snap cache"
-          command: sudo tar xzfv ~/snap.tar -C /
+          command: [[ -f ~/snap.tar ]] && sudo tar xzfv ~/snap.tar -C /
 
       - run:
           <<: *golang-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: "Obtain snap cache version"
           command: |
-            echo "go-$(snap info go | grep "${GOLANG_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )-microk8s-$(snap info microk8s | grep "${MICROK8S_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )" > /tmp/snap_version
+            echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 2 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 2 )" > /tmp/snap_version
             cat /tmp/snap_version
       - run:
           <<: *obtain-tree-hash
@@ -201,7 +201,6 @@ jobs:
             - /snap/
             - /var/snap/
             - /var/lib/snapd/
-            - ~/snap
       - run:
           name: "Run end-to-end tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ defaults:
       ## TODO adjust release job
       cd ~/.snaps
       sudo snap ack golang.assert
-      sudo snap install golang.snap
+      sudo snap install golang.snap --classic
 
       echo "export GOROOT=/snap/go/current" >> $BASH_ENV
       ## cleaning up path: remove pre-installed golang version
@@ -156,7 +156,7 @@ jobs:
           command: |
             cd ~/.snaps
             sudo snap ack microk8s.assert
-            sudo snap install microk8s.snap
+            sudo snap install microk8s.snap --classic
       - save_cache:
           ## We want to save cache only if both installations were successful
           key: snaps-cache-{{ checksum "/tmp/snaps_version" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ defaults:
     IKE_E2E_MANAGE_CLUSTER: "false"
     IKE_LOG_DEBUG: "true"
     BUILD_CACHE_FOLDER: ".circleci/cache"
-    MICROK8S_VERSION: "1.18/stable"
+    MICROK8S_SNAP_VERSION: "1.18/stable"
+    GOLANG_SNAP_VERSION: "1.16/stable"
   golang-install: &golang-install
     name: "Install latest Golang"
     command: |
@@ -15,9 +16,6 @@ defaults:
       echo "export GOROOT=/snap/go/current" >> $BASH_ENV
       ## cleaning up path: remove pre-installed golang version
       sudo rm -rf /usr/local/go
-      echo "export GOVERSION=$(go version | cut -d' ' -f 3)" >> $BASH_ENV
-      echo "${GOVERSION}-$(snap info microk8s | grep "${MICROK8S_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )" > /tmp/snap_version
-      cat /tmp/snap_version
   node-install: &node-install
     name: "Install Node"
     command: |
@@ -98,10 +96,11 @@ jobs:
       <<: *env-vars
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
-            - snap-cache-{{ checksum "/tmp/snap_version" }}
+      - run:
+          name: "Obtain snap cache version"
+          command: |
+            echo "$(snap info go | grep "${GOLANG_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )-$(snap info microk8s | grep "${MICROK8S_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )" > /tmp/snap_version
+            cat /tmp/snap_version
       - run:
           <<: *obtain-tree-hash
       - restore_cache:
@@ -110,6 +109,10 @@ jobs:
           <<: *check-if-build-executed
       - run:
           <<: *skip-e2e-check
+      - restore_cache:
+          keys:
+            - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
+            - snap-cache-{{ checksum "/tmp/snap_version" }}
       - run:
           <<: *golang-install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snaps_version
       - restore_cache:
           keys:
-            - snaps-cache-{{ checksum "/tmp/snaps_version" }}
+            - snap-cache-v1-{{ checksum "/tmp/snaps_version" }}
       - run:
           name: "Downloading snaps (if not restored)"
           command: |
@@ -125,8 +125,9 @@ jobs:
             if [[ ! -d .snaps ]]; then
                 mkdir -p .snaps
                 cd .snaps
-                sudo snap download microk8s --channel ${MICROK8S_SNAP_VERSION} --basename microk8s
-                sudo snap download go --channel ${GOLANG_SNAP_VERSION} --basename golang
+                snap download microk8s --channel ${MICROK8S_SNAP_VERSION} --basename microk8s
+                snap download core --channel stable --basename core
+                snap download go --channel ${GOLANG_SNAP_VERSION} --basename golang
             fi
       - run:
           <<: *golang-install
@@ -155,11 +156,13 @@ jobs:
           name: Install Microk8s
           command: |
             cd ~/.snaps
+            sudo snap ack core.assert
+            sudo snap install core.snap
             sudo snap ack microk8s.assert
             sudo snap install microk8s.snap --classic
       - save_cache:
           ## We want to save cache only if both installations were successful
-          key: snaps-cache-{{ checksum "/tmp/snaps_version" }}
+          key: snap-cache-v1-{{ checksum "/tmp/snaps_version" }}
           paths:
             - ~/.snaps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults:
   golang-install: &golang-install
     name: "Install latest Golang"
     command: |
-      ## TODO adjust release job
+      ## Requires snap caching to be also used in the job
       cd ~/.snaps
       sudo snap ack golang.assert
       sudo snap install golang.snap --classic
@@ -37,16 +37,6 @@ defaults:
         echo "/skip-e2e directive detected. Explictly stopping e2e tests."
         circleci step halt
       fi
-  obtain-tree-hash: &obtain-tree-hash
-    name: "Obtain git tree hash"
-    command: |
-      mkdir -p ${BUILD_CACHE_FOLDER}
-      export TREE_SHA1=$(git rev-parse HEAD:)
-      echo "export TREE_SHA1=${TREE_SHA1}" >> $BASH_ENV
-      echo ${TREE_SHA1} > /tmp/tree.sha1
-  restore-tree-hash: &restore-tree-hash
-      keys:
-        - job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }} # workaround for https://discuss.circleci.com/t/cannot-use-circle-yml-environment-variables-in-cache-keys/10994/20
   check-if-build-executed: &check-if-build-executed
     name: "Check if build with this content was already executed"
     command: |
@@ -57,10 +47,27 @@ defaults:
         echo "New build - if succeeds build git hash will be cached"
         echo "${TREE_SHA1}" > ${BUILD_CACHE_FOLDER}/${CIRCLE_JOB}.githash
       fi
+  obtain-tree-hash: &obtain-tree-hash
+    name: "Obtain git tree hash"
+    command: |
+      mkdir -p ${BUILD_CACHE_FOLDER}
+      export TREE_SHA1=$(git rev-parse HEAD:)
+      echo "export TREE_SHA1=${TREE_SHA1}" >> $BASH_ENV
+      echo ${TREE_SHA1} > /tmp/tree.sha1
+  restore-tree-hash: &restore-tree-hash
+      keys:
+        - job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }} # workaround for https://discuss.circleci.com/t/cannot-use-circle-yml-environment-variables-in-cache-keys/10994/20
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:
     - ./.circleci/cache # Can't use env variable here - needs to be explicit value
+  save-snaps: &save-snaps
+    key: snap-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/snaps_version" }}
+    paths:
+      - ~/.snaps
+  restore-snaps: &restore-snaps
+    keys:
+      - snap-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/snaps_version" }}
 
 jobs:
 
@@ -116,8 +123,7 @@ jobs:
           command: |
             echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snaps_version
       - restore_cache:
-          keys:
-            - snap-cache-v1-{{ checksum "/tmp/snaps_version" }}
+          <<: *restore-snaps
       - run:
           name: "Downloading snaps (if not restored)"
           command: |
@@ -132,7 +138,7 @@ jobs:
       - run:
           <<: *golang-install
       - run:
-          name: "Install telepresence"
+          name: "Install Telepresence"
           command: |
             cd ~
             pyenv global 3.9.1
@@ -161,10 +167,7 @@ jobs:
             sudo snap ack microk8s.assert
             sudo snap install microk8s.snap --classic
       - save_cache:
-          ## We want to save cache only if both installations were successful
-          key: snap-cache-v1-{{ checksum "/tmp/snaps_version" }}
-          paths:
-            - ~/.snaps
+          <<: *save-snaps
       - run:
           name: Launch Microk8s
           command: |
@@ -221,7 +224,7 @@ jobs:
             done
             echo "Tekton installed"
       - run:
-          name: "Run end-to-end tests"
+          name: "Runs end-to-end tests"
           command: |
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
 
@@ -265,6 +268,23 @@ jobs:
       <<: *env-vars
     steps:
       - checkout
+      - run:
+          name: "Calculate snap cache key"
+          command: |
+            echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snaps_version
+      - restore_cache:
+          <<: *restore-snaps
+      - run:
+          name: "Downloading snaps (if not restored)"
+          command: |
+            cd ~
+            if [[ ! -d .snaps ]]; then
+                mkdir -p .snaps
+                cd .snaps
+                snap download go --channel ${GOLANG_SNAP_VERSION} --basename golang
+            fi
+      - save_cache:
+          <<: *save-snaps
       - run:
           <<: *golang-install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ jobs:
           name: "Obtain snap cache version"
           command: |
             echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snap_version
-            cat /tmp/snap_version
       - run:
           <<: *obtain-tree-hash
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,11 @@ jobs:
             - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - snap-cache-{{ arch }}-{{ checksum "/tmp/snap_version" }}
+            - snap-cache-tar-{{ checksum "/tmp/snap_version" }}
+      - run:
+          name: "Restoring snap cache"
+          command: sudo tar xzfv ~/snap.tar -C /
+
       - run:
           <<: *golang-install
       - run:
@@ -194,12 +198,14 @@ jobs:
               sleep 10
             done
             echo "Tekton installed"
+      - run:
+          name: "Tar snap folders"
+          command: |
+            sudo tar -cfzh ~/snap.tar /snap/ /var/snap/ /var/lib/snapd/
       - save_cache:
-          key: snap-cache-{{ arch }}-{{ checksum "/tmp/snap_version" }}
+          key: snap-cache-tar-{{ checksum "/tmp/snap_version" }}
           paths:
-            - /snap/
-            - /var/snap/
-            - /var/lib/snapd/
+            - ~/snap.tar
       - run:
           name: "Run end-to-end tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ defaults:
     command: |
       sudo snap install go --classic --channel 1.16/stable
       echo "export GOROOT=/snap/go/current" >> $BASH_ENV
+      echo "export GOVERSION=$(go version | cut -d' ' -f 3)" >> $BASH_ENV
       ## cleaning up path: remove pre-installed golang version
       sudo rm -rf /usr/local/go
   node-install: &node-install
@@ -97,6 +98,7 @@ jobs:
       - restore_cache:
           keys:
             - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
+            - snap-cache-{{ .Environment.GOVERSION }}-{{ .Environment.MICROK8S_VERSION}}
       - run:
           <<: *obtain-tree-hash
       - restore_cache:
@@ -185,6 +187,12 @@ jobs:
               sleep 10
             done
             echo "Tekton installed"
+            echo "export MICROK8S_VERSION=$(microk8s.kubectl version --short=true | tail -n 1 | cut -d' ' -f 3)" >> $BASH_ENV
+      - run:
+          name: "[TEST]"
+          command: |
+            echo $MICROK8S_VERSION
+            echo $GOVERSION
       - run:
           name: "Run end-to-end tests"
           command: |
@@ -221,6 +229,13 @@ jobs:
             - ./vendor
       - save_cache:
           <<: *save-tree-hash
+      - save_cache:
+          key: snap-cache-{{ .Environment.GOVERSION }}-{{ .Environment.MICROK8S_VERSION}}
+          paths:
+            - /snap/
+            - /var/snap/
+            - /var/lib/snapd/
+            - ~/snap
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - run:
           name: Install official kubectl
           command: |
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.4/bin/linux/amd64/kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - run:
@@ -195,11 +195,13 @@ jobs:
               sleep 10
             done
             echo "Tekton installed"
-      - run:
-          name: "[TEST]"
-          command: |
-            echo $MICROK8S_VERSION
-            echo $GOVERSION
+      - save_cache:
+          key: snap-cache-{{ checksum "/tmp/snap_version" }}
+          paths:
+            - /snap/
+            - /var/snap/
+            - /var/lib/snapd/
+            - ~/snap
       - run:
           name: "Run end-to-end tests"
           command: |
@@ -236,13 +238,6 @@ jobs:
             - ./vendor
       - save_cache:
           <<: *save-tree-hash
-      - save_cache:
-          key: snap-cache-{{ checksum "/tmp/snap_version" }}
-          paths:
-            - /snap/
-            - /var/snap/
-            - /var/lib/snapd/
-            - ~/snap
 
   release:
     working_directory: ~/.go_workspace/src/github.com/maistra/istio-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,23 @@
 version: 2.1
 
 defaults:
+  env-vars: &env-vars
+    GOPATH: /home/circleci/.go_workspace
+    IKE_E2E_KEEP_NS: "false"
+    IKE_E2E_MANAGE_CLUSTER: "false"
+    IKE_LOG_DEBUG: "true"
+    BUILD_CACHE_FOLDER: ".circleci/cache"
+    MICROK8S_VERSION: "1.18/stable"
   golang-install: &golang-install
     name: "Install latest Golang"
     command: |
       sudo snap install go --classic --channel 1.16/stable
       echo "export GOROOT=/snap/go/current" >> $BASH_ENV
-      echo "export GOVERSION=$(go version | cut -d' ' -f 3)" >> $BASH_ENV
       ## cleaning up path: remove pre-installed golang version
       sudo rm -rf /usr/local/go
+      echo "export GOVERSION=$(go version | cut -d' ' -f 3)" >> $BASH_ENV
+      echo "${GOVERSION}-$(snap info microk8s | grep "${MICROK8S_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )" > /tmp/snap_version
+      cat /tmp/snap_version
   node-install: &node-install
     name: "Install Node"
     command: |
@@ -49,13 +58,7 @@ defaults:
   save-tree-hash: &save-tree-hash
     key: job-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "/tmp/tree.sha1" }}
     paths:
-      - ./.circleci/cache # Can't use env variable here - needs to be explicit value
-  env-vars: &env-vars
-    GOPATH: /home/circleci/.go_workspace
-    IKE_E2E_KEEP_NS: "false"
-    IKE_E2E_MANAGE_CLUSTER: "false"
-    IKE_LOG_DEBUG: "true"
-    BUILD_CACHE_FOLDER: ".circleci/cache"
+    - ./.circleci/cache # Can't use env variable here - needs to be explicit value
 
 jobs:
 
@@ -98,7 +101,7 @@ jobs:
       - restore_cache:
           keys:
             - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
-            - snap-cache-{{ .Environment.GOVERSION }}-{{ .Environment.MICROK8S_VERSION}}
+            - snap-cache-{{ checksum "/tmp/snap_version" }}
       - run:
           <<: *obtain-tree-hash
       - restore_cache:
@@ -133,7 +136,7 @@ jobs:
       - run:
           name: Launch Microk8s
           command: |
-            sudo snap install microk8s --classic --channel 1.18/stable
+            sudo snap install microk8s --classic --channel ${MICROK8S_VERSION}
 
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig
@@ -187,7 +190,6 @@ jobs:
               sleep 10
             done
             echo "Tekton installed"
-            echo "export MICROK8S_VERSION=$(microk8s.kubectl version --short=true | tail -n 1 | cut -d' ' -f 3)" >> $BASH_ENV
       - run:
           name: "[TEST]"
           command: |
@@ -230,7 +232,7 @@ jobs:
       - save_cache:
           <<: *save-tree-hash
       - save_cache:
-          key: snap-cache-{{ .Environment.GOVERSION }}-{{ .Environment.MICROK8S_VERSION}}
+          key: snap-cache-{{ checksum "/tmp/snap_version" }}
           paths:
             - /snap/
             - /var/snap/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,11 @@ defaults:
   golang-install: &golang-install
     name: "Install latest Golang"
     command: |
-      sudo snap install go --classic --channel 1.16/stable
+      ## TODO adjust release job
+      cd ~/.snaps
+      sudo snap ack golang.assert
+      sudo snap install golang.snap
+
       echo "export GOROOT=/snap/go/current" >> $BASH_ENV
       ## cleaning up path: remove pre-installed golang version
       sudo rm -rf /usr/local/go
@@ -97,10 +101,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Obtain snap cache version"
-          command: |
-            echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snap_version
-      - run:
           <<: *obtain-tree-hash
       - restore_cache:
           <<: *restore-tree-hash
@@ -111,14 +111,23 @@ jobs:
       - restore_cache:
           keys:
             - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
+      - run:
+          name: "Calculate snap cache key"
+          command: |
+            echo "go-$(echo "${GOLANG_SNAP_VERSION}" | cut -d '/' -f 1 )-microk8s-$(echo "${MICROK8S_SNAP_VERSION}" | cut -d '/' -f 1 )" > /tmp/snaps_version
       - restore_cache:
           keys:
-            - snap-cache-tar-{{ checksum "/tmp/snap_version" }}
+            - snaps-cache-{{ checksum "/tmp/snaps_version" }}
       - run:
-          name: "Restoring snap cache"
+          name: "Downloading snaps (if not restored)"
           command: |
-            [[ -f ~/snap.tar ]] && sudo tar xzfv ~/snap.tar -C / || true
-
+            cd ~
+            if [[ ! -d .snaps ]]; then
+                mkdir -p .snaps
+                cd .snaps
+                sudo snap download microk8s --channel ${MICROK8S_SNAP_VERSION} --basename microk8s
+                sudo snap download go --channel ${GOLANG_SNAP_VERSION} --basename golang
+            fi
       - run:
           <<: *golang-install
       - run:
@@ -143,10 +152,19 @@ jobs:
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - run:
+          name: Install Microk8s
+          command: |
+            cd ~/.snaps
+            sudo snap ack microk8s.assert
+            sudo snap install microk8s.snap
+      - save_cache:
+          ## We want to save cache only if both installations were successful
+          key: snaps-cache-{{ checksum "/tmp/snaps_version" }}
+          paths:
+            - ~/.snaps
+      - run:
           name: Launch Microk8s
           command: |
-            sudo snap install microk8s --classic --channel ${MICROK8S_SNAP_VERSION}
-
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig
 
@@ -199,14 +217,6 @@ jobs:
               sleep 10
             done
             echo "Tekton installed"
-      - run:
-          name: "Tar snap folders"
-          command: |
-            sudo tar -cfzh ~/snap.tar /snap/ /var/snap/ /var/lib/snapd/
-      - save_cache:
-          key: snap-cache-tar-{{ checksum "/tmp/snap_version" }}
-          paths:
-            - ~/snap.tar
       - run:
           name: "Run end-to-end tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: "Obtain snap cache version"
           command: |
-            echo "$(snap info go | grep "${GOLANG_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )-$(snap info microk8s | grep "${MICROK8S_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )" > /tmp/snap_version
+            echo "go-$(snap info go | grep "${GOLANG_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )-microk8s-$(snap info microk8s | grep "${MICROK8S_SNAP_VERSION}:" | tr -s ' ' | cut -d ' ' -f 3 )" > /tmp/snap_version
             cat /tmp/snap_version
       - run:
           <<: *obtain-tree-hash
@@ -112,6 +112,8 @@ jobs:
       - restore_cache:
           keys:
             - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
+      - restore_cache:
+          keys:
             - snap-cache-{{ checksum "/tmp/snap_version" }}
       - run:
           <<: *golang-install
@@ -139,7 +141,7 @@ jobs:
       - run:
           name: Launch Microk8s
           command: |
-            sudo snap install microk8s --classic --channel ${MICROK8S_VERSION}
+            sudo snap install microk8s --classic --channel ${MICROK8S_SNAP_VERSION}
 
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
             - golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - snap-cache-{{ checksum "/tmp/snap_version" }}
+            - snap-cache-{{ arch }}-{{ checksum "/tmp/snap_version" }}
       - run:
           <<: *golang-install
       - run:
@@ -195,7 +195,7 @@ jobs:
             done
             echo "Tekton installed"
       - save_cache:
-          key: snap-cache-{{ checksum "/tmp/snap_version" }}
+          key: snap-cache-{{ arch }}-{{ checksum "/tmp/snap_version" }}
           paths:
             - /snap/
             - /var/snap/


### PR DESCRIPTION
#### Short description of what this resolves:

Snap has been quite unstable for couple of weeks. This PR brings caching of snaps so they are downloaded once and then shared across the builds.

#### Changes proposed in this pull request:

- downloads snaps locally to install later from files
- caches snaps for each job separately

