### PR TITLE
Populate the missing Status fields RefNames & Strategies

### DIFF
--- a/build/bundle.Containerfile
+++ b/build/bundle.Containerfile
@@ -7,9 +7,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=istio-workspace-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.8.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v2.0.0+git
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/config/manifests/bases/istio-workspace-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/istio-workspace-operator.clusterserviceversion.yaml
@@ -7,7 +7,8 @@ metadata:
     categories: Developer Tools
     containerImage: controller:latest
     createdAt: "1970-01-01 00:00:0"
-    description: Safely develop and test on any Kubernetes cluster without affecting others.
+    description: Safely develop and test on any Kubernetes cluster without affecting
+      others.
     repository: https://github.com/maistra/istio-workspace
     support: Red Hat, Inc.
   name: istio-workspace-operator.v0.0.0


### PR DESCRIPTION
#### Short description of what this resolves:

Missing fields in `oc get`

#### Changes proposed in this pull request:

Calculate fields as we process the refs. 

Fixes #860
