### PR TITLE
feat(circleci): aggregates junit reports for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ defaults:
     command: |
       nvm install 10
       nvm use 10
+  merge-junit-reports: &merge-junit-reports
+    name: "Merges ginkgo junit test results"
+    command: |
+      sudo npm install -g junit-report-merger
+      mkdir -p test-results
+      jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
   docker:
     - image: &golang-img cimg/go:1.16.5-node
   machine-conf: &machine-conf
@@ -102,11 +108,9 @@ jobs:
           name: "Run the build"
           command: make build-ci
       - run:
-          name: "Merges ginkgo junit test results"
-          command: |
-            sudo npm install -g junit-report-merger
-            mkdir -p test-results
-            jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
+          <<: *node-install
+      - run:
+          <<: *merge-junit-reports
       - store_test_results:
           path: ./test-results
       - save_cache:
@@ -172,13 +176,13 @@ jobs:
             echo $QUAY_AUTH_JSON > ~/.docker/config.json
             docker login quay.io
       - run:
-          name: Install official kubectl
+          name: "Install official kubectl"
           command: |
             curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.5/bin/linux/amd64/kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - run:
-          name: Install Microk8s
+          name: "Install Microk8s"
           command: |
             cd ~/.snaps
             sudo snap ack core.assert
@@ -188,7 +192,7 @@ jobs:
       - save_cache:
           <<: *save-snaps
       - run:
-          name: Launch Microk8s
+          name: "Launch Microk8s"
           command: |
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig
@@ -273,9 +277,10 @@ jobs:
 
             make test-e2e
       - run:
+          <<: *node-install
+      - run:
           name: "Merges ginkgo junit test results"
           command: |
-            sudo snap install node --classic
             sudo npm install -g junit-report-merger
             mkdir -p test-results
             jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ defaults:
   merge-junit-reports: &merge-junit-reports
     name: "Merges ginkgo junit test results"
     command: |
+      nvm use 10
       sudo npm install -g junit-report-merger
       mkdir -p ./test-results/
       jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,9 +109,6 @@ jobs:
           command: make build-ci
       - run:
           when: always
-          <<: *node-install
-      - run:
-          when: always
           <<: *merge-junit-reports
       - store_test_results:
           path: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ defaults:
       nvm install 10
       nvm use 10
   docker:
-    - image: &golang-img cimg/go:1.16.2
+    - image: &golang-img cimg/go:1.16.5-node
   machine-conf: &machine-conf
     image: ubuntu-2004:202101-01
   skip-e2e-check: &skip-e2e-check
@@ -101,6 +101,14 @@ jobs:
       - run:
           name: "Run the build"
           command: make build-ci
+      - run:
+          name: "Merges ginkgo junit test results"
+          command: |
+            npm install -g junit-report-merger
+            mkdir -p test-results
+            jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
+      - store_test_results:
+          path: ./test-results
       - save_cache:
           key: golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
           paths:
@@ -264,6 +272,14 @@ jobs:
             make bundle bundle-build bundle-push
 
             make test-e2e
+      - run:
+          name: "Merges ginkgo junit test results"
+          command: |
+            npm install -g junit-report-merger
+            mkdir -p test-results
+            jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
+      - store_test_results:
+          path: ./test-results
       - save_cache:
           key: golang-deps-{{ .Environment.CIRCLE_JOB }}-cache-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ defaults:
   merge-junit-reports: &merge-junit-reports
     name: "Merges ginkgo junit test results"
     command: |
-      nvm install 10
-      nvm use 10
       sudo npm install -g junit-report-merger
       mkdir -p ./test-results/
       jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
@@ -279,7 +277,9 @@ jobs:
             make test-e2e
       - run:
           when: always
-          <<: *node-install
+          name: "Installs node using snap"
+          command: |
+            sudo snap install node --classic
       - run:
           when: always
           <<: *merge-junit-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ defaults:
   merge-junit-reports: &merge-junit-reports
     name: "Merges ginkgo junit test results"
     command: |
+      nvm install 10
       nvm use 10
       sudo npm install -g junit-report-merger
       mkdir -p ./test-results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - run:
           name: "Merges ginkgo junit test results"
           command: |
-            npm install -g junit-report-merger
+            sudo npm install -g junit-report-merger
             mkdir -p test-results
             jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
       - store_test_results:
@@ -275,7 +275,7 @@ jobs:
       - run:
           name: "Merges ginkgo junit test results"
           command: |
-            npm install -g junit-report-merger
+            sudo npm install -g junit-report-merger
             mkdir -p test-results
             jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ defaults:
     name: "Merges ginkgo junit test results"
     command: |
       sudo npm install -g junit-report-merger
-      mkdir -p test-results
+      mkdir -p ./test-results/
       jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
   docker:
     - image: &golang-img cimg/go:1.16.5-node
@@ -108,8 +108,10 @@ jobs:
           name: "Run the build"
           command: make build-ci
       - run:
+          when: always
           <<: *node-install
       - run:
+          when: always
           <<: *merge-junit-reports
       - store_test_results:
           path: ./test-results
@@ -277,13 +279,11 @@ jobs:
 
             make test-e2e
       - run:
+          when: always
           <<: *node-install
       - run:
-          name: "Merges ginkgo junit test results"
-          command: |
-            sudo npm install -g junit-report-merger
-            mkdir -p test-results
-            jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)
+          when: always
+          <<: *merge-junit-reports
       - store_test_results:
           path: ./test-results
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,7 @@ jobs:
       - run:
           name: "Merges ginkgo junit test results"
           command: |
+            sudo snap install node --classic
             sudo npm install -g junit-report-merger
             mkdir -p test-results
             jrm ./test-results/junit-report-combined.xml $(find . -type f -name ginkgo-test-results.xml)

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ converted-release-notes.md
 
 # Test results
 *ginkgo-test-results.xml
+test-results/
 
 # Git tree hash files - used for CircleCI build optimization - see https://github.com/Maistra/istio-workspace/issues/428
 

--- a/Makefile
+++ b/Makefile
@@ -210,32 +210,32 @@ $(PROJECT_DIR)/bin/yq:
 	GOBIN=$(PROJECT_DIR)/bin go install -mod=readonly github.com/mikefarah/yq/v4
 
 $(PROJECT_DIR)/bin/protoc-gen-go:
-	$(call header,"Installing")
+	$(call header,"Installing protoc-gen-go")
 	GOBIN=$(PROJECT_DIR)/bin go install -mod=readonly github.com/golang/protobuf/protoc-gen-go
 
 $(PROJECT_DIR)/bin/go-bindata:
-	$(call header,"Installing")
+	$(call header,"Installing go-bindata")
 	GOBIN=$(PROJECT_DIR)/bin go install -mod=readonly github.com/go-bindata/go-bindata/v3/...
 
 $(PROJECT_DIR)/bin/ginkgo:
-	$(call header,"Installing")
+	$(call header,"Installing ginkgo")
 	GOBIN=$(PROJECT_DIR)/bin go install -mod=readonly github.com/onsi/ginkgo/ginkgo
 
 $(PROJECT_DIR)/bin/goimports:
-	$(call header,"Installing")
+	$(call header,"Installing goimports")
 	GOBIN=$(PROJECT_DIR)/bin go install -mod=readonly golang.org/x/tools/cmd/goimports
 
 $(PROJECT_DIR)/bin/golangci-lint:
-	$(call header,"Installing")
+	$(call header,"Installing golangci-lint")
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_DIR)/bin v1.40.1
 
 $(PROJECT_DIR)/bin/controller-gen:
-	$(call header,"Installing")
+	$(call header,"Installing controller-gen")
 	$(call go-get-tool,$(PROJECT_DIR)/bin/controller-gen,sigs.k8s.io/controller-tools/cmd/controller-gen@$(shell go mod graph | grep controller-tools | head -n 1 | cut -d'@' -f 2))
 
 KUSTOMIZE_VERSION?=v3.9.3
 $(PROJECT_DIR)/bin/kustomize:
-	$(call header,"Installing")
+	$(call header,"Installing kustomize")
 	wget -q -c https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$(GOOS)_$(GOARCH).tar.gz -O /tmp/kustomize.tar.gz
 	tar xzvf /tmp/kustomize.tar.gz -C $(PROJECT_DIR)/bin/
 	chmod +x $(PROJECT_DIR)/bin/kustomize


### PR DESCRIPTION
#### Short description of what this resolves:

Ginkgo produces one junit xml per suite.

CircleCI can show the test summary but expects one file with all test runs.

This PR introduces simple logic around the build step which takes ginkgo results and merges them into one file, so CircleCI can consume it.

#### Changes proposed in this pull request:

- config for circle
- aggregation using [`junit-report-merger`](https://www.npmjs.com/package/junit-report-merger) node tool \o/


##### Some insights on why I went with node

I tried few others (included go and python-based ones but they were not working). This one in the contrary works like a charm.

Another possibility I tried was to use [`gotestsum`](https://github.com/gotestyourself/gotestsum) which is pretty neat but does not really work well with ginkgo. I also tried using `go test` in combination with `gotestsum` to run ginkgo tests, but that somehow ended up with an incomplete test report. So after all those attempts jrm seems to be the only one working easily.