### PR TITLE
chore(e2e): replaces hello-world container with 2MB image

### DIFF
--- a/e2e/bash_completion_test.go
+++ b/e2e/bash_completion_test.go
@@ -43,17 +43,17 @@ var _ = Describe("Bash Completion Tests", func() {
 			Expect(nsCompletion).To(ContainElement(CompletionProject2))
 		})
 
-		It("should show available deployments for current namespace (datawire-project)", func() {
+		It("should show available deployments for current namespace", func() {
 			if !RunsOnOpenshift {
 				Skip("This is OpenShift specific test which assumes current namespace/project is set and oc available. " +
 					"Completion for specified namespace is covered in the follow-up test.")
 			}
 			<-shell.Execute("oc project " + CompletionProject1).Done()
-			Expect(completionFor("ike develop -d ")).To(ConsistOf("my-datawire-deployment"))
+			Expect(completionFor("ike develop -d ")).To(ConsistOf("my-deployment"))
 		})
 
-		It("should show available deployments for selected namespace (datawire-other-project)", func() {
-			Expect(completionFor("ike develop -n " + CompletionProject2 + " -d ")).To(ConsistOf("other-1-datawire-deployment", "other-2-datawire-deployment"))
+		It("should show available deployments for selected namespace (other-project)", func() {
+			Expect(completionFor("ike develop -n " + CompletionProject2 + " -d ")).To(ConsistOf("other-1-deployment", "other-2-deployment"))
 		})
 	})
 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -92,9 +92,9 @@ func createProjectsForCompletionTests() {
 		NewProjectCmd(CompletionProject1),
 		NewProjectCmd(CompletionProject2),
 	)
-	testshell.ExecuteAll(DeployHelloWorldCmd("my-datawire-deployment", CompletionProject1)...)
-	testshell.ExecuteAll(DeployHelloWorldCmd("other-1-datawire-deployment", CompletionProject2)...)
-	testshell.ExecuteAll(DeployHelloWorldCmd("other-2-datawire-deployment", CompletionProject2)...)
+	testshell.ExecuteAll(DeployNoopLoopCmd("my-deployment", CompletionProject1)...)
+	testshell.ExecuteAll(DeployNoopLoopCmd("other-1-deployment", CompletionProject2)...)
+	testshell.ExecuteAll(DeployNoopLoopCmd("other-2-deployment", CompletionProject2)...)
 }
 
 func deleteProjectsForCompletionTests() {

--- a/e2e/infra/deployment.go
+++ b/e2e/infra/deployment.go
@@ -35,15 +35,15 @@ func DeleteProjectCmd(name string) string {
 	return "kubectl delete namespace " + name + " --wait=false"
 }
 
-func DeployHelloWorldCmd(name, ns string) []string {
+func DeployNoopLoopCmd(name, ns string) []string {
 	return []string{
 		"kubectl run " + name +
-			" --image=datawire/hello-world" +
+			" --image=crccheck/hello-world" +
 			" --port 8000" +
 			" --expose" +
 			" --namespace " + ns,
 		"kubectl create deployment " + name +
-			" --image=datawire/hello-world" +
+			" --image=crccheck/hello-world" +
 			" --namespace " + ns,
 	}
 }

--- a/pkg/k8s/deployment_test.go
+++ b/pkg/k8s/deployment_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 							Spec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
-										Image: "datawire/hello-world:latest",
+										Image: "crccheck/hello-world:latest",
 										Env:   []v1.EnvVar{},
 										LivenessProbe: &v1.Probe{
 											ProbeHandler: v1.ProbeHandler{
@@ -310,7 +310,7 @@ var _ = Describe("Operations for k8s Deployment kind", func() {
 							Spec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
-										Image: "datawire/hello-world:latest",
+										Image: "crccheck/hello-world:latest",
 										Env:   []v1.EnvVar{},
 									},
 								},

--- a/pkg/openshift/deploymentconfig_test.go
+++ b/pkg/openshift/deploymentconfig_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 							Spec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
-										Image: "datawire/hello-world:latest",
+										Image: "crccheck/hello-world:latest",
 										Env:   []v1.EnvVar{},
 										LivenessProbe: &v1.Probe{
 											ProbeHandler: v1.ProbeHandler{
@@ -324,7 +324,7 @@ var _ = Describe("Operations for openshift DeploymentConfig kind", func() {
 							Spec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
-										Image: "datawire/hello-world:latest",
+										Image: "crccheck/hello-world:latest",
 										Env:   []v1.EnvVar{},
 									},
 								},


### PR DESCRIPTION
#### Short description of what this resolves:

The previously used `datawire/hello-world` testing image is 102MB. It's a bit too large for the purpose it serves.

#### Changes proposed in this pull request:

- new, slim image for testing autocompletion. 2MB in size


