### PR TITLE
feat(operator): split action and success state in model

### DIFF
--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -61,11 +61,11 @@ func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
 			}
 			err = ctx.Client.Update(ctx, &mutatedDr)
 			if err != nil {
-				ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: dr.GetName(), Action: model.ActionFailed})
+				ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, dr.GetName(), model.ActionModified, err.Error()))
 				ctx.Log.Error(err, "failed to update DestinationRule", "name", dr.GetName())
 			}
 
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: dr.GetName(), Action: model.ActionModified})
+			ref.AddResourceStatus(model.NewSuccessResource(DestinationRuleKind, dr.GetName(), model.ActionModified))
 		}
 	}
 	return nil
@@ -81,7 +81,7 @@ func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			if errors.IsNotFound(err) { // Not found, nothing to clean
 				break
 			}
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: resource.Name, Action: model.ActionFailed})
+			ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, resource.Name, resource.Action, err.Error()))
 			break
 		}
 
@@ -92,11 +92,11 @@ func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
 		}
 		err = ctx.Client.Update(ctx, &mutatedDr)
 		if err != nil {
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: resource.Name, Action: model.ActionFailed})
+			ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, resource.Name, resource.Action, err.Error()))
 			break
 		}
 		// ok, removed
-		ref.RemoveResourceStatus(model.ResourceStatus{Kind: DestinationRuleKind, Name: resource.Name})
+		ref.RemoveResourceStatus(model.NewSuccessResource(DestinationRuleKind, resource.Name, resource.Action))
 	}
 
 	return nil

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -54,8 +54,7 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //n
 
 	vss, err := getVirtualServices(ctx, ctx.Namespace)
 	if err != nil {
-		// TODO: is this really a Resource Status? we can't point to any
-		ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: ctx.Namespace, Action: model.ActionFailed})
+		ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, ctx.Namespace, model.ActionLocated, err.Error()))
 		return err
 	}
 
@@ -73,9 +72,9 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //n
 			mutatedVs, isNew, err := mutateVirtualService(ctx, ref, hostName, vs)
 			if err != nil {
 				if isNew {
-					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, vs.Name, model.ActionCreated))
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, vs.Name, model.ActionCreated, err.Error()))
 				} else {
-					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, vs.Name, model.ActionModified))
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, vs.Name, model.ActionModified, err.Error()))
 				}
 				return err
 			}
@@ -86,14 +85,14 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //n
 			if isNew {
 				err = ctx.Client.Create(ctx, &mutatedVs)
 				if err != nil && !errors.IsAlreadyExists(err) {
-					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, mutatedVs.Name, model.ActionCreated))
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, mutatedVs.Name, model.ActionCreated, err.Error()))
 					return err
 				}
 				ref.AddResourceStatus(model.NewSuccessResource(VirtualServiceKind, mutatedVs.Name, model.ActionCreated))
 			} else {
 				err = ctx.Client.Update(ctx, &mutatedVs)
 				if err != nil {
-					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, mutatedVs.Name, model.ActionModified))
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, mutatedVs.Name, model.ActionModified, err.Error()))
 					return err
 				}
 				ref.AddResourceStatus(model.NewSuccessResource(VirtualServiceKind, mutatedVs.Name, model.ActionModified))
@@ -114,7 +113,7 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			if errors.IsNotFound(err) { // Not found, nothing to clean
 				break
 			}
-			ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action))
+			ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action, err.Error()))
 			break
 		}
 		ctx.Log.Info("Found VirtualService", "name", resource.Name)
@@ -127,13 +126,13 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			}
 			err = ctx.Client.Update(ctx, &mutatedVs)
 			if err != nil {
-				ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action))
+				ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action, err.Error()))
 				break
 			}
 		case model.ActionCreated:
 			err = ctx.Client.Delete(ctx, vs)
 			if err != nil {
-				ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action))
+				ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action, err.Error()))
 				break
 			}
 		}

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -54,6 +54,7 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //n
 
 	vss, err := getVirtualServices(ctx, ctx.Namespace)
 	if err != nil {
+		// TODO: is this really a Resource Status? we can't point to any
 		ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: ctx.Namespace, Action: model.ActionFailed})
 		return err
 	}
@@ -71,7 +72,11 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //n
 
 			mutatedVs, isNew, err := mutateVirtualService(ctx, ref, hostName, vs)
 			if err != nil {
-				ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: vs.Name, Action: model.ActionFailed})
+				if isNew {
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, vs.Name, model.ActionCreated))
+				} else {
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, vs.Name, model.ActionModified))
+				}
 				return err
 			}
 
@@ -81,17 +86,17 @@ func VirtualServiceMutator(ctx model.SessionContext, ref *model.Ref) error { //n
 			if isNew {
 				err = ctx.Client.Create(ctx, &mutatedVs)
 				if err != nil && !errors.IsAlreadyExists(err) {
-					ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: mutatedVs.Name, Action: model.ActionFailed})
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, mutatedVs.Name, model.ActionCreated))
 					return err
 				}
-				ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: mutatedVs.Name, Action: model.ActionCreated})
+				ref.AddResourceStatus(model.NewSuccessResource(VirtualServiceKind, mutatedVs.Name, model.ActionCreated))
 			} else {
 				err = ctx.Client.Update(ctx, &mutatedVs)
 				if err != nil {
-					ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: mutatedVs.Name, Action: model.ActionFailed})
+					ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, mutatedVs.Name, model.ActionModified))
 					return err
 				}
-				ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: mutatedVs.Name, Action: model.ActionModified})
+				ref.AddResourceStatus(model.NewSuccessResource(VirtualServiceKind, mutatedVs.Name, model.ActionModified))
 			}
 		}
 	}
@@ -109,7 +114,7 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			if errors.IsNotFound(err) { // Not found, nothing to clean
 				break
 			}
-			ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: resource.Name, Action: model.ActionFailed})
+			ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action))
 			break
 		}
 		ctx.Log.Info("Found VirtualService", "name", resource.Name)
@@ -122,13 +127,13 @@ func VirtualServiceRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			}
 			err = ctx.Client.Update(ctx, &mutatedVs)
 			if err != nil {
-				ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: resource.Name, Action: model.ActionFailed})
+				ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action))
 				break
 			}
 		case model.ActionCreated:
 			err = ctx.Client.Delete(ctx, vs)
 			if err != nil {
-				ref.AddResourceStatus(model.ResourceStatus{Kind: VirtualServiceKind, Name: resource.Name, Action: model.ActionFailed})
+				ref.AddResourceStatus(model.NewFailedResource(VirtualServiceKind, resource.Name, resource.Action))
 				break
 			}
 		}

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -94,11 +94,11 @@ func DeploymentMutator(engine template.Engine) model.Mutator {
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned Deployment", "name", deploymentClone.Name)
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentKind, Name: deploymentClone.Name, Action: model.ActionFailed})
+			ref.AddResourceStatus(model.NewFailedResource(DeploymentKind, deploymentClone.Name, model.ActionCreated, err.Error()))
 			return err
 		}
 		ctx.Log.Info("Cloned Deployment", "name", deploymentClone.Name)
-		ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentKind, Name: deploymentClone.Name, Action: model.ActionCreated})
+		ref.AddResourceStatus(model.NewSuccessResource(DeploymentKind, deploymentClone.Name, model.ActionCreated))
 		return nil
 	}
 }
@@ -116,11 +116,11 @@ func DeploymentRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			if errors.IsNotFound(err) {
 				return nil
 			}
-			ctx.Log.Info("Failed to delete Deployment", "name", deployment.Name)
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentKind, Name: deployment.Name, Action: model.ActionFailed})
+			ctx.Log.Info("Failed to delete Deployment", "name", status.Name)
+			ref.AddResourceStatus(model.NewFailedResource(DeploymentKind, status.Name, status.Action, err.Error()))
 			return err
 		}
-		ref.RemoveResourceStatus(model.ResourceStatus{Kind: DeploymentKind, Name: deployment.Name})
+		ref.RemoveResourceStatus(model.NewSuccessResource(DeploymentKind, status.Name, status.Action))
 	}
 	return nil
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -222,6 +222,7 @@ type ResourceStatus struct {
 	Name      string
 	TimeStamp time.Time
 	Action    ResourceAction // created, mutated, failed
+	Success   bool
 	Prop      map[string]string
 }
 
@@ -236,11 +237,32 @@ type LocatedResourceStatus struct {
 func NewLocatedResource(kind, name string, labels map[string]string) LocatedResourceStatus {
 	return LocatedResourceStatus{
 		ResourceStatus: ResourceStatus{
-			Kind:   kind,
-			Name:   name,
-			Action: ActionLocated,
+			Kind:    kind,
+			Name:    name,
+			Action:  ActionLocated,
+			Success: true,
 		},
 		Labels: labels,
+	}
+}
+
+// NewFailedResource is a simple helper to create ResourceStatus with failed status.
+func NewFailedResource(kind, name string, action ResourceAction) ResourceStatus {
+	return ResourceStatus{
+		Kind:    kind,
+		Name:    name,
+		Action:  action,
+		Success: false,
+	}
+}
+
+// NewSuccessResource is a simple helper to create ResourceStatus with success status.
+func NewSuccessResource(kind, name string, action ResourceAction) ResourceStatus {
+	return ResourceStatus{
+		Kind:    kind,
+		Name:    name,
+		Action:  action,
+		Success: true,
 	}
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -221,8 +221,9 @@ type ResourceStatus struct {
 	Kind      string
 	Name      string
 	TimeStamp time.Time
-	Action    ResourceAction // created, mutated, failed
+	Action    ResourceAction
 	Success   bool
+	Message   string
 	Prop      map[string]string
 }
 
@@ -247,12 +248,13 @@ func NewLocatedResource(kind, name string, labels map[string]string) LocatedReso
 }
 
 // NewFailedResource is a simple helper to create ResourceStatus with failed status.
-func NewFailedResource(kind, name string, action ResourceAction) ResourceStatus {
+func NewFailedResource(kind, name string, action ResourceAction, message string) ResourceStatus {
 	return ResourceStatus{
 		Kind:    kind,
 		Name:    name,
 		Action:  action,
 		Success: false,
+		Message: message,
 	}
 }
 
@@ -274,8 +276,6 @@ const (
 	ActionCreated ResourceAction = "created"
 	// ActionModified imply the Named Kind has been modified and needs to be reverted to get back to original state
 	ActionModified ResourceAction = "modified"
-	// ActionFailed imply what ever was attempted failed. Assume current state is ok in clean up?
-	ActionFailed ResourceAction = "failed"
 	// ActionLocated imply the resource was found, but nothing was changed.
 	ActionLocated ResourceAction = "located"
 )

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -99,11 +99,11 @@ func DeploymentConfigMutator(engine template.Engine) model.Mutator {
 		err = ctx.Client.Create(ctx, deploymentClone)
 		if err != nil {
 			ctx.Log.Info("Failed to create cloned DeploymentConfig", "name", deploymentClone.Name)
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentConfigKind, Name: deploymentClone.Name, Action: model.ActionFailed})
+			ref.AddResourceStatus(model.NewFailedResource(DeploymentConfigKind, deploymentClone.Name, model.ActionCreated, err.Error()))
 			return err
 		}
 		ctx.Log.Info("Cloned DeploymentConfig", "name", deploymentClone.Name)
-		ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentConfigKind, Name: deploymentClone.Name, Action: model.ActionCreated})
+		ref.AddResourceStatus(model.NewSuccessResource(DeploymentConfigKind, deploymentClone.Name, model.ActionCreated))
 		return nil
 	}
 }
@@ -121,11 +121,11 @@ func DeploymentConfigRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			if errors.IsNotFound(err) {
 				return nil
 			}
-			ctx.Log.Info("Failed to delete DeploymentConfig", "name", deployment.Name)
-			ref.AddResourceStatus(model.ResourceStatus{Kind: DeploymentConfigKind, Name: deployment.Name, Action: model.ActionFailed})
+			ctx.Log.Info("Failed to delete DeploymentConfig", "name", status.Name)
+			ref.AddResourceStatus(model.NewFailedResource(DeploymentConfigKind, status.Name, status.Action, err.Error()))
 			return err
 		}
-		ref.RemoveResourceStatus(model.ResourceStatus{Kind: DeploymentConfigKind, Name: deployment.Name})
+		ref.RemoveResourceStatus(model.NewSuccessResource(DeploymentConfigKind, status.Name, status.Action))
 	}
 	return nil
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Splits action and success state in the model to better reflect the condition / events happening while controller tries to manipulates various resources in the namespace.

Fixes #781
