### PR TITLE
test: add tests for validation rules

### DIFF
--- a/controllers/session/validation.go
+++ b/controllers/session/validation.go
@@ -28,7 +28,7 @@ func chainValidator(ctx model.SessionContext, ref model.Ref, session *istiov1alp
 			}
 
 			reason := ValidationReason
-			status := strconv.FormatBool(succeeded)
+			status := strconv.FormatBool(err == nil)
 			session.AddCondition(istiov1alpha1.Condition{
 				Source: istiov1alpha1.Source{
 					Kind: "Session",

--- a/pkg/model/sync.go
+++ b/pkg/model/sync.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"reflect"
+	"runtime"
+)
+
 // Sync is the entry point for ensuring the desired state for the given Ref is up to date.
 type Sync func(SessionContext, Ref, ModificatorController, LocatedReporter, ModificatorStatusReporter)
 
@@ -15,7 +20,7 @@ func NewSync(locators []Locator, modificators []Modificator) Sync {
 			)
 
 			if err != nil {
-				context.Log.Error(err, "locating failed", "locator", locator)
+				context.Log.Error(err, "locating failed", "locator", runtime.FuncForPC(reflect.ValueOf(locator).Pointer()).Name())
 			}
 		}
 		if !modify(located.Store) {

--- a/test/cmd/test-scenario/generator/generators.go
+++ b/test/cmd/test-scenario/generator/generators.go
@@ -23,6 +23,8 @@ const (
 var (
 	TestImageName = ""
 	GatewayHost   = "*"
+
+	allSubGenerators = []SubGenerator{Deployment, DeploymentConfig, Service, DestinationRule, VirtualService}
 )
 
 // Entry is a simple value object that holds the basic configuration used by the generator.
@@ -48,8 +50,7 @@ type SubGenerator func(service Entry) runtime.Object
 type Modifier func(service Entry, object runtime.Object)
 
 // Generate runs and prints the full test scenario generation to sysout.
-func Generate(out io.Writer, services []Entry, modifiers ...Modifier) {
-	sub := []SubGenerator{Deployment, DeploymentConfig, Service, DestinationRule, VirtualService}
+func Generate(out io.Writer, services []Entry, sub []SubGenerator, modifiers ...Modifier) {
 	modify := func(service Entry, object runtime.Object) {
 		for _, modifier := range modifiers {
 			modifier(service, object)

--- a/test/cmd/test-scenario/generator/scenarios.go
+++ b/test/cmd/test-scenario/generator/scenarios.go
@@ -18,6 +18,7 @@ func TestScenario1HTTPThreeServicesInSequence(out io.Writer) {
 	Generate(
 		out,
 		[]Entry{productpage, reviews, ratings},
+		allSubGenerators,
 		WithVersion("v1"),
 		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway(GatewayHost)),
 		ForService(reviews, Call(HTTP(), ratings)),
@@ -35,6 +36,7 @@ func TestScenario1GRPCThreeServicesInSequence(out io.Writer) {
 	Generate(
 		out,
 		[]Entry{productpage, reviews, ratings},
+		allSubGenerators,
 		WithVersion("v1"),
 		ForService(productpage, Call(GRPC(), reviews), ConnectToGateway(GatewayHost)),
 		ForService(reviews, Call(GRPC(), ratings)),
@@ -53,6 +55,7 @@ func TestScenario2ThreeServicesInSequenceDeploymentConfig(out io.Writer) {
 	Generate(
 		out,
 		[]Entry{productpage, reviews, ratings},
+		allSubGenerators,
 		WithVersion("v1"),
 		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway(GatewayHost)),
 		ForService(reviews, Call(HTTP(), ratings)),
@@ -71,10 +74,45 @@ func DemoScenario(out io.Writer) {
 	Generate(
 		out,
 		[]Entry{productpage, reviews, ratings, authors, locations},
+		allSubGenerators,
 		WithVersion("v1"),
 		ForService(productpage, Call(HTTP(), reviews), Call(HTTP(), authors), ConnectToGateway("ike-demo.io")),
 		ForService(reviews, Call(GRPC(), ratings)),
 		ForService(authors, Call(GRPC(), locations)),
 		GatewayOnHost("ike-demo.io"),
+	)
+}
+
+// IncompleteMissingVirtualServices generates a scenario where there are no DestinationRules.
+func IncompleteMissingDestinationRules(out io.Writer) {
+	productpage := Entry{"productpage", "Deployment", Namespace}
+	reviews := Entry{"reviews", "Deployment", Namespace}
+	ratings := Entry{"ratings", "Deployment", Namespace}
+
+	Generate(
+		out,
+		[]Entry{productpage, reviews, ratings},
+		[]SubGenerator{Deployment, DeploymentConfig, Service, VirtualService},
+		WithVersion("v1"),
+		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway(GatewayHost)),
+		ForService(reviews, Call(HTTP(), ratings)),
+		GatewayOnHost(GatewayHost),
+	)
+}
+
+// IncompleteMissingVirtualServices generates a scenario where there are no VirtualServices.
+func IncompleteMissingVirtualServices(out io.Writer) {
+	productpage := Entry{"productpage", "Deployment", Namespace}
+	reviews := Entry{"reviews", "Deployment", Namespace}
+	ratings := Entry{"ratings", "Deployment", Namespace}
+
+	Generate(
+		out,
+		[]Entry{productpage, reviews, ratings},
+		[]SubGenerator{Deployment, DeploymentConfig, Service, DestinationRule},
+		WithVersion("v1"),
+		ForService(productpage, Call(HTTP(), reviews), ConnectToGateway(GatewayHost)),
+		ForService(reviews, Call(HTTP(), ratings)),
+		GatewayOnHost(GatewayHost),
 	)
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Adds the ability to add custom set of SubGenerators to the scenario generator. Opens up the option to add and remove SubGenerators per scenario.

#### Changes proposed in this pull request:

fixed minor issue where the conditions coming after a failure would all
be false due to variable scope.
