### PR TITLE
feat(operator): bumps operator-sdk to latest v1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
 
             make deps tools
 
-            ./bin/operator-sdk olm install --version v1.8.1
+            ./bin/operator-sdk olm install --version v0.18.2
 
             make docker-build docker-push-versioned
             make docker-build-test docker-push-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
 
             make deps tools
 
-            ./bin/operator-sdk olm install --version v0.17.0 # pins to working version for now, see: https://github.com/operator-framework/operator-sdk/issues/4833
+            ./bin/operator-sdk olm install --version v1.8.1
 
             make docker-build docker-push-versioned
             make docker-build-test docker-push-test

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ $(PROJECT_DIR)/bin/controller-gen:
 	$(call header,"Installing")
 	$(call go-get-tool,$(PROJECT_DIR)/bin/controller-gen,sigs.k8s.io/controller-tools/cmd/controller-gen@$(shell go mod graph | grep controller-tools | head -n 1 | cut -d'@' -f 2))
 
-KUSTOMIZE_VERSION?=v3.9.3
+KUSTOMIZE_VERSION?=v4.2.0
 $(PROJECT_DIR)/bin/kustomize:
 	$(call header,"Installing")
 	wget -q -c https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$(GOOS)_$(GOARCH).tar.gz -O /tmp/kustomize.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ $(PROJECT_DIR)/bin/protoc:
 	$(PROJECT_DIR)/scripts/dev/get-protobuf.sh
 	chmod +x $(PROJECT_DIR)/bin/protoc
 
-OPERATOR_SDK_VERSION=v1.6.1
+OPERATOR_SDK_VERSION=v1.8.1
 $(PROJECT_DIR)/bin/operator-sdk:
 	$(call header,"Installing operator-sdk cli")
 	wget -q -c https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$(GOOS)_$(GOARCH) -O $(PROJECT_DIR)/bin/operator-sdk


### PR DESCRIPTION
#### Short description of what this resolves:

Bumps `operator-sdk` and olm install on microk8s.

#### Changes proposed in this pull request:

- bumps operator-sdk to latest v1.8.1 
- olm-install on microk8s has been updated too because aforementioned issue has been resolved within the container itself
- bumps kustomize to latest release v4.2.0

