### PR TITLE
feat(make): enables image builder overwrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,11 @@ ifneq (, $(shell which oc))
 	k8s=oc
 endif
 
-IMG_BUILDER:=docker
-## Prefer to use podman
+# Prefer to use podman if not explicitly set
 ifneq (, $(shell which podman))
-	IMG_BUILDER=podman
+	IMG_BUILDER?=podman
+else
+	IMG_BUILDER?=docker
 endif
 
 ###########################################################################


### PR DESCRIPTION
#### Short description of what this resolves:

Before, if `podman` was on the path, it was always using it. Bu if you really want to check how `docker` works, with the current setup you need to manipulate `Makefile`.

#### Changes proposed in this pull request:

- using `IMG_BUILDER` environment variable you can now define desired image builder
