### PR TITLE
chore(circleci): updates olm version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
 
             make deps tools
 
-            ./bin/operator-sdk olm install --version v0.18.3
+            ./bin/operator-sdk olm install --version v0.21.2
 
             make container-image container-push
             make container-image-test container-push-test


### PR DESCRIPTION
#### Short description of what this resolves:

Pins olm version to latest v0.21.2 for end-to-end tests.

