### PR TITLE
feat(circleci): skips build and e2e tests for non-code changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,13 @@ defaults:
     - image: &golang-img cimg/go:1.17.1-node
   machine-conf: &machine-conf
     image: ubuntu-2004:202101-01
+  skip-for-non-code-changes: &skip-for-non-code-changes
+    name: "Skip job for non-code changes"
+    command: |
+      if git diff -s --exit-code HEAD~..HEAD -- . ':!docs' ':!.github' ':!.circleci' ':!scripts'; then
+        echo "This commit has only non-code related changes."
+        circleci step halt
+      fi
   skip-e2e-check: &skip-e2e-check
     name: "Check for /skip-e2e directive"
     command: |
@@ -96,6 +103,8 @@ jobs:
       - run:
           <<: *skip-build-check
       - run:
+          <<: *skip-for-non-code-changes
+      - run:
           << : *obtain-tree-hash
       - restore_cache:
           << : *restore-tree-hash
@@ -128,6 +137,8 @@ jobs:
       <<: *env-vars
     steps:
       - checkout
+      - run:
+          <<: *skip-for-non-code-changes
       - run:
           <<: *obtain-tree-hash
       - restore_cache:


### PR DESCRIPTION
#### Short description of what this resolves:

We don't need to run build nor tests when non-code related assets have been changes such as docs or CI config. This PR fixes it for Circle jobs.

#### Changes proposed in this pull request:

- circleci step to skip job for given commit when only non-code assets have been changed

Fixes #656 
