### PR TITLE
fix(tp): handles telepresence version newer than v1

### DIFF
--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -5,7 +5,7 @@ In this section we walk you through necessary steps to start using `ike`. It wil
 == What do you need
 
 * [x] `oc` or `kubectl`
-* [x] https://www.telepresence.io/reference/install[Telepresence] CLI tool (and required runtime dependencies)
+* [x] https://www.telepresence.io/docs/v1/reference/install/[Telepresence] CLI tool (and required runtime dependencies)
 * [x] `ike` binary (see below)
 * [x] Kubernetes cluster with Istio (i.e. Maistra)
 

--- a/pkg/cmd/develop/cmd_test.go
+++ b/pkg/cmd/develop/cmd_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Usage of ike develop command", func() {
 
 		tmpPath := NewTmpPath()
 		BeforeEach(func() {
-			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.TpSleepBin))
+			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.Tp1WithSleepBin))
 		})
 		AfterEach(tmpPath.Restore)
 
@@ -50,7 +50,7 @@ var _ = Describe("Usage of ike develop command", func() {
 
 		tmpPath := NewTmpPath()
 		BeforeEach(func() {
-			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.TpSleepBin))
+			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.Tp1WithSleepBin))
 		})
 		AfterEach(tmpPath.Restore)
 
@@ -196,7 +196,7 @@ var _ = Describe("Usage of ike develop command", func() {
 
 		tmpPath := NewTmpPath()
 		BeforeEach(func() {
-			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.TpSleepBin))
+			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.Tp1WithSleepBin))
 		})
 		AfterEach(tmpPath.Restore)
 

--- a/pkg/cmd/execute/cmd_test.go
+++ b/pkg/cmd/execute/cmd_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Usage of ike execute command", func() {
 		tmpPath := NewTmpPath()
 
 		BeforeEach(func() {
-			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.TpSleepBin), path.Dir(shell.JavaBin))
+			tmpPath.SetPath(path.Dir(shell.MvnBin), path.Dir(shell.Tp1WithSleepBin), path.Dir(shell.JavaBin))
 		})
 
 		AfterEach(tmpPath.Restore)

--- a/pkg/cmd/internal/session/session_func_test.go
+++ b/pkg/cmd/internal/session/session_func_test.go
@@ -14,10 +14,12 @@ import (
 var _ = Describe("Usage of session func", func() {
 
 	var restoreEnvVars func()
-	BeforeEach(func() {
+
+	JustBeforeEach(func() {
 		restoreEnvVars = test.TemporaryEnvVars("TELEPRESENCE_VERSION", "0.123")
 	})
-	AfterEach(func() {
+
+	JustAfterEach(func() {
 		restoreEnvVars()
 	})
 

--- a/pkg/cmd/internal/session/session_suite_test.go
+++ b/pkg/cmd/internal/session/session_suite_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"path"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -19,14 +20,19 @@ func TestDevelopCmd(t *testing.T) {
 
 var current goleak.Option
 
+var tmpPath = NewTmpPath()
 var _ = SynchronizedBeforeSuite(func() []byte {
 	current = goleak.IgnoreCurrent()
-	shell.StubShellCommands()
+	tpPath := shell.BuildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1")
+
+	tmpPath = NewTmpPath()
+	tmpPath.SetPath(path.Dir(tpPath))
 
 	return []byte{}
 }, func([]byte) {})
 
 var _ = SynchronizedAfterSuite(func() {}, func() {
+	tmpPath.Restore()
 	gexec.CleanupBuildArtifacts()
 	goleak.VerifyNone(GinkgoT(), current)
 })

--- a/pkg/shell/funcs.go
+++ b/pkg/shell/funcs.go
@@ -124,7 +124,6 @@ func BinaryExists(binName, hint string) bool {
 
 		return false
 	}
-
 	logger().V(1).Info(fmt.Sprintf("Found '%s' executable in '%s'.", binName, path))
 	logger().V(1).Info(fmt.Sprintf("See '%s.log' for more details about its execution.", binName))
 

--- a/pkg/telepresence/wrapper.go
+++ b/pkg/telepresence/wrapper.go
@@ -13,7 +13,7 @@ import (
 const (
 	// BinaryName is a name of telepresence binary we assume be available on the $PATH.
 	BinaryName  = "telepresence"
-	installHint = "Head over to https://www.telepresence.io/reference/install for installation instructions.\n"
+	installHint = "Head over to https://www.telepresence.io/docs/v1/reference/install/ for installation instructions.\n"
 )
 
 var errorNoTelepresenceHint = fmt.Errorf("couldn't find '%s' installed in your system.\n%s\n"+

--- a/pkg/telepresence/wrapper.go
+++ b/pkg/telepresence/wrapper.go
@@ -16,33 +16,47 @@ const (
 	installHint = "Head over to https://www.telepresence.io/docs/v1/reference/install/ for installation instructions.\n"
 )
 
-var errorNoTelepresenceHint = fmt.Errorf("couldn't find '%s' installed in your system.\n%s\n"+
-	"you can specify the version using TELEPRESENCE_VERSION environment variable", BinaryName, installHint)
+var (
+	errBinaryNotFound = fmt.Errorf("couldn't find '%s' installed in your system.\n%s\n"+
+		"you can specify the version using TELEPRESENCE_VERSION environment variable", BinaryName, installHint)
+	errUnsupportedBinary = fmt.Errorf("you are using unsupported version of %s, please install v1.\n%s", BinaryName, installHint)
+)
 
 // GetVersion checks which version of telepresence should be used or is available on the path
 // TELEPRESENCE_VERSION env variable is checked and if is defined takes precedence.
 // If the binary is present on the $PATH then its version is used.
 // If all above fails we return error, as there's no telepresence in use nor env var is defined.
 func GetVersion() (string, error) {
-	tpVersion, found := os.LookupEnv("TELEPRESENCE_VERSION")
-	if !found && BinaryAvailable() {
-		done := make(chan gocmd.Status, 1)
-		defer close(done)
+	if !BinaryAvailable() {
+		return "", errBinaryNotFound
+	}
 
-		go func() {
-			tp := gocmd.NewCmdOptions(shell.BufferAndStreamOutput, "telepresence", "--version")
-			shell.Start(tp, done)
-		}()
-
-		finalStatus := <-done
-		tpVersion = strings.Join(finalStatus.Stdout, " ")
+	tpVersion, versionSpecified := os.LookupEnv("TELEPRESENCE_VERSION")
+	if !versionSpecified {
+		// Check if we are dealing with Telepresence v2
+		versionCmd := execute("telepresence", "version")
+		if versionCmd.Exit == 0 {
+			return "", errUnsupportedBinary
+		}
+		versionCmd = execute("telepresence", "--version")
+		tpVersion = strings.Join(versionCmd.Stdout, " ")
 	}
 
 	if tpVersion == "" {
-		return "", errorNoTelepresenceHint
+		return "", errUnsupportedBinary
 	}
 
 	return tpVersion, nil
+}
+
+func execute(cmd string, args ...string) gocmd.Status {
+	done := make(chan gocmd.Status, 1)
+	defer close(done)
+
+	command := gocmd.NewCmdOptions(shell.BufferAndStreamOutput, cmd, args...)
+	shell.Start(command, done)
+
+	return <-done
 }
 
 // BinaryAvailable checks if telepresence binary is available on the path.

--- a/pkg/telepresence/wrapper_test.go
+++ b/pkg/telepresence/wrapper_test.go
@@ -48,7 +48,7 @@ var _ = Describe("telepresence commands wrapper", func() {
 		It("should retrieve version from TELEPRESENCE_VERSION env variable when defined", func() {
 			// given
 			tmpPath := NewTmpPath()
-			tmpPath.SetPath(path.Dir(shell.TpVersionFlagBin))
+			tmpPath.SetPath(path.Dir(shell.Tp1VersionFlagBin))
 			restoreEnvVars := TemporaryEnvVars("TELEPRESENCE_VERSION", "0.123")
 
 			defer restoreEnvVars()
@@ -78,7 +78,7 @@ var _ = Describe("telepresence commands wrapper", func() {
 
 		It("should retrieve version from telepresence binary", func() {
 			tmpPath := NewTmpPath()
-			tmpPath.SetPath(path.Dir(shell.TpFixedVersionBin))
+			tmpPath.SetPath(path.Dir(shell.Tp1FixedVersionBin))
 			defer tmpPath.Restore()
 
 			// when

--- a/pkg/telepresence/wrapper_test.go
+++ b/pkg/telepresence/wrapper_test.go
@@ -47,8 +47,12 @@ var _ = Describe("telepresence commands wrapper", func() {
 
 		It("should retrieve version from TELEPRESENCE_VERSION env variable when defined", func() {
 			// given
+			tmpPath := NewTmpPath()
+			tmpPath.SetPath(path.Dir(shell.TpVersionFlagBin))
 			restoreEnvVars := TemporaryEnvVars("TELEPRESENCE_VERSION", "0.123")
+
 			defer restoreEnvVars()
+			defer tmpPath.Restore()
 
 			// when
 			version, err := telepresence.GetVersion()
@@ -58,9 +62,23 @@ var _ = Describe("telepresence commands wrapper", func() {
 			Expect(version).To(Equal("0.123"))
 		})
 
+		It("should warn about unsupported version of telepresence", func() {
+			// given
+			tmpPath := NewTmpPath()
+			tmpPath.SetPath(path.Dir(shell.Tp2VersionFlagBin))
+			defer tmpPath.Restore()
+
+			// when
+			_, err := telepresence.GetVersion()
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("you are using unsupported version of telepresence"))
+		})
+
 		It("should retrieve version from telepresence binary", func() {
 			tmpPath := NewTmpPath()
-			tmpPath.SetPath(path.Dir(shell.TpVersionBin))
+			tmpPath.SetPath(path.Dir(shell.TpFixedVersionBin))
 			defer tmpPath.Restore()
 
 			// when

--- a/test/shell/test_setup.go
+++ b/test/shell/test_setup.go
@@ -11,10 +11,12 @@ import (
 )
 
 var (
-	MvnBin       string
-	TpSleepBin   string
-	TpVersionBin string
-	JavaBin      string
+	MvnBin            string
+	TpSleepBin        string
+	TpFixedVersionBin string
+	TpVersionFlagBin  string
+	Tp2VersionFlagBin string
+	JavaBin           string
 )
 
 func StubShellCommands() {
@@ -23,9 +25,11 @@ func StubShellCommands() {
 		"-ldflags", "-w -X main.SleepMs=1024")
 	_ = buildBinary("github.com/maistra/istio-workspace/test/echo", "ike",
 		"-ldflags", "-w -X main.SleepMs=50")
-	TpVersionBin = buildBinary("github.com/maistra/istio-workspace/test/echo", "telepresence", "-ldflags", "-w -X main.Echo=0.234")
-	TpSleepBin = buildBinary("github.com/maistra/istio-workspace/test/echo",
-		"telepresence", "-ldflags", "-w -X main.SleepMs=256")
+	TpFixedVersionBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1 -X main.Return=0.234")
+	TpVersionFlagBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1")
+	Tp2VersionFlagBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v2")
+	TpSleepBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub",
+		"telepresence", "-ldflags", "-w -X main.SleepMs=256 -X main.Version=v1")
 }
 
 func ExecuteCommand(outputChan chan string, execute func() (string, error)) func() {
@@ -39,7 +43,7 @@ func ExecuteCommand(outputChan chan string, execute func() (string, error)) func
 
 var appFs = afero.NewOsFs()
 
-func buildBinary(packagePath, name string, flags ...string) string { //nolint:unparam //reason at this moment we always pass the same value for packagePath
+func buildBinary(packagePath, name string, flags ...string) string {
 	binPath, err := gexec.Build(packagePath, flags...)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/test/shell/test_setup.go
+++ b/test/shell/test_setup.go
@@ -11,24 +11,24 @@ import (
 )
 
 var (
-	MvnBin            string
-	TpSleepBin        string
-	TpFixedVersionBin string
-	TpVersionFlagBin  string
-	Tp2VersionFlagBin string
-	JavaBin           string
+	MvnBin             string
+	Tp1WithSleepBin    string
+	Tp1FixedVersionBin string
+	Tp1VersionFlagBin  string
+	Tp2VersionFlagBin  string
+	JavaBin            string
 )
 
 func StubShellCommands() {
-	MvnBin = buildBinary("github.com/maistra/istio-workspace/test/echo", "mvn")
-	JavaBin = buildBinary("github.com/maistra/istio-workspace/test/echo", "java",
+	MvnBin = BuildBinary("github.com/maistra/istio-workspace/test/echo", "mvn")
+	JavaBin = BuildBinary("github.com/maistra/istio-workspace/test/echo", "java",
 		"-ldflags", "-w -X main.SleepMs=1024")
-	_ = buildBinary("github.com/maistra/istio-workspace/test/echo", "ike",
+	_ = BuildBinary("github.com/maistra/istio-workspace/test/echo", "ike",
 		"-ldflags", "-w -X main.SleepMs=50")
-	TpFixedVersionBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1 -X main.Return=0.234")
-	TpVersionFlagBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1")
-	Tp2VersionFlagBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v2")
-	TpSleepBin = buildBinary("github.com/maistra/istio-workspace/test/tp_stub",
+	Tp1FixedVersionBin = BuildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1 -X main.Return=0.234")
+	Tp1VersionFlagBin = BuildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v1")
+	Tp2VersionFlagBin = BuildBinary("github.com/maistra/istio-workspace/test/tp_stub", "telepresence", "-ldflags", "-w -X main.Version=v2")
+	Tp1WithSleepBin = BuildBinary("github.com/maistra/istio-workspace/test/tp_stub",
 		"telepresence", "-ldflags", "-w -X main.SleepMs=256 -X main.Version=v1")
 }
 
@@ -43,7 +43,7 @@ func ExecuteCommand(outputChan chan string, execute func() (string, error)) func
 
 var appFs = afero.NewOsFs()
 
-func buildBinary(packagePath, name string, flags ...string) string {
+func BuildBinary(packagePath, name string, flags ...string) string {
 	binPath, err := gexec.Build(packagePath, flags...)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/test/tp_stub/main.go
+++ b/test/tp_stub/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// SleepMs indicates for how long the program should sleep before he gets terminated
+// The value is in milliseconds.
+var SleepMs string
+
+// Return if specified as build flag will be the output of the command.
+var Return string
+
+// Version indicates which version of binary should be used.
+var Version string
+
+const versionFlag = "version"
+
+func main() {
+	if Version == "v2" {
+		if os.Args[1] == versionFlag {
+			os.Exit(0)
+		}
+	} else {
+		if os.Args[1] == versionFlag {
+			os.Exit(123)
+		}
+	}
+
+	if Return != "" {
+		fmt.Println(Return)
+	} else {
+		fmt.Println(os.Args[1:])
+	}
+
+	if SleepMs != "" {
+		sleep()
+	}
+}
+
+func sleep() {
+	sleepInt, err := strconv.ParseInt(SleepMs, 0, 64)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(-1)
+	}
+	fmt.Println("Sleep for: " + SleepMs + "ms")
+	time.Sleep(time.Duration(sleepInt) * time.Millisecond)
+}


### PR DESCRIPTION
#### Short description of what this resolves:

If a newer version of Telepresence is the first one available on path `ike` fails with a misleading error claiming the binary is in the path. It should instead error with information that user should install `v1` instead.

#### Changes proposed in this pull request:

- reworks `telepresence` binary version check
- adjusts tests

Fixes #957
