### PR TITLE
build(deps): Bump ubi8/ubi-minimal from 8.4 to 8.5

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 ADD ike /usr/local/bin/ike

--- a/build/ContainerfileTest
+++ b/build/ContainerfileTest
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 ADD test-service /usr/local/bin/test-service
 ENTRYPOINT ["test-service"]

--- a/build/ContainerfileTestPrepared
+++ b/build/ContainerfileTestPrepared
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 EXPOSE 9080
 


### PR DESCRIPTION
#### Short description of what this resolves:

Brings updated ubi8-minimal for all our images. This is is due to limitation of @dependabot which handles `Dockerfile`s but still not `Containerfile`s.

#### Changes proposed in this pull request:

- deps update for all images
