### PR TITLE
feat(gh-actions): squashes pre-release commits

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -49,13 +49,19 @@ while test $# -gt 0; do
   esac
 done
 
+
 ## Check if tag exists
 tag_exists=$(git --no-pager tag --list | grep -c "${version}")
 if [[ ${tag_exists} -ne 0 ]]; then
   die "Tag \`${version}\` already exists!"
 fi
 
-## Replace antora version for docs build
+
+git reset $(git merge-base master HEAD)
+git add -A
+git commit -m "release: highlights of ${version}"
+
+## Replace Antora version for docs build
 sed -i "/version:/c\version: ${version}" docs/antora.yml
 sed -i "/append:release_notes/a include::release_notes\/${version}.adoc[]\n" docs/modules/ROOT/pages/release_notes.adoc
 
@@ -74,4 +80,4 @@ IKE_VERSION="${version}-next" make bundle
 
 git commit -am"release: next iteration" -m"/skip-e2e" -m"/skip-build"
 
-git push
+git push -f


### PR DESCRIPTION
#### Short description of what this resolves:

All commits prior to `/release` will be squashed to one.

The downside (?): bot account becomes the author of the original commit.

Example of these changes being "tested": https://github.com/bartoszmajsak/istio-workspace/pull/81

#### Changes proposed in this pull request:

- updates in `release.sh` script

Fixes #795 
