### PR TITLE
chore(lint): bumps golangci-lint to latest release

### DIFF
--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go env
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.2
+          go-version: 1.16.5
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
@@ -32,5 +32,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.40
+          version: v1.41
           working-directory: go/src/github.com/${{ env.REPOSITORY }}

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ $(PROJECT_DIR)/bin/goimports:
 
 $(PROJECT_DIR)/bin/golangci-lint:
 	$(call header,"Installing")
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_DIR)/bin v1.40.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_DIR)/bin v1.41.1
 
 $(PROJECT_DIR)/bin/controller-gen:
 	$(call header,"Installing")

--- a/controllers/session/session_controller_int_test.go
+++ b/controllers/session/session_controller_int_test.go
@@ -353,7 +353,7 @@ func Scenario(scheme *runtime.Scheme, namespace string, scenarioGenerator func(i
 	scenarioGenerator(buf)
 	fileContent := buf.String()
 
-	var objects []runtime.Object
+	objects := []runtime.Object{}
 
 	fileChunks := strings.Split(fileContent, "---")
 	for _, fileChunk := range fileChunks {
@@ -365,9 +365,7 @@ func Scenario(scheme *runtime.Scheme, namespace string, scenarioGenerator func(i
 		if err != nil {
 			return nil, err
 		}
-		if rObj, ok := obj.(runtime.Object); ok {
-			objects = append(objects, rObj)
-		}
+		objects = append(objects, obj)
 	}
 
 	return objects, nil


### PR DESCRIPTION
#### Changes proposed in this pull request:

 * both locally and in gh action bumped to latest version
 * aligned golang version for the action itself
 * additionally fixes a little problem found with the new version


