### PR TITLE
feat(operator): creates new destinationrules instead of manipulating

### DIFF
--- a/controllers/session/model_convert_test.go
+++ b/controllers/session/model_convert_test.go
@@ -1,7 +1,6 @@
 package session_test
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -224,8 +223,6 @@ var _ = Describe("Basic model conversion", func() {
 		It("resource statues mapped", func() {
 			Expect(refs).To(HaveLen(2))
 
-			fmt.Println("weeerewtrewtew")
-			fmt.Println(refs[0].ResourceStatuses)
 			Expect(refs[0].ResourceStatuses[0].Kind).To(Equal(*sess.Status.Refs[0].Resources[0].Kind))
 			Expect(refs[0].ResourceStatuses[0].Name).To(Equal(*sess.Status.Refs[0].Resources[0].Name))
 			Expect(refs[0].ResourceStatuses[0].TimeStamp).To(Equal(sess.Status.Refs[0].Resources[0].LastTransitionTime.Time))

--- a/controllers/session/session_controller_int_test.go
+++ b/controllers/session/session_controller_int_test.go
@@ -350,22 +350,22 @@ func Scenario(scheme *runtime.Scheme, namespace string, scenarioGenerator func(i
 
 	buf := new(bytes.Buffer)
 	scenarioGenerator(buf)
-	filecontent := buf.String()
+	fileContent := buf.String()
 
 	var objects []runtime.Object
 
-	filechunks := strings.Split(filecontent, "---")
-	for _, filechuck := range filechunks {
-		if strings.Trim(filechuck, "\n") == "" {
+	fileChunks := strings.Split(fileContent, "---")
+	for _, fileChunk := range fileChunks {
+		if strings.Trim(fileChunk, "\n") == "" {
 			continue
 		}
 		decode := serializer.NewCodecFactory(scheme).UniversalDeserializer().Decode
-		obj, _, err := decode([]byte(filechuck), nil, nil)
+		obj, _, err := decode([]byte(fileChunk), nil, nil)
 		if err != nil {
 			return nil, err
 		}
-		if robj, ok := obj.(runtime.Object); ok {
-			objects = append(objects, robj)
+		if rObj, ok := obj.(runtime.Object); ok {
+			objects = append(objects, rObj)
 		}
 	}
 

--- a/controllers/session/session_controller_int_test.go
+++ b/controllers/session/session_controller_int_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Complete session manipulation", func() {
 		_ = corev1.AddToScheme(schema)
 		_ = appsv1.AddToScheme(schema)
 		_ = istionetwork.AddToScheme(schema)
-		_ = osappsv1.AddToScheme(schema)
+		_ = osappsv1.Install(schema)
 
 		objs, err := Scenario(schema, namespace, scenario)
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Operator installation", func() {
 	Context("on bare k8s", func() {
 
 		var (
-			operatorNamepace string
-			namespaces       []string
+			operatorNamespace string
+			namespaces        []string
 
 			cleanEnvVariable func()
 		)
@@ -43,8 +43,8 @@ var _ = Describe("Operator installation", func() {
 			}
 
 			namespaces = []string{}
-			operatorNamepace = generateNamespaceName()
-			cleanEnvVariable = test.TemporaryEnvVars("OPERATOR_NAMESPACE", operatorNamepace)
+			operatorNamespace = generateNamespaceName()
+			cleanEnvVariable = test.TemporaryEnvVars("OPERATOR_NAMESPACE", operatorNamespace)
 		})
 
 		AfterEach(func() {
@@ -52,7 +52,7 @@ var _ = Describe("Operator installation", func() {
 			for _, namespace := range namespaces {
 				cleanupNamespace(namespace)
 			}
-			cleanupNamespace(operatorNamepace)
+			cleanupNamespace(operatorNamespace)
 		})
 
 		CreateNamespace := func() {
@@ -80,7 +80,7 @@ var _ = Describe("Operator installation", func() {
 						operatorLog := shell.ExecuteInDir(".",
 							"kubectl", "logs",
 							"deployment/istio-workspace-operator-controller-manager",
-							"-n", operatorNamepace,
+							"-n", operatorNamespace,
 						)
 						<-operatorLog.Done()
 
@@ -100,9 +100,9 @@ var _ = Describe("Operator installation", func() {
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(BeZero())
 
-			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(AllDeploymentsAndPodsReady(operatorNamespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
-			VerifyWatchList(operatorNamepace)
+			VerifyWatchList(operatorNamespace)
 		})
 
 		It("should install to the single namespace", func() {
@@ -115,7 +115,7 @@ var _ = Describe("Operator installation", func() {
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(BeZero())
 
-			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(AllDeploymentsAndPodsReady(operatorNamespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(namespaces...)
 		})
@@ -130,7 +130,7 @@ var _ = Describe("Operator installation", func() {
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(BeZero())
 
-			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(AllDeploymentsAndPodsReady(operatorNamespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(namespaces...)
 		})
@@ -143,7 +143,7 @@ var _ = Describe("Operator installation", func() {
 			<-bundle.Done()
 			Expect(bundle.Status().Exit).To(BeZero())
 
-			Eventually(AllDeploymentsAndPodsReady(operatorNamepace), 10*time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(AllDeploymentsAndPodsReady(operatorNamespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 
 			VerifyWatchList(namespaces...)
 		})

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -1,6 +1,10 @@
 package istio
 
 import (
+	"math"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,12 +45,13 @@ func (d destinationRuleManipulator) Revert() model.Revertor {
 // DestinationRuleMutator creates destination rule mutator which is responsible for alternating the traffic for development
 // of the forked service.
 func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
+	var accErrors *multierror.Error
 	for _, hostName := range ref.GetTargetHostNames() {
 		newVersion := ref.GetNewVersion(ctx.Name)
 
 		destinationRule := istionetwork.DestinationRule{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dr-" + ref.KindName.Name + "-" + hostName.Name + "-" + ctx.Name,
+				Name:      concatToMax(63, "dr", ref.KindName.Name, hostName.Name, ctx.Name),
 				Namespace: ctx.Namespace,
 			},
 			Spec: istionetworkv1alpha3.DestinationRule{
@@ -67,30 +72,38 @@ func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
 		}
 
 		if err := ctx.Client.Create(ctx, &destinationRule); err != nil {
-			ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, destinationRule.GetName(), model.ActionCreated, err.Error()))
-			ctx.Log.Error(err, "failed to update DestinationRule", "name", destinationRule.GetName())
+			if !k8sErrors.IsAlreadyExists(err) {
+				ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, destinationRule.GetName(), model.ActionCreated, err.Error()))
+				ctx.Log.Error(err, "failed to create DestinationRule", "name", destinationRule.GetName())
+				accErrors = multierror.Append(accErrors, errors.Wrap(err, "failed to create DestinationRule"))
+
+				continue
+			}
 		}
 
 		ref.AddResourceStatus(model.NewSuccessResource(DestinationRuleKind, destinationRule.GetName(), model.ActionCreated))
 	}
 
-	return nil
+	return errors.Wrapf(accErrors.ErrorOrNil(), "failed to manipulate destination rules for session %s in namespace %s", ctx.Name, ctx.Namespace)
 }
 
 // DestinationRuleRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects.
 func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
+	var accErrors *multierror.Error
 	for _, hostName := range ref.GetTargetHostNames() {
 		dr := istionetwork.DestinationRule{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dr-" + ref.KindName.Name + "-" + hostName.Name + "-" + ctx.Name,
+				Name:      concatToMax(63, "dr", ref.KindName.Name, hostName.Name, ctx.Name),
 				Namespace: ctx.Namespace,
 			},
 		}
 
-		err := ctx.Client.Delete(ctx, &dr)
-		if err != nil {
+		if err := ctx.Client.Delete(ctx, &dr); err != nil {
 			if !k8sErrors.IsNotFound(err) { // Not found, nothing to clean
 				ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, dr.GetName(), model.ActionCreated, err.Error()))
+				accErrors = multierror.Append(accErrors, errors.Wrap(err, "failed to delete DestinationRule"))
+
+				continue
 			}
 		}
 
@@ -98,5 +111,17 @@ func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
 		ref.RemoveResourceStatus(model.NewSuccessResource(DestinationRuleKind, dr.GetName(), model.ActionCreated))
 	}
 
-	return nil
+	return errors.Wrapf(accErrors.ErrorOrNil(), "failed to revert destination rules for session %s in namespace %s", ctx.Name, ctx.Namespace)
+}
+
+// concatToMax will cut each section to length based on number of sections to not go beyond max and separate the sections with -.
+func concatToMax(max int, sections ...string) string {
+	sectionLength := (max - len(sections) - 1) / len(sections)
+	name := ""
+
+	for _, section := range sections {
+		name = name + "-" + section[:int32(math.Min(float64(len(section)), float64(sectionLength)))]
+	}
+
+	return name[1:]
 }

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -1,17 +1,13 @@
 package istio
 
 import (
-	"strings"
-
-	"github.com/pkg/errors"
-	"istio.io/api/networking/v1alpha3"
+	istionetworkv1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetwork "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/maistra/istio-workspace/pkg/model"
-	"github.com/maistra/istio-workspace/pkg/reference"
 )
 
 const (
@@ -45,28 +41,33 @@ func (d destinationRuleManipulator) Revert() model.Revertor {
 // of the forked service.
 func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
 	for _, hostName := range ref.GetTargetHostNames() {
-		drs, err := getDestinationRulesByHost(ctx, ctx.Namespace, hostName)
-		if err != nil {
-			return err
-		}
-		for _, dr := range drs {
-			newVersion := ref.GetNewVersion(ctx.Name)
-			if alreadyMutated(*dr, newVersion) {
-				continue
-			}
-			ctx.Log.Info("Found DestinationRule", "name", dr.GetName())
-			mutatedDr := mutateDestinationRule(*dr, newVersion)
-			if err = reference.Add(ctx.ToNamespacedName(), &mutatedDr); err != nil {
-				ctx.Log.Error(err, "failed to add relation reference", "kind", mutatedDr.Kind, "name", mutatedDr.Name)
-			}
-			err = ctx.Client.Update(ctx, &mutatedDr)
-			if err != nil {
-				ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, dr.GetName(), model.ActionModified, err.Error()))
-				ctx.Log.Error(err, "failed to update DestinationRule", "name", dr.GetName())
-			}
+		newVersion := ref.GetNewVersion(ctx.Name)
 
-			ref.AddResourceStatus(model.NewSuccessResource(DestinationRuleKind, dr.GetName(), model.ActionModified))
+		dr := istionetwork.DestinationRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dr-" + ref.KindName.Name + "-" + hostName.Name + "-" + ctx.Name,
+				Namespace: ctx.Namespace,
+			},
+			Spec: istionetworkv1alpha3.DestinationRule{
+				Host: hostName.Name,
+				Subsets: []*istionetworkv1alpha3.Subset{
+					{
+						Name: newVersion,
+						Labels: map[string]string{
+							"version": newVersion,
+						},
+					},
+				},
+			},
 		}
+
+		err := ctx.Client.Create(ctx, &dr)
+		if err != nil {
+			ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, dr.GetName(), model.ActionCreated, err.Error()))
+			ctx.Log.Error(err, "failed to update DestinationRule", "name", dr.GetName())
+		}
+
+		ref.AddResourceStatus(model.NewSuccessResource(DestinationRuleKind, dr.GetName(), model.ActionCreated))
 	}
 
 	return nil
@@ -74,88 +75,24 @@ func DestinationRuleMutator(ctx model.SessionContext, ref *model.Ref) error {
 
 // DestinationRuleRevertor looks at the Ref.ResourceStatus and attempts to revert the state of the mutated objects.
 func DestinationRuleRevertor(ctx model.SessionContext, ref *model.Ref) error {
-	resources := ref.GetResources(model.Kind(DestinationRuleKind))
+	for _, hostName := range ref.GetTargetHostNames() {
+		dr := istionetwork.DestinationRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dr-" + ref.KindName.Name + "-" + hostName.Name + "-" + ctx.Name,
+				Namespace: ctx.Namespace,
+			},
+		}
 
-	for _, resource := range resources {
-		dr, err := getDestinationRule(ctx, ctx.Namespace, resource.Name)
+		err := ctx.Client.Delete(ctx, &dr)
 		if err != nil {
-			if k8sErrors.IsNotFound(err) { // Not found, nothing to clean
-				break
+			if !k8sErrors.IsNotFound(err) { // Not found, nothing to clean
+				ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, dr.GetName(), model.ActionCreated, err.Error()))
 			}
-			ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, resource.Name, resource.Action, err.Error()))
-
-			break
 		}
 
-		ctx.Log.Info("Found DestinationRule", "name", resource.Name)
-		mutatedDr := revertDestinationRule(*dr, ref.GetNewVersion(ctx.Name))
-		if err = reference.Remove(ctx.ToNamespacedName(), &mutatedDr); err != nil {
-			ctx.Log.Error(err, "failed to remove relation reference", "kind", mutatedDr.Kind, "name", mutatedDr.Name)
-		}
-		err = ctx.Client.Update(ctx, &mutatedDr)
-		if err != nil {
-			ref.AddResourceStatus(model.NewFailedResource(DestinationRuleKind, resource.Name, resource.Action, err.Error()))
-
-			break
-		}
 		// ok, removed
-		ref.RemoveResourceStatus(model.NewSuccessResource(DestinationRuleKind, resource.Name, resource.Action))
+		ref.RemoveResourceStatus(model.NewSuccessResource(DestinationRuleKind, dr.GetName(), model.ActionCreated))
 	}
 
 	return nil
-}
-
-func alreadyMutated(dr istionetwork.DestinationRule, name string) bool {
-	for _, sub := range dr.Spec.Subsets {
-		if sub.Name == name {
-			return true
-		}
-	}
-
-	return false
-}
-
-func mutateDestinationRule(dr istionetwork.DestinationRule, name string) istionetwork.DestinationRule {
-	dr.Spec.Subsets = append(dr.Spec.Subsets, &v1alpha3.Subset{
-		Name: name,
-		Labels: map[string]string{
-			"version": name,
-		},
-	})
-
-	return dr
-}
-
-func revertDestinationRule(dr istionetwork.DestinationRule, name string) istionetwork.DestinationRule {
-	for i := 0; i < len(dr.Spec.Subsets); i++ {
-		if strings.Contains(dr.Spec.Subsets[i].Name, name) {
-			dr.Spec.Subsets = append(dr.Spec.Subsets[:i], dr.Spec.Subsets[i+1:]...)
-
-			break
-		}
-	}
-
-	return dr
-}
-
-func getDestinationRule(ctx model.SessionContext, namespace, name string) (*istionetwork.DestinationRule, error) {
-	destinationRule := istionetwork.DestinationRule{}
-	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &destinationRule)
-
-	return &destinationRule, errors.Wrapf(err, "failed obtaining destinationrule %s in namespace %s", name, namespace)
-}
-
-func getDestinationRulesByHost(ctx model.SessionContext, namespace string, hostName model.HostName) ([]*istionetwork.DestinationRule, error) {
-	var matches []*istionetwork.DestinationRule
-
-	destinationRules := istionetwork.DestinationRuleList{}
-	err := ctx.Client.List(ctx, &destinationRules, client.InNamespace(namespace))
-	for _, dr := range destinationRules.Items { //nolint:gocritic //reason for readability
-		if hostName.Match(dr.Spec.Host) {
-			match := dr
-			matches = append(matches, &match)
-		}
-	}
-
-	return matches, errors.Wrapf(err, "failed finding destinationrule in namespace %s matching hostname %v", namespace, hostName)
 }

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			},
 			&istionetwork.DestinationRule{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "customer-revert",
+					Name:      "customer-other",
 					Namespace: "test",
 				},
 				Spec: istionetworkv1alpha3.DestinationRule{
-					Host: "customer-revert",
+					Host: "customer-other",
 					Subsets: []*istionetworkv1alpha3.Subset{
 						{
 							Name: "v1",
@@ -165,7 +165,10 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 		Context("existing rule", func() {
 
 			It("should remove reference", func() {
-				err := istio.DestinationRuleRevertor(ctx, ref)
+				err := istio.DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				dr := get.DestinationRules("test", testclient.HasRefPredicate)
@@ -173,7 +176,10 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 			})
 
 			It("should not fail on subsequent remove of reference", func() {
-				err := istio.DestinationRuleRevertor(ctx, ref)
+				err := istio.DestinationRuleMutator(ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = istio.DestinationRuleRevertor(ctx, ref)

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/maistra/istio-workspace/pkg/istio"
 	"github.com/maistra/istio-workspace/pkg/log"
 	"github.com/maistra/istio-workspace/pkg/model"
-	"github.com/maistra/istio-workspace/pkg/reference"
 	"github.com/maistra/istio-workspace/test/testclient"
 )
 
@@ -111,27 +110,27 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-mutate")
-				Expect(reference.Get(&dr)).To(HaveLen(1))
+				dr := get.DestinationRules("test", testclient.HasRefPredicate)
+				Expect(dr.Items).To(HaveLen(1))
 			})
 
-			It("new subset added", func() {
+			It("should have one subset defined", func() {
 				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-mutate")
-				Expect(dr.Spec.Subsets).To(HaveLen(2))
+				dr := get.DestinationRules("test", testclient.HasRefPredicate)
+				Expect(dr.Items[0].Spec.Subsets).To(HaveLen(1))
 			})
 
-			It("new subset added with name", func() {
+			It("should have one subset defined with name", func() {
 				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-mutate")
-				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
+				dr := get.DestinationRules("test", testclient.HasRefPredicate)
+				Expect(dr.Items[0].Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
 			})
 
-			It("new subset only added once", func() {
+			It("should not create new destination rules for subsequents mutations", func() {
 				err := istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -139,9 +138,10 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				err = istio.DestinationRuleMutator(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-mutate")
-				Expect(dr.Spec.Subsets).To(HaveLen(2))
-				Expect(dr.Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
+				dr := get.DestinationRules("test", testclient.HasRefPredicate)
+				Expect(dr.Items).To(HaveLen(1))
+				Expect(dr.Items[0].Spec.Subsets).To(HaveLen(1))
+				Expect(dr.Items[0].Spec.Subsets).To(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
 			})
 		})
 	})
@@ -168,25 +168,21 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				err := istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-revert")
-				Expect(reference.Get(&dr)).To(BeEmpty())
+				dr := get.DestinationRules("test", testclient.HasRefPredicate)
+				Expect(dr.Items).To(BeEmpty())
 			})
 
-			It("new subset removed", func() {
+			It("should not fail on subsequent remove of reference", func() {
 				err := istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-revert")
-				Expect(dr.Spec.Subsets).To(HaveLen(2))
-			})
-
-			It("correct subset removed", func() {
-				err := istio.DestinationRuleRevertor(ctx, ref)
+				err = istio.DestinationRuleRevertor(ctx, ref)
 				Expect(err).ToNot(HaveOccurred())
 
-				dr := get.DestinationRule("test", "customer-revert")
-				Expect(dr.Spec.Subsets).ToNot(ContainElement(WithTransform(GetName, Equal(ref.GetNewVersion(ctx.Name)))))
+				dr := get.DestinationRules("test", testclient.HasRefPredicate)
+				Expect(dr.Items).To(BeEmpty())
 			})
+
 		})
 	})
 })

--- a/pkg/istio/gateway_test.go
+++ b/pkg/istio/gateway_test.go
@@ -331,7 +331,7 @@ var _ = Describe("Operations for istio gateway kind", func() {
 					Client: ctx.Client,
 					Log:    ctx.Log,
 				}
-				// Another Context would have had another Ref object with the Gateway Resource Status modifed. simulate.
+				// Another Context would have had another Ref object with the Gateway Resource Status modified. simulate.
 				ref.AddResourceStatus(model.ResourceStatus{Kind: "Gateway", Name: "gateway", Action: model.ActionModified})
 				err = istio.GatewayRevertor(ctx2, ref)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/istio/istio_suite_test.go
+++ b/pkg/istio/istio_suite_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/maistra/istio-workspace/test"
 )
 
-func TestK8(t *testing.T) {
+func TestIstio(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "Istio object Suite")
 }

--- a/pkg/k8s/k8s_suite_test.go
+++ b/pkg/k8s/k8s_suite_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/maistra/istio-workspace/test"
 )
 
-func TestK8(t *testing.T) {
+func TestK8s(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecWithJUnitReporter(t, "k8s object Suite")
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -53,13 +53,13 @@ type Ref struct {
 	ResourceStatuses []ResourceStatus
 }
 
-// RefKindName holds the optionally specified Kind togather with the name, e.g. deploymentconfig/name.
+// RefKindName holds the optionally specified Kind together with the name, e.g. deploymentconfig/name.
 type RefKindName struct {
 	Kind string
 	Name string
 }
 
-// String returns the string formated kind/name.
+// String returns the string formatted kind/name.
 func (r RefKindName) String() string {
 	if r.Kind == "" {
 		return r.Name

--- a/pkg/reference/enqueue_annotations.go
+++ b/pkg/reference/enqueue_annotations.go
@@ -75,7 +75,7 @@ var (
 //	annotations:
 //		maistra.io/istio-workspaces: "namespace/session1,session2"
 //
-// Note: multiple sessions can manipulate the same resource, therefore the annonation is a list defined as comma-separated values.
+// Note: multiple sessions can manipulate the same resource, therefore the annotation is a list defined as comma-separated values.
 //
 // Though an annotation-based watch handler removes the boundaries set by native owner reference implementation,
 // the garbage collector still respects the scope restrictions. For example,

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Operations for template system", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(BeEquivalentTo("v1"))
 			})
-			It("should be able to equal numberic values", func() {
+			It("should be able to equal numeric values", func() {
 				v := tj.Equal("/spec/replicas", 1)
 				Expect(v).To(BeTrue())
 			})
@@ -90,7 +90,7 @@ var _ = Describe("Operations for template system", func() {
 				Expect(v).To(BeTrue())
 			})
 
-			It("should error on non numberic slice index", func() {
+			It("should error on non numeric slice index", func() {
 				_, err := tj.Value("/spec/template/spec/containers/X")
 				Expect(err).To(HaveOccurred())
 			})

--- a/test/testclient/getters.go
+++ b/test/testclient/getters.go
@@ -88,8 +88,8 @@ var HasRefPredicate Predicate = func(c client.Object) bool {
 	return len(reference.Get(c)) != 0
 }
 
-// DestinationRules returns all DestinationRules in a given namespace. When predicates are provided all of the should be satisfied
-// in order to keep the element on the list.
+// DestinationRules returns all DestinationRules in a given namespace.
+// When predicates are provided all of them should be satisfied in order to keep the element on the list.
 func DestinationRules(c client.Client) func(namespace string, predicates ...Predicate) istionetwork.DestinationRuleList {
 	return func(namespace string, predicates ...Predicate) istionetwork.DestinationRuleList {
 		s := istionetwork.DestinationRuleList{}

--- a/test/testclient/getters.go
+++ b/test/testclient/getters.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/maistra/istio-workspace/api/maistra/v1alpha1"
+	"github.com/maistra/istio-workspace/pkg/reference"
 )
 
 /*
@@ -24,6 +25,7 @@ func New(c client.Client) *Getters {
 		Session:                   Session(c),
 		Gateway:                   Gateway(c),
 		DestinationRule:           DestinationRule(c),
+		DestinationRules:          DestinationRules(c),
 		VirtualService:            VirtualService(c),
 		VirtualServices:           VirtualServices(c),
 		Deployment:                Deployment(c),
@@ -38,6 +40,7 @@ type Getters struct {
 	Session                   func(namespace, name string) v1alpha1.Session
 	Gateway                   func(namespace, name string) istionetwork.Gateway
 	DestinationRule           func(namespace, name string) istionetwork.DestinationRule
+	DestinationRules          func(namespace string, predicates ...Predicate) istionetwork.DestinationRuleList
 	VirtualService            func(namespace, name string) istionetwork.VirtualService
 	Deployment                func(namespace, name string) appsv1.Deployment
 	DeploymentWithError       func(namespace, name string) (appsv1.Deployment, error)
@@ -73,6 +76,43 @@ func DestinationRule(c client.Client) func(namespace, name string) istionetwork.
 	return func(namespace, name string) istionetwork.DestinationRule {
 		s := istionetwork.DestinationRule{}
 		err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &s)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		return s
+	}
+}
+
+type Predicate func(c client.Object) bool
+
+var HasRefPredicate Predicate = func(c client.Object) bool {
+	return len(reference.Get(c)) != 0
+}
+
+// DestinationRules returns all DestinationRules in a given namespace. When predicates are provided all of the should be satisfied
+// in order to keep the element on the list.
+func DestinationRules(c client.Client) func(namespace string, predicates ...Predicate) istionetwork.DestinationRuleList {
+	return func(namespace string, predicates ...Predicate) istionetwork.DestinationRuleList {
+		s := istionetwork.DestinationRuleList{}
+		err := c.List(context.Background(), &s, client.InNamespace(namespace))
+		items := s.Items
+
+		for i := 0; i < len(items); i++ {
+			keep := true
+			for _, predicate := range predicates {
+				if !predicate(&items[i]) {
+					keep = false
+
+					break
+				}
+			}
+			if !keep {
+				items = append(items[:i], items[i+1:]...)
+				i--
+			}
+		}
+
+		s.Items = items
+
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		return s


### PR DESCRIPTION
#### Short description of what this resolves:

Avoids manipulating the user controlled resources when we don't have to.

#### Changes proposed in this pull request:

- creates new destination rule per host pr session
- deletes on revert
- added multi error handling/reporting

Fixes #796
