### PR TITLE
fix(circleci): upgrades resource class for docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
   build:
     docker:
       - image: *golang-img
+    resource_class: large
     environment:
       BUILD_CACHE_FOLDER: ".circleci/cache"
     steps:


### PR DESCRIPTION
The new resource class is set to large (4 vCPUs and 15GB of RAM).

Default one (medium) seems to `sigkill` compilation phase quite frequently as of late.