### PR TITLE
chore: do not show cmd output when getting tp version

### DIFF
--- a/pkg/telepresence/wrapper.go
+++ b/pkg/telepresence/wrapper.go
@@ -31,7 +31,6 @@ func GetVersion() (string, error) {
 
 		go func() {
 			tp := gocmd.NewCmdOptions(shell.BufferAndStreamOutput, "telepresence", "--version")
-			shell.RedirectStreams(tp, os.Stdout, os.Stderr)
 			shell.Start(tp, done)
 		}()
 


### PR DESCRIPTION
Minor fix - now showing outup of `telepresence --version` to stdout

Related to #833
