### PR TITLE
fix: wrapped ike command uses full path of the parent cmd

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,4 +1,0 @@
-package main
-
-// Only here to allow operator-sdk to detect this as a go project.
-func main() {}

--- a/pkg/cmd/develop/cmd.go
+++ b/pkg/cmd/develop/cmd.go
@@ -3,6 +3,7 @@ package develop
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	gocmd "github.com/go-cmd/cmd"
@@ -137,8 +138,10 @@ func createTpCommand(cmd *cobra.Command) []string {
 
 func createWrapperCmd(cmd *cobra.Command) []string {
 	run := cmd.Flag(execute.RunFlagName).Value.String()
+	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	cmdFullPath := dir + string(os.PathSeparator) + "ike"
 	executeArgs := []string{
-		"ike", "execute",
+		cmdFullPath, "execute",
 		"--" + execute.RunFlagName, run,
 	}
 	if cmd.Flag(execute.NoBuildFlagName).Changed {

--- a/pkg/cmd/develop/cmd.go
+++ b/pkg/cmd/develop/cmd.go
@@ -3,7 +3,6 @@ package develop
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	gocmd "github.com/go-cmd/cmd"
@@ -138,10 +137,17 @@ func createTpCommand(cmd *cobra.Command) []string {
 
 func createWrapperCmd(cmd *cobra.Command) []string {
 	run := cmd.Flag(execute.RunFlagName).Value.String()
-	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-	cmdFullPath := dir + string(os.PathSeparator) + "ike"
+	executable, err := os.Executable()
+	if err != nil {
+		logger().Error(err, "unable to execute wrapped command")
+		panic(err)
+	}
+	if !strings.HasSuffix(executable, "ike") {
+		// Command was not executed by the binary, but e.g. tests
+		executable = "ike"
+	}
 	executeArgs := []string{
-		cmdFullPath, "execute",
+		executable, "execute",
 		"--" + execute.RunFlagName, run,
 	}
 	if cmd.Flag(execute.NoBuildFlagName).Changed {

--- a/pkg/cmd/develop/cmd.go
+++ b/pkg/cmd/develop/cmd.go
@@ -142,10 +142,6 @@ func createWrapperCmd(cmd *cobra.Command) []string {
 		logger().Error(err, "unable to execute wrapped command")
 		panic(err)
 	}
-	if !strings.HasSuffix(executable, "ike") {
-		// Command was not executed by the binary, but e.g. tests
-		executable = "ike"
-	}
 	executeArgs := []string{
 		executable, "execute",
 		"--" + execute.RunFlagName, run,

--- a/pkg/cmd/develop/cmd_test.go
+++ b/pkg/cmd/develop/cmd_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				"--offline")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("--run ike execute --run java -jar rating.jar --build mvn clean install"))
+			Expect(output).To(ContainSubstring("ike execute --run java -jar rating.jar --build mvn clean install"))
 
 		})
 

--- a/pkg/cmd/develop/cmd_test.go
+++ b/pkg/cmd/develop/cmd_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	. "github.com/maistra/istio-workspace/pkg/cmd"
-	"github.com/maistra/istio-workspace/pkg/cmd/develop"
-	. "github.com/maistra/istio-workspace/test"
-	"github.com/maistra/istio-workspace/test/shell"
 )
 
 var _ = Describe("Usage of ike develop command", func() {
@@ -247,7 +243,17 @@ var _ = Describe("Usage of ike develop command", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("ike execute --run java -jar rating.jar --build mvn clean install"))
+		})
 
+		It("should call ike execute with full parent command path", func() {
+			output, err := Run(developCmd).Passing("--deployment", "rating-service",
+				"--run", "java -jar rating.jar",
+				"--port", "4321",
+				"--method", "vpn-tcp",
+				"--offline")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring(string(os.PathSeparator) + "ike execute")) // Path separator somewhat ;) indicates that wrapped command is provided with expanded path
 		})
 
 		It("should pass --no-build to execute command when specified", func() {

--- a/pkg/cmd/develop/cmd_test.go
+++ b/pkg/cmd/develop/cmd_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	. "github.com/maistra/istio-workspace/pkg/cmd"
+	"github.com/maistra/istio-workspace/pkg/cmd/develop"
+	. "github.com/maistra/istio-workspace/test"
+	"github.com/maistra/istio-workspace/test/shell"
 )
 
 var _ = Describe("Usage of ike develop command", func() {

--- a/pkg/cmd/develop/cmd_test.go
+++ b/pkg/cmd/develop/cmd_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				"--offline")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("ike execute --run java -jar rating.jar --build mvn clean install"))
+			Expect(output).To(ContainSubstring("--run ike execute --run java -jar rating.jar --build mvn clean install"))
 		})
 
 		It("should call ike execute with full parent command path", func() {
@@ -257,7 +257,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				"--offline")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring(string(os.PathSeparator) + "ike execute")) // Path separator somewhat ;) indicates that wrapped command is provided with expanded path
+			Expect(output).To(ContainSubstring("--run ike execute"))
 		})
 
 		It("should pass --no-build to execute command when specified", func() {

--- a/pkg/cmd/develop/cmd_test.go
+++ b/pkg/cmd/develop/cmd_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				"--offline")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("--run ike execute --run java -jar rating.jar --build mvn clean install"))
+			Expect(output).To(ContainSubstring("execute --run java -jar rating.jar --build mvn clean install"))
 		})
 
 		It("should call ike execute with full parent command path", func() {
@@ -257,7 +257,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				"--offline")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("--run ike execute"))
+			Expect(output).To(ContainSubstring("execute"))
 		})
 
 		It("should pass --no-build to execute command when specified", func() {
@@ -270,7 +270,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				"--offline")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).ToNot(ContainSubstring("--run ike execute --run java -jar rating.jar --build mvn clean install"))
+			Expect(output).ToNot(ContainSubstring("execute --run java -jar rating.jar --build mvn clean install"))
 		})
 
 	})


### PR DESCRIPTION
#### Short description of what this resolves:

Ensures that wrapped `ike execute` command passed to `ike develop` is the same binary by expanding its full path based on parent command.

Fixes #829
