### PR TITLE
fix(operatorhub): uses ansible test scripts from new repo

### DIFF
--- a/.github/workflows/operator_bundle_tests.yml
+++ b/.github/workflows/operator_bundle_tests.yml
@@ -30,3 +30,10 @@ jobs:
           cd go/src/github.com/${{ env.REPOSITORY }}
           make lint-prepare bundle-test
         shell: bash
+      - name: Print test logs on failure
+        if: ${{ failure() }}
+        run: |
+          cat /tmp/test.out
+          echo -e "\n--------------------------------------------------------------------------\n"
+          cat /tmp/op-test/log.out
+        shell: bash

--- a/.github/workflows/operator_bundle_tests.yml
+++ b/.github/workflows/operator_bundle_tests.yml
@@ -5,6 +5,8 @@ on: pull_request
 jobs:
   operatorhub-test:
     runs-on: ubuntu-latest
+    env:
+      OP_TEST_CONTAINER_OPT: "-i"
     steps:
       - name: Set up Go env
         uses: actions/setup-go@v2

--- a/.github/workflows/operator_bundle_tests.yml
+++ b/.github/workflows/operator_bundle_tests.yml
@@ -12,7 +12,7 @@ jobs:
           go-version: 1.17.1
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           path: go/src/github.com/${{ env.REPOSITORY }}
       - name: Set $GOPATH
         run: |
@@ -24,6 +24,7 @@ jobs:
           python-version: 3.7
       - name: Tests bundle
         run: |
+          git config --global user.name "GitHub Actions" && git config --global user.email "actions@users.noreply.github.com"
           cd go/src/github.com/${{ env.REPOSITORY }}
           make lint-prepare bundle-test
         shell: bash

--- a/.github/workflows/operator_bundle_tests.yml
+++ b/.github/workflows/operator_bundle_tests.yml
@@ -1,0 +1,29 @@
+name: Tests Operator Bundle
+
+on: pull_request
+
+jobs:
+  operatorhub-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go env
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: go/src/github.com/${{ env.REPOSITORY }}
+      - name: Set $GOPATH
+        run: |
+          echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
+        shell: bash
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Tests bundle
+        run: |
+          cd go/src/github.com/${{ env.REPOSITORY }}
+          make lint-prepare bundle-test
+        shell: bash

--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,10 @@ bundle-run-all:		## Run the bundle image in AllNamespace(OPERATOR_NAMESPACE) ins
 bundle-clean:	## Clean the bundle image
 	operator-sdk cleanup istio-workspace-operator -n $(OPERATOR_NAMESPACE)
 
+.PHONY: bundle-test
+bundle-test: bundle	## Open up a PR to the Operator Hub community catalog
+	./scripts/release/operatorhub.sh --dry-run --test
+
 .PHONY: bundle-publish
 bundle-publish:	## Open up a PR to the Operator Hub community catalog
 	./scripts/release/operatorhub.sh

--- a/Makefile
+++ b/Makefile
@@ -422,7 +422,7 @@ bundle-clean:	## Clean the bundle image
 	operator-sdk cleanup istio-workspace-operator -n $(OPERATOR_NAMESPACE)
 
 .PHONY: bundle-test
-bundle-test: bundle	## Open up a PR to the Operator Hub community catalog
+bundle-test: bundle	## Run the Operator Hub test suite
 	./scripts/release/operatorhub.sh --dry-run --test
 
 .PHONY: bundle-publish

--- a/scripts/release/operatorhub.sh
+++ b/scripts/release/operatorhub.sh
@@ -98,6 +98,7 @@ if [[ $runTests -ne 0 ]]; then
   bash <(curl -sL https://cutt.ly/AEeucaw) \
   "$tests" \
   "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"
+  echo $?
 fi
 
 if [[ ! $dryRun && -z $GITHUB_TOKEN ]]; then

--- a/scripts/release/operatorhub.sh
+++ b/scripts/release/operatorhub.sh
@@ -87,8 +87,8 @@ git checkout -b "${BRANCH}"
 mkdir -p "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"/
 cp -a "${CUR_DIR}"/../../bundle/. "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"/
 
-git add .
-git commit -s -S -m"${TITLE}"
+skipInDryRun git add .
+skipInDryRun git commit -s -S -m"${TITLE}"
 
 if [[ $runTests -ne 0 ]]; then
   echo "Running tests: $tests"

--- a/scripts/release/operatorhub.sh
+++ b/scripts/release/operatorhub.sh
@@ -94,11 +94,19 @@ if [[ $runTests -ne 0 ]]; then
   echo "Running tests: $tests"
 
   cd "${TMP_DIR}"
-  export OP_TEST_ANSIBLE_PULL_REPO="https://github.com/redhat-openshift-ecosystem/operator-test-playbooks" ## can be removed after https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/244 is merged
+
+  ## can be removed after https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/244 is merged
+  export OP_TEST_ANSIBLE_PULL_REPO="https://github.com/redhat-openshift-ecosystem/operator-test-playbooks"
+
   bash <(curl -sL https://cutt.ly/AEeucaw) \
   "$tests" \
-  "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"
-  echo $?
+  "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}" > /tmp/test.out
+
+  ## Until the script is fixed https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/247
+  if tail -n 4 /tmp/test.out | grep "Failed with rc";
+  then
+    exit 1;
+  fi # "Failed" was found in the logs
 fi
 
 if [[ ! $dryRun && -z $GITHUB_TOKEN ]]; then

--- a/scripts/release/operatorhub.sh
+++ b/scripts/release/operatorhub.sh
@@ -64,7 +64,7 @@ FORK="${FORK:-maistra}"
 FORK_REPO_URL="${FORK_REPO_URL:-https://${GIT_USER}:${GITHUB_TOKEN}@github.com/${FORK}/community-operators.git}"
 
 OPERATOR_NAME=istio-workspace-operator
-OPERATOR_VERSION=${OPERATOR_VERSION:-0.0.5}
+OPERATOR_VERSION=${OPERATOR_VERSION:-0.3.0}
 OPERATOR_HUB=${OPERATOR_HUB:-community-operators}
 
 BRANCH=${BRANCH:-"${OPERATOR_HUB}/${OPERATOR_NAME}-${OPERATOR_VERSION}"}
@@ -94,8 +94,8 @@ if [[ $runTests -ne 0 ]]; then
   echo "Running tests: $tests"
 
   cd "${TMP_DIR}"
-
-  bash <(curl -sL https://cutt.ly/WhkV76k) \
+  export OP_TEST_ANSIBLE_PULL_REPO="https://github.com/redhat-openshift-ecosystem/operator-test-playbooks" ## can be removed after https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/244 is merged
+  bash <(curl -sL https://cutt.ly/AEeucaw) \
   "$tests" \
   "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"
 fi


### PR DESCRIPTION
#### Short description of what this resolves:

As operatorhub repository has been split into two locations this affected the ansible-based test harness we use for the release process. This fix corrects the location from where we download it.

This can be further improved when https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/244 is accepted and merged.

#### Changes proposed in this pull request:

- updated test script downloading ansible testing harness from new repository
- new Make target `bundle-test` which will execute tests in `--dry-run` mode
- GitHub Action for testing bundle using newly created target

Fixes #890 
