### PR TITLE
feat(build): adds support for ARM64 chips

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,10 @@ builds:
   goarch:
     - 386
     - amd64
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: 386
   ldflags:
     ## FIXME Overlaps with what is defined in Makefile - we should find a away of having it defined only once
     - -s -w -X {{.Env.PACKAGE_NAME}}/version.Release={{.Env.RELEASE}} -X {{.Env.PACKAGE_NAME}}/version.Version=v{{.Version}} -X {{.Env.PACKAGE_NAME}}/version.Commit={{.ShortCommit}} -X {{.Env.PACKAGE_NAME}}/version.BuildTime={{.Date}}


### PR DESCRIPTION
#### Short description of what this resolves:

Adds configuration for `goreleaser` to build `arm64` binaries so that `ike` can be used on e.g. Mac M1 chips.

#### Changes proposed in this pull request:

- `goreleaser` arm64 config


Fixes #1032
