### PR TITLE
fix(gh): updates golangci-lint gh action

### DIFF
--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -30,7 +30,7 @@ jobs:
           make lint-prepare
         shell: bash
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.41
           working-directory: go/src/github.com/${{ env.REPOSITORY }}


### PR DESCRIPTION
#### Short description of what this resolves:

Seemingly previous version started failing on `master` build. This PR updates related GH Action. Tested locally with [`act`](https://github.com/nektos/act).

#### Changes proposed in this pull request:

- bumps go setup to v3
- bumps golangci action to v3
