### PR TITLE
fix(build): use go install to fetch controller-gen bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
#### Short description of what this resolves:

`make tools` does not manage to install `controller-gen` on go1.18 as `go get` for installing binaries is deprecated. 

https://go.dev/doc/go-get-install-deprecation

#### Changes proposed in this pull request:

Switch to `go install`
