### PR TITLE
chore(gh-actions): pins ubuntu to ubuntu-20.04

### DIFF
--- a/.github/workflows/cleanup_pr_images.yml
+++ b/.github/workflows/cleanup_pr_images.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cleanup-images:
     name: quay-image-cleanup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Delete PR-related images
         env:

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       REPOSITORY: ${{ github.repository }}
     steps:

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -11,7 +11,7 @@ jobs:
       && (contains(github.event.comment.author_association, 'MEMBER')
           || contains(github.event.comment.author_association, 'OWNER')
           || contains(github.event.comment.author_association, 'COLLABORATOR'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Fetch all tags

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -5,7 +5,7 @@ on:
     branches: master
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: "Tag matching commit (with `/tag vX.Y.Z` directive in the commit message)"
         uses: actions/github-script@v3.1

--- a/.github/workflows/update_labels.yml
+++ b/.github/workflows/update_labels.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: micnncim/action-label-syncer@v1

--- a/.github/workflows/validate_circleci.yml
+++ b/.github/workflows/validate_circleci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   circle-ci-validate:
     name: config validation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install CircleCI CLI
         run: |


### PR DESCRIPTION
#### Short description of what this resolves:

We were pointing to `ubuntu-latest` which for few months is anyway 20.04, so this change should be harmless (emphasis on should ;).

#### Changes proposed in this pull request:

- updates all the GH-action files

Fixes #671