### PR TITLE
fix(error): handle no destination rules found error

### DIFF
--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 
 		Context("missing rule", func() {
 
-			It("no rules found", func() {
+			It("should fail when no rules found", func() {
 				ref := &model.Ref{
 					KindName: model.ParseRefKindName("customer-v5"),
 					Targets: []model.LocatedResourceStatus{

--- a/pkg/istio/destinationrule_test.go
+++ b/pkg/istio/destinationrule_test.go
@@ -161,6 +161,22 @@ var _ = Describe("Operations for istio DestinationRule kind", func() {
 				Expect(dr.Items[0].Spec.Subsets[0].TrafficPolicy.ConnectionPool.Http.MaxRetries).To(Equal(int32(100)))
 			})
 		})
+
+		Context("missing rule", func() {
+
+			It("no rules found", func() {
+				ref := &model.Ref{
+					KindName: model.ParseRefKindName("customer-v5"),
+					Targets: []model.LocatedResourceStatus{
+						model.NewLocatedResource("Deployment", "customer-v5", map[string]string{"version": "v5"}),
+						model.NewLocatedResource("Service", "customer-missing", nil),
+					},
+				}
+				err := istio.DestinationRuleMutator(ctx, ref)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed finding destinationrule in namespace [test] matching hostname [customer-missing] and subset version [v5]"))
+			})
+		})
 	})
 
 	Context("revertors", func() {

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -180,7 +180,7 @@ func getGateway(ctx model.SessionContext, namespace, name string) (*istionetwork
 	Gateway := istionetwork.Gateway{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &Gateway)
 
-	return &Gateway, errors.Wrapf(err, "failed finding gateway %s in namespace %s", name, namespace)
+	return &Gateway, errors.Wrapf(err, "failed finding gateway [%s] in namespace [%s]", name, namespace)
 }
 
 func existInList(hosts []string, host string) bool {

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -224,14 +224,14 @@ func getVirtualService(ctx model.SessionContext, namespace, name string) (*istio
 	virtualService := istionetwork.VirtualService{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &virtualService)
 
-	return &virtualService, errors.Wrapf(err, "failed finding virtual service %s in namespace %s", name, namespace)
+	return &virtualService, errors.Wrapf(err, "failed finding virtual service %s in namespace [%s]", name, namespace)
 }
 
 func getVirtualServices(ctx model.SessionContext, namespace string) (*istionetwork.VirtualServiceList, error) {
 	virtualServices := istionetwork.VirtualServiceList{}
 	err := ctx.Client.List(ctx, &virtualServices, client.InNamespace(namespace))
 
-	return &virtualServices, errors.Wrapf(err, "failed finding virtual services in namespace %s", namespace)
+	return &virtualServices, errors.Wrapf(err, "failed finding virtual services in namespace [%s]", namespace)
 }
 
 func mutationRequired(vs istionetwork.VirtualService, targetHost model.HostName, targetVersion string) bool {

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -128,7 +128,7 @@ func DeploymentRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			ctx.Log.Info("Failed to delete Deployment", "name", status.Name)
 			ref.AddResourceStatus(model.NewFailedResource(DeploymentKind, status.Name, status.Action, err.Error()))
 
-			return errors.Wrapf(err, "failed to delete Deployment %s", status.Name)
+			return errors.Wrapf(err, "failed to delete Deployment [%s]", status.Name)
 		}
 		ref.RemoveResourceStatus(model.NewSuccessResource(DeploymentKind, status.Name, status.Action))
 	}
@@ -160,5 +160,5 @@ func getDeployment(ctx model.SessionContext, namespace, name string) (*appsv1.De
 	deployment := appsv1.Deployment{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment)
 
-	return &deployment, errors.Wrapf(err, "failed finding deployment %s in namespace %s", name, namespace)
+	return &deployment, errors.Wrapf(err, "failed finding deployment [%s] in namespace [%s]", name, namespace)
 }

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -44,5 +44,5 @@ func getServices(ctx model.SessionContext, namespace string) (*corev1.ServiceLis
 	services := corev1.ServiceList{}
 	err := ctx.Client.List(ctx, &services, client.InNamespace(namespace))
 
-	return &services, errors.Wrapf(err, "failed listing services in namespace %s", namespace)
+	return &services, errors.Wrapf(err, "failed listing services in namespace [%s]", namespace)
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -166,6 +166,14 @@ func (h *HostName) Match(name string) bool {
 	return equalsShortName || equalsFullDNSName
 }
 
+// String returns the String representation of a HostName
+func (h *HostName) String() string {
+	if h.Namespace != "" {
+		return fmt.Sprint(h.Name, ".", h.Namespace, ".svc.cluster.local")
+	}
+	return h.Name
+}
+
 // GetTargetHostNames returns a list of Host names that the target Deployment can be reached under.
 func (r *Ref) GetTargetHostNames() []HostName {
 	targets := r.GetTargets(Kind("Service"))

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -166,11 +166,12 @@ func (h *HostName) Match(name string) bool {
 	return equalsShortName || equalsFullDNSName
 }
 
-// String returns the String representation of a HostName
+// String returns the String representation of a HostName.
 func (h *HostName) String() string {
 	if h.Namespace != "" {
 		return fmt.Sprint(h.Name, ".", h.Namespace, ".svc.cluster.local")
 	}
+
 	return h.Name
 }
 

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -134,7 +134,7 @@ func DeploymentConfigRevertor(ctx model.SessionContext, ref *model.Ref) error {
 			ctx.Log.Info("Failed to delete DeploymentConfig", "name", status.Name)
 			ref.AddResourceStatus(model.NewFailedResource(DeploymentConfigKind, status.Name, status.Action, err.Error()))
 
-			return errors.Wrapf(err, "failed to delete DeploymentConfig %s", status.Name)
+			return errors.Wrapf(err, "failed to delete DeploymentConfig [%s]", status.Name)
 		}
 		ref.RemoveResourceStatus(model.NewSuccessResource(DeploymentConfigKind, status.Name, status.Action))
 	}
@@ -166,5 +166,5 @@ func getDeploymentConfig(ctx model.SessionContext, namespace, name string) (*app
 	deployment := appsv1.DeploymentConfig{}
 	err := ctx.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment)
 
-	return &deployment, errors.Wrapf(err, "failed finding DeploymentConfig %s in namespace %s", name, namespace)
+	return &deployment, errors.Wrapf(err, "failed finding DeploymentConfig [%s] in namespace [%s]", name, namespace)
 }


### PR DESCRIPTION
Ensure we return an error when no rules found, and when no subset found.

Related to #827
