### PR TITLE
chore: minor improvements around noglobals linter

### DIFF
--- a/controllers/session/session_controller_test.go
+++ b/controllers/session/session_controller_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/model"
 )
 
-var (
-	kind, name, action = "test", "details", "created"
-)
+var kind, name, action = "test", "details", "created"
 
 var _ = Describe("Basic session manipulation", func() {
 	var (

--- a/pkg/cmd/serve/cmd.go
+++ b/pkg/cmd/serve/cmd.go
@@ -21,17 +21,16 @@ import (
 )
 
 const (
-	watchNamespaceEnvVar = "WATCH_NAMESPACE"
-)
-
-var logger = func() logr.Logger {
-	return log.Log.WithValues("type", "serve")
-}
-
-var (
+	watchNamespaceEnvVar       = "WATCH_NAMESPACE"
 	metricsHost                = "0.0.0.0"
 	metricsPort          int32 = 8080
-	errorWatchNsNotFound       = fmt.Errorf("%s must be set", watchNamespaceEnvVar)
+)
+
+var (
+	errorWatchNsNotFound = fmt.Errorf("%s must be set", watchNamespaceEnvVar)
+	logger               = func() logr.Logger {
+		return log.Log.WithValues("type", "serve")
+	}
 )
 
 // NewCmd creates instance of "ike serve" Cobra Command which is intended to be ran in the

--- a/pkg/shell/funcs.go
+++ b/pkg/shell/funcs.go
@@ -14,22 +14,24 @@ import (
 	"github.com/maistra/istio-workspace/pkg/log"
 )
 
-var logger = func() logr.Logger {
-	return log.Log.WithValues("type", "shell")
-}
+var (
+	// StreamOutput sets streaming of output instead of buffering it when running gocmd.Cmd.
+	StreamOutput gocmd.Options = gocmd.Options{
+		Buffered:  false,
+		Streaming: true,
+	}
 
-// StreamOutput sets streaming of output instead of buffering it when running gocmd.Cmd.
-var StreamOutput = gocmd.Options{
-	Buffered:  false,
-	Streaming: true,
-}
+	// BufferAndStreamOutput sets buffering and streaming of output when running gocmd.Cmd
+	// Buffering lets easy inspection of outputs in tests through inspecting gocmd.Cmd.Status.Stdout/err slices.
+	BufferAndStreamOutput = gocmd.Options{
+		Buffered:  true,
+		Streaming: true,
+	}
 
-// BufferAndStreamOutput sets buffering and streaming of output when running gocmd.Cmd
-// Buffering lets easy inspection of outputs in tests through inspecting gocmd.Cmd.Status.Stdout/err slices.
-var BufferAndStreamOutput = gocmd.Options{
-	Buffered:  true,
-	Streaming: true,
-}
+	logger = func() logr.Logger {
+		return log.Log.WithValues("type", "shell")
+	}
+)
 
 // Start starts new process (gocmd) and wait until it's done. Status struct is then propagated back to
 // done channel passed as argument.

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Operations for template system", func() {
 	})
 })
 
-var testDeployment = `
+const testDeployment = `
 {
     "apiVersion": "extensions/v1beta1",
     "kind": "Deployment",

--- a/test/cmd/test-service/main.pb.go
+++ b/test/cmd/test-service/main.pb.go
@@ -8,14 +8,15 @@ package main
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
Keeping it disabled is a reasonable thing to do as discussed in the related issue.

This PR brings few minor cleanups from going through the findings of this linter.

Fixes #479
