### PR TITLE
chore(circleci): bumps microk8s to 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
             echo "Istio enabled"
 
             echo "Installing tekton"
-            kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.27.2/release.yaml
+            kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.27.3/release.yaml
             sleep 10
             n=0
             until [ $n -ge 10 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
 
             export KUBECONFIG=/tmp/kubeconfig \
               IKE_CLUSTER_HOST=localhost \
-              IKE_ISTIO_INGRESS=http://localhost:32023 \
+              IKE_ISTIO_INGRESS=http://localhost:$(sudo microk8s.kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.spec.ports[?(@.port==15021)].nodePort}') \
               PRE_BUILT_IMAGES=true \
               IKE_INTERNAL_DOCKER_REGISTRY=quay.io \
               IKE_EXTERNAL_DOCKER_REGISTRY=quay.io \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
 
             make deps tools
 
-            ./bin/operator-sdk olm install --version v0.18.2
+            ./bin/operator-sdk olm install --version v0.18.3
 
             make docker-build docker-push
             make docker-build-test docker-push-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
 
             export KUBECONFIG=/tmp/kubeconfig \
               IKE_CLUSTER_HOST=localhost \
-              IKE_ISTIO_INGRESS=http://localhost:$(sudo microk8s.kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.spec.ports[?(@.port==15021)].nodePort}') \
+              IKE_ISTIO_INGRESS=http://localhost:$(sudo microk8s.kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.spec.ports[?(@.port==80)].nodePort}') \
               PRE_BUILT_IMAGES=true \
               IKE_INTERNAL_DOCKER_REGISTRY=quay.io \
               IKE_EXTERNAL_DOCKER_REGISTRY=quay.io \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults:
     IKE_E2E_MANAGE_CLUSTER: "false"
     IKE_LOG_DEBUG: "true"
     BUILD_CACHE_FOLDER: ".circleci/cache"
-    MICROK8S_SNAP_VERSION: "1.19/stable"
+    MICROK8S_SNAP_VERSION: "1.22/stable"
     GOLANG_SNAP_VERSION: "1.16/stable"
   golang-install: &golang-install
     name: "Install latest Golang"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
             echo "Istio enabled"
 
             echo "Installing tekton"
-            kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.22.0/release.yaml
+            kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.27.2/release.yaml
             sleep 10
             n=0
             until [ $n -ge 10 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
 
             export KUBECONFIG=/tmp/kubeconfig \
               IKE_CLUSTER_HOST=localhost \
-              IKE_ISTIO_INGRESS=http://localhost:31380 \
+              IKE_ISTIO_INGRESS=http://localhost:32023 \
               PRE_BUILT_IMAGES=true \
               IKE_INTERNAL_DOCKER_REGISTRY=quay.io \
               IKE_EXTERNAL_DOCKER_REGISTRY=quay.io \

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 
 		})
 
-		FContext("verify external integrations", func() {
+		Context("verify external integrations", func() {
 
 			Context("Tekton", func() {
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 
 		})
 
-		Context("verify external integrations", func() {
+		FContext("verify external integrations", func() {
 
 			Context("Tekton", func() {
 

--- a/integration/tekton/tasks/ike-create/ike-create.yaml
+++ b/integration/tekton/tasks/ike-create/ike-create.yaml
@@ -37,6 +37,7 @@ spec:
     - name: ike
       image: released-image
       script: |
+        #!/usr/bin/env bash
         ike_create_cmd="ike create --session $(params.session) --deployment $(params.target) --namespace $(params.namespace) --image $(params.image) --json"
         if [ -n "$(params.route)" ]; then
           ike_create_cmd="${ike_create_cmd} --route $(params.route)"
@@ -48,4 +49,4 @@ spec:
           echo "${STATE}"
           exit $exit_code
         fi
-        echo "${STATE}" | grep \" | cut -d \" -f 2 | uniq | tr -d '\n' > /tekton/results/url
+        echo "${STATE}" | grep \" | cut -d \" -f 2 | uniq | tr -d '\n' | tee $(results.url.path)

--- a/integration/tekton/tasks/ike-delete/ike-delete.yaml
+++ b/integration/tekton/tasks/ike-delete/ike-delete.yaml
@@ -27,4 +27,5 @@ spec:
     - name: ike
       image: released-image
       script: |
+        #!/usr/bin/env bash
         ike delete --session "$(params.session)" --deployment "$(params.target)" --namespace "$(params.namespace)"

--- a/integration/tekton/tasks/ike-session-url/ike-session-url.yaml
+++ b/integration/tekton/tasks/ike-session-url/ike-session-url.yaml
@@ -32,4 +32,4 @@ spec:
           echo "${STATE}"
           exit $error
         fi
-        echo "${STATE}" | grep \" | cut -d \" -f 2 | uniq | tr -d '\n' > /tekton/results/url
+        echo "${STATE}" | grep \" | cut -d \" -f 2 | uniq | tr -d '\n' | tee $(results.url.path)

--- a/integration/tekton/tasks/ike-session-url/ike-session-url.yaml
+++ b/integration/tekton/tasks/ike-session-url/ike-session-url.yaml
@@ -27,6 +27,7 @@ spec:
     - name: oc
       image: quay.io/openshift/origin-cli:4.9
       script: |
+        #!/usr/bin/env bash
         if ! STATE=$(oc get session "$(params.session)" --namespace "$(params.namespace)" -o jsonpath={.status.hosts}); then
           error=$?
           echo "${STATE}"


### PR DESCRIPTION
#### Short description of what this resolves:

This PR updates microk8s and istio so we can test against the latest upstream. It also bring few tweaks to Tekton tasks.

#### Changes proposed in this pull request:

- bumps microk8s to 1.22
- bumps tekton to latest release
- auto discovers istio ingress port for tests
- tweaks tekton tasks


