### PR TITLE
fix(session): makes sure session name follows RFC 1123

### DIFF
--- a/pkg/internal/session/session_test.go
+++ b/pkg/internal/session/session_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Session operations", func() {
 		})
 		Context("create", func() {
 
-			It("should create a new session if non found", func() {
+			It("should create a new session if none found", func() {
 				// given - no exiting sessions
 				// when - adding a ref to a session
 				_, remove, err := session.CreateOrJoinHandler(opts, client)

--- a/pkg/naming/name_generator.go
+++ b/pkg/naming/name_generator.go
@@ -2,6 +2,7 @@ package naming
 
 import (
 	"crypto/rand"
+	"math"
 	"math/big"
 )
 
@@ -27,4 +28,16 @@ func RandName(length int) string {
 	}
 
 	return string(b)
+}
+
+// ConcatToMax will cut each section to length based on number of sections to not go beyond max and separate the sections with -.
+func ConcatToMax(max int, sections ...string) string {
+	sectionLength := (max - len(sections) - 1) / len(sections)
+	name := ""
+
+	for _, section := range sections {
+		name = name + "-" + section[:int32(math.Min(float64(len(section)), float64(sectionLength)))]
+	}
+
+	return name[1:]
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Validates given session name against RFC 1123 (which is a standard naming requirement in k8s) and ensures generated one does conform one as well (when the username is used as part of it)

#### Changes proposed in this pull request:

- session name validation if passed from CLI
- changes session name generation to ensure that it conforms to these rules too (especially considering using the username as part of it)

Fixes #832
