### PR TITLE
fix(operator): runs the same test suite as on hub PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ jobs:
             else
               echo "New build - if succeeds subsequent run will be skipped."
 
-              OWNER="k8s-operators" make bundle-publish
+              OWNER="k8s-operatorhub" make bundle-publish
 
               OWNER="redhat-openshift-ecosystem" OPERATOR_HUB="community-operators-prod" \
               make bundle-publish

--- a/.github/workflows/operator_bundle_tests.yml
+++ b/.github/workflows/operator_bundle_tests.yml
@@ -10,7 +10,7 @@ jobs:
   operatorhub-test:
     runs-on: ubuntu-latest
     env:
-      OP_TEST_CONTAINER_OPT: "-i"
+      OPP_CONTAINER_OPT: "-i"
     steps:
       - name: Set up Go env
         uses: actions/setup-go@v2

--- a/api/maistra/v1alpha1/session_types.go
+++ b/api/maistra/v1alpha1/session_types.go
@@ -93,7 +93,7 @@ type SessionStatus struct {
 }
 
 type StatusReadiness struct {
-	// Status of resources deployed/modifed by this Session resource
+	// Status of resources deployed/modified by this Session resource
 	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Resources", xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses"
 	Components StatusComponents `json:"components,omitempty"`
 }

--- a/config/crd/bases/workspace.maistra.io_sessions.yaml
+++ b/config/crd/bases/workspace.maistra.io_sessions.yaml
@@ -160,7 +160,7 @@ spec:
               readiness:
                 properties:
                   components:
-                    description: Status of resources deployed/modifed by this Session
+                    description: Status of resources deployed/modified by this Session
                       resource
                     properties:
                       pending:

--- a/scripts/release/operatorhub/publish.sh
+++ b/scripts/release/operatorhub/publish.sh
@@ -74,7 +74,7 @@ OPERATORS_DIR="operators/${OPERATOR_NAME}/${OPERATOR_VERSION}/"
 mkdir -p "${OPERATORS_DIR}"
 cp -a "${BUNDLE_DIR}"/. "${OPERATORS_DIR}"
 
-TITLE="Add ${OPERATOR_NAME} release ${OPERATOR_VERSION} to ${OPERATOR_HUB}"
+TITLE="operators ${OPERATOR_NAME} (${OPERATOR_VERSION})"
 skipInDryRun git add .
 skipInDryRun git commit -s -S -m"${TITLE}"
 

--- a/scripts/release/operatorhub/test.sh
+++ b/scripts/release/operatorhub/test.sh
@@ -9,10 +9,10 @@ show_help() {
   echo " "
   echo "Options:"
   echo "-h, --help              shows brief help"
-  echo "-t, --test              runs operator-framework ansible tests (default: all. other supported values are: orange, kiwi or lemon)"
+  echo "-t, --test              runs operator-framework ansible tests (default: kiwi. supported values: all, orange, kiwi, lemon)"
 }
 
-tests=all
+tests=kiwi
 
 while test $# -gt 0; do
   case "$1" in
@@ -56,42 +56,56 @@ TMP_DIR=$(mktemp -d -t "${OPERATOR_NAME}.XXXXXXXXXX")
 trap '{ rm -rf -- "$TMP_DIR"; }' EXIT
 
 #### We can keep old repository to run tests (upstream testing script still relies on that)
-OWNER="${OWNER:-operator-framework}"
-HUB_REPO_URL="${HUB_REPO_URL:-https://github.com/${OWNER}/community-operators.git}"
-HUB_BASE_BRANCH="${HUB_BASE_BRANCH:-master}"
+OWNER="${OWNER:-k8s-operatorhub}"
+HUB_REPO_URL="${HUB_REPO_URL:-https://github.com/${OWNER}/${OPERATOR_HUB}.git}"
+HUB_BASE_BRANCH="${HUB_BASE_BRANCH:-main}"
 
 FORK="${FORK:-maistra}"
-FORK_REPO_URL="${FORK_REPO_URL:-https://${GIT_USER}:${GITHUB_TOKEN}@github.com/${FORK}/community-operators-archived.git}"
+FORK_REPO_URL="${FORK_REPO_URL:-https://${GIT_USER}:${GITHUB_TOKEN}@github.com/${FORK}/community-operators.git}"
 
 BRANCH=${BRANCH:-"${OPERATOR_HUB}/${OPERATOR_NAME}-${OPERATOR_VERSION}"}
 
 source "${CUR_DIR}"/../validate_semver.sh
 
 validate_semantic_versioning "v${OPERATOR_VERSION}"
-
+echo "git clone ${HUB_REPO_URL} ${TMP_DIR}"
 git clone "${HUB_REPO_URL}" "${TMP_DIR}"
 
 cd "${TMP_DIR}"
 git remote add fork "${FORK_REPO_URL}"
 git checkout -b "${BRANCH}"
 
-mkdir -p "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"/
-cp -a "${BUNDLE_DIR}"/. "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}"/
+mkdir -p "operators/${OPERATOR_NAME}/${OPERATOR_VERSION}"/
+cp -a "${BUNDLE_DIR}"/. "operators/${OPERATOR_NAME}/${OPERATOR_VERSION}"/
 
-## No need to use copied repo - run on our own instead ? it has to have certain structure ... like before stream/operator/version
+OPP_SCRIPT_URL="https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/ci/latest/ci/scripts/opp.sh"
+OPP_SCRIPT_ENV_URL="https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/ci/latest/ci/scripts/opp-env.sh"
+OPP_SCRIPT_ENV_OPRT_URL="https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/ci/latest/ci/scripts/opp-oprt.sh"
+OPP_IMAGE="quay.io/operator_testing/operator-test-playbooks:latest"
+OPP_ANSIBLE_PULL_REPO="https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/"
+OPP_ANSIBLE_PULL_BRANCH="upstream-community"
+OPP_THIS_REPO_BASE="https://github.com"
+OPP_THIS_REPO="${FORK}/${OPERATOR_HUB}"
+OPP_THIS_BRANCH="main"
+OPP_RELEASE_BUNDLE_REGISTRY="quay.io"
+OPP_RELEASE_BUNDLE_ORGANIZATION="operatorhubio"
+OPP_RELEASE_INDEX_REGISTRY="quay.io"
+OPP_RELEASE_INDEX_ORGANIZATION="operatorhubio"
+OPP_RELEASE_INDEX_NAME="catalog"
+OPP_MIRROR_INDEX_MULTIARCH_BASE="registry.redhat.io/openshift4/ose-operator-registry:v4.5"
+OPP_MIRROR_INDEX_MULTIARCH_POSTFIX="s"
+KIND_KUBE_VERSION="v1.21.1"
+OPP_PRODUCTION_TYPE="k8s"
+
 echo "Running tests: $tests"
 cd "${TMP_DIR}"
 
-## can be removed after https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/244 is merged
-export OP_TEST_ANSIBLE_PULL_REPO="https://github.com/redhat-openshift-ecosystem/operator-test-playbooks"
-
-bash <(curl -sL https://cutt.ly/AEeucaw) \
+bash <(curl -sL $OPP_SCRIPT_URL) \
   "$tests" \
-  "${OPERATOR_HUB}/${OPERATOR_NAME}/${OPERATOR_VERSION}" > /tmp/test.out
+  "operators/${OPERATOR_NAME}/${OPERATOR_VERSION}"
 
 ## Until the script is fixed https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/247
 if tail -n 4 /tmp/test.out | grep "Failed with rc";
 then
   exit 1;
 fi # "Failed" was found in the logs
-


### PR DESCRIPTION
#### Short description of what this resolves:

Adjusts operator test suite to the same one as used in upstream hub repos.

#### Changes proposed in this pull request:

- fixed test script logic
- narrows test suite (runs `kiwi` instead of `all`)
- adjusts CI config
