### PR TITLE
build(deps): bumps ubi8 from 8.5 to 8.6

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ADD ike /usr/local/bin/ike

--- a/build/ContainerfileTest
+++ b/build/ContainerfileTest
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ADD test-service /usr/local/bin/test-service
 ENTRYPOINT ["test-service"]

--- a/build/ContainerfileTestPrepared
+++ b/build/ContainerfileTestPrepared
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 EXPOSE 9080
 


### PR DESCRIPTION
#### Short description of what this resolves:

Updating our base ubi8 image from 8.5 to 8.6. This resolves all CVEs found in Quay.


#### Changes proposed in this pull request:

- bumps ubi8 images
