### PR TITLE
fix(watch): correctly excludes paths starting with 

### DIFF
--- a/pkg/cmd/develop/cmd.go
+++ b/pkg/cmd/develop/cmd.go
@@ -103,7 +103,7 @@ func NewCmd() *cobra.Command {
 	developCmd.Flags().Bool(execute.NoBuildFlagName, false, "always skips build")
 	developCmd.Flags().Bool("watch", false, "enables watch")
 	developCmd.Flags().StringSliceP("watch-include", "w", []string{"."}, "list of directories to watch (relative to the one from which ike has been started)")
-	developCmd.Flags().StringSlice("watch-exclude", execute.DefaultExclusions, fmt.Sprintf("list of patterns to exclude (always excludes %v)", execute.DefaultExclusions))
+	developCmd.Flags().StringSlice("watch-exclude", []string{}, fmt.Sprintf("list of patterns to exclude (always excludes %v)", execute.DefaultExclusions))
 	developCmd.Flags().Int64("watch-interval", 500, "watch interval (in ms)")
 	if err := developCmd.Flags().MarkHidden("watch-interval"); err != nil {
 		logger().Error(err, "failed while trying to hide a flag")

--- a/pkg/cmd/execute/cmd.go
+++ b/pkg/cmd/execute/cmd.go
@@ -56,8 +56,9 @@ func NewCmd() *cobra.Command {
 	executeCmd.Flags().StringP(RunFlagName, "r", "", "command to run your application")
 	// Watch config
 	executeCmd.Flags().Bool("watch", false, "enables watch")
-	executeCmd.Flags().StringSliceP("dir", "w", []string{"."}, "list of directories to watch")
-	executeCmd.Flags().StringSlice("exclude", DefaultExclusions, "list of patterns to exclude (defaults to telepresence.log which is always excluded)")
+	executeCmd.Flags().StringSlice("dir", []string{"."}, "list of directories to watch (defaults to current directory)")
+	// Empty slice as we are always adding DefaultExclusions while constructing the watch
+	executeCmd.Flags().StringSlice("exclude", []string{}, fmt.Sprintf("list of patterns to exclude (always excludes %v)", DefaultExclusions))
 	executeCmd.Flags().Int64("interval", 500, "watch interval (in ms)")
 	if err := executeCmd.Flags().MarkHidden("interval"); err != nil {
 		logger().Error(err, "failed while trying to hide a flag")

--- a/pkg/telepresence/wrapper.go
+++ b/pkg/telepresence/wrapper.go
@@ -119,7 +119,7 @@ func createWrapperExecutionCmd(cmd *cobra.Command) ([]string, error) {
 func stringSliceToCSV(flags *pflag.FlagSet, name string) string {
 	slice, _ := flags.GetStringSlice(name)
 
-	return fmt.Sprintf(`"%s"`, strings.Join(slice, ","))
+	return strings.Join(slice, ",")
 }
 
 func executeCmd(cmd string, args ...string) gocmd.Status {

--- a/pkg/watch/watch_builder.go
+++ b/pkg/watch/watch_builder.go
@@ -1,7 +1,9 @@
 package watch
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"emperror.dev/errors"
@@ -53,19 +55,23 @@ func (wb *Builder) OnPaths(paths ...string) (watch *Watch, err error) {
 		if err != nil {
 			return nil, errors.WrapWithDetails(err, "failed checking path", "path", path)
 		}
-
-		if !dir.IsDir() {
-			if e := wb.w.addPath(path); e != nil {
-				return nil, e
-			}
-		} else {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return nil, errors.WrapWithDetails(err, "failed determining absolute path", "path", path)
+		}
+		if dir.IsDir() {
 			if e := wb.w.addExclusions(wb.exclusions); e != nil {
 				return nil, e
 			}
-			if e := wb.w.addGitIgnore(path); e != nil {
+			if e := wb.w.addGitIgnore(absPath); e != nil {
 				return nil, e
 			}
-			if e := wb.w.addRecursiveWatch(path); e != nil {
+			if e := wb.w.addRecursiveWatch(absPath); e != nil {
+				return nil, e
+			}
+		} else {
+			e := wb.w.addPath(absPath)
+			if e != nil {
 				return nil, e
 			}
 		}

--- a/pkg/watch/watch_builder.go
+++ b/pkg/watch/watch_builder.go
@@ -1,7 +1,6 @@
 package watch
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -2,7 +2,9 @@ package watch_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 
 	"emperror.dev/errors"
 	"github.com/fsnotify/fsnotify"
@@ -13,7 +15,7 @@ import (
 	. "github.com/maistra/istio-workspace/test"
 )
 
-var _ = Describe("File changes watch", func() {
+var _ = Describe("Watching for file changes", func() {
 
 	tmpFs := NewTmpFileSystem(GinkgoT())
 
@@ -21,169 +23,201 @@ var _ = Describe("File changes watch", func() {
 		tmpFs.Cleanup()
 	})
 
-	It("should recognize file change", func() {
-		// given
-		done := make(chan struct{})
-		config := tmpFs.File("config.yaml", "content")
+	Context("in the current directory", func() {
 
-		watcher, e := watch.CreateWatch(1).
-			WithHandlers(expectFileChange(config.Name(), done)).
-			OnPaths(config.Name())
-		Expect(e).ToNot(HaveOccurred())
+		It("should react on file change for the file starting with '.'", func() {
+			// given
+			done := make(chan struct{})
 
-		defer watcher.Close()
+			_, testFile, _, _ := runtime.Caller(0)
+			fullPath := filepath.Dir(testFile) + string(os.PathSeparator) + ".run.exe" // Adding .exe as it's gitignored for the repo
+			fileToWatch := tmpFs.File(fullPath, "content")
 
-		// when
-		watcher.Start()
-		_, _ = config.WriteString(" modified!")
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(expectChangesOf(fileToWatch.Name(), done)).
+				OnPaths(".") // current directory
+			Expect(e).ToNot(HaveOccurred())
 
-		// then
-		Eventually(done).Should(BeClosed())
+			defer watcher.Close()
+
+			// when
+			watcher.Start()
+			_, _ = fileToWatch.WriteString(" modified!")
+
+			// then
+			Eventually(done).Should(BeClosed())
+		})
 	})
 
-	It("should recognize file change in watched directory", func() {
-		// given
-		done := make(chan struct{})
-		tmpDir := tmpFs.Dir("watch_yaml_txt")
-		_ = tmpFs.File(tmpDir+"/config.yaml", "content")
-		text := tmpFs.File(tmpDir+"/text.txt", "text text text")
+	Context("in the arbitrary directory", func() {
 
-		watcher, e := watch.CreateWatch(1).
-			WithHandlers(expectFileChange(text.Name(), done)).
-			OnPaths(tmpDir)
-		Expect(e).ToNot(HaveOccurred())
+		It("should react on file change", func() {
+			// given
+			done := make(chan struct{})
+			config := tmpFs.File("config.yaml", "content")
 
-		defer watcher.Close()
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(expectChangesOf(config.Name(), done)).
+				OnPaths(config.Name())
+			Expect(e).ToNot(HaveOccurred())
 
-		// when
-		watcher.Start()
-		_, _ = text.WriteString(" modified!")
+			defer watcher.Close()
 
-		// then
-		Eventually(done).Should(BeClosed())
-	})
+			// when
+			watcher.Start()
+			_, _ = config.WriteString(" modified!")
 
-	It("should recognize file change in sub-directory (recursive watch)", func() {
-		// given
-		done := make(chan struct{})
-		tmpDir := tmpFs.Dir("watch_yaml_txt")
-		_ = tmpFs.File(tmpDir+"/config.yaml", "content")
-		text := tmpFs.File(tmpDir+"/text.txt", "text text text")
+			// then
+			Eventually(done).Should(BeClosed())
+		})
 
-		watcher, e := watch.CreateWatch(1).
-			WithHandlers(expectFileChange(text.Name(), done)).
-			OnPaths(tmpDir)
-		Expect(e).ToNot(HaveOccurred())
+		It("should react on file change in watched directory", func() {
+			// given
+			done := make(chan struct{})
+			tmpDir := tmpFs.Dir("watch_yaml_txt")
+			_ = tmpFs.File(tmpDir+"/config.yaml", "content")
+			text := tmpFs.File(tmpDir+"/text.txt", "text text text")
 
-		defer watcher.Close()
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(expectChangesOf(text.Name(), done)).
+				OnPaths(tmpDir)
+			Expect(e).ToNot(HaveOccurred())
 
-		// when
-		watcher.Start()
-		_, _ = text.WriteString(" modified!")
+			defer watcher.Close()
 
-		// then
-		Eventually(done).Should(BeClosed())
-	})
+			// when
+			watcher.Start()
+			_, _ = text.WriteString(" modified!")
 
-	It("should not recognize file change if matches file extension exclusion", func() {
-		// given
-		done := make(chan struct{})
-		tmpDir := tmpFs.Dir("watch_yaml_txt")
-		config := tmpFs.File(tmpDir+"/config.yaml", "content")
-		text := tmpFs.File(tmpDir+"/text.txt", "text text text")
+			// then
+			Eventually(done).Should(BeClosed())
+		})
 
-		watcher, e := watch.CreateWatch(1).
-			WithHandlers(expectFileChange(text.Name(), done), notExpectFileChange(config.Name())).
-			Excluding("*.yaml").
-			OnPaths(tmpDir)
-		Expect(e).ToNot(HaveOccurred())
+		It("should react on file change in sub-directory (recursive watch)", func() {
+			// given
+			done := make(chan struct{})
+			tmpDir := tmpFs.Dir("watch_yaml_txt")
+			_ = tmpFs.File(tmpDir+"/config.yaml", "content")
+			text := tmpFs.File(tmpDir+"/text.txt", "text text text")
 
-		defer watcher.Close()
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(expectChangesOf(text.Name(), done)).
+				OnPaths(tmpDir)
+			Expect(e).ToNot(HaveOccurred())
 
-		// when
-		watcher.Start()
-		_, _ = config.WriteString(" should not be watched")
-		_, _ = text.WriteString(" modified!")
+			defer watcher.Close()
 
-		// then
-		Eventually(done).Should(BeClosed())
-	})
+			// when
+			watcher.Start()
+			_, _ = text.WriteString(" modified!")
 
-	It("should not recognize file change in excluded directory", func() {
-		// given
-		done := make(chan struct{})
-		skipTmpDir := tmpFs.Dir("skip_watch")
-		config := tmpFs.File(skipTmpDir+"/config.yaml", "content")
-		watchTmpDir := tmpFs.Dir("watch")
-		code := tmpFs.File(watchTmpDir+"/main.go", "package main")
+			// then
+			Eventually(done).Should(BeClosed())
+		})
 
-		watcher, e := watch.CreateWatch(1).
-			WithHandlers(notExpectFileChange(config.Name()), expectFileChange(code.Name(), done)).
-			Excluding("skip_watch/**").
-			OnPaths(filepath.Dir(skipTmpDir), filepath.Dir(watchTmpDir))
-		Expect(e).ToNot(HaveOccurred())
+		It("should not react on file change if matches file extension exclusion", func() {
+			// given
+			done := make(chan struct{})
+			tmpDir := tmpFs.Dir("watch_yaml_txt")
+			config := tmpFs.File(tmpDir+"/config.yaml", "content")
+			text := tmpFs.File(tmpDir+"/text.txt", "text text text")
 
-		defer watcher.Close()
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(expectChangesOf(text.Name(), done), ignoreChangesOf(config.Name())).
+				Excluding("*.yaml").
+				OnPaths(tmpDir)
+			Expect(e).ToNot(HaveOccurred())
 
-		// when
-		watcher.Start()
-		_, _ = config.WriteString(" should not be watched")
-		_, _ = code.WriteString("\n // Bla!")
+			defer watcher.Close()
 
-		// then
-		Eventually(done).Should(BeClosed())
-	})
+			// when
+			watcher.Start()
+			_, _ = config.WriteString(" should not be watched")
+			_, _ = text.WriteString(" modified!")
 
-	It("should not recognize file change if it's git-ignored", func() {
-		// given
-		done := make(chan struct{})
+			// then
+			Eventually(done).Should(BeClosed())
+		})
 
-		watchTmpDir := tmpFs.Dir("watch")
-		config := tmpFs.File(watchTmpDir+"/.idea/config.toml", "content")
-		test := tmpFs.File(watchTmpDir+"/.idea/test.yaml", "content")
-		nestedFile := tmpFs.File(watchTmpDir+"/src/main/org/acme/Main.java", "package org.acme")
-		gitIgnore := tmpFs.File(watchTmpDir+"/.gitignore", `
+		It("should not react on file change in excluded directory", func() {
+			// given
+			done := make(chan struct{})
+			skipTmpDir := tmpFs.Dir("skip_watch")
+			config := tmpFs.File(skipTmpDir+"/config.yaml", "content")
+			watchTmpDir := tmpFs.Dir("watch")
+			code := tmpFs.File(watchTmpDir+"/main.go", "package main")
+
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(ignoreChangesOf(config.Name()), expectChangesOf(code.Name(), done)).
+				Excluding("skip_watch/**").
+				OnPaths(filepath.Dir(skipTmpDir), filepath.Dir(watchTmpDir))
+			Expect(e).ToNot(HaveOccurred())
+
+			defer watcher.Close()
+
+			// when
+			watcher.Start()
+			_, _ = config.WriteString(" should not be watched")
+			_, _ = code.WriteString("\n // Bla!")
+
+			// then
+			Eventually(done).Should(BeClosed(), "Changes in the files has not been recognized!")
+		})
+
+		It("should not react on file change if it's git-ignored", func() {
+			// given
+			done := make(chan struct{})
+
+			watchTmpDir := tmpFs.Dir("watch")
+			config := tmpFs.File(watchTmpDir+"/.idea/config.toml", "content")
+			test := tmpFs.File(watchTmpDir+"/.idea/test.yaml", "content")
+			nestedFile := tmpFs.File(watchTmpDir+"/src/main/org/acme/Main.java", "package org.acme")
+			gitIgnore := tmpFs.File(watchTmpDir+"/.gitignore", `
 *.yaml
-src/main/**/*.java
+**/src/main/**/*.java
 .idea/
 `)
-		code := tmpFs.File(watchTmpDir+"/main.go", "package main")
+			code := tmpFs.File(watchTmpDir+"/main.go", "package main")
 
-		defer func() {
-			if err := config.Close(); err != nil {
-				fmt.Println(err)
-			}
-			if err := test.Close(); err != nil {
-				fmt.Println(err)
-			}
-			if err := nestedFile.Close(); err != nil {
-				fmt.Println(err)
-			}
-			if err := gitIgnore.Close(); err != nil {
-				fmt.Println(err)
-			}
-		}()
+			defer func() {
+				if err := config.Close(); err != nil {
+					fmt.Println(err)
+				}
+				if err := test.Close(); err != nil {
+					fmt.Println(err)
+				}
+				if err := nestedFile.Close(); err != nil {
+					fmt.Println(err)
+				}
+				if err := gitIgnore.Close(); err != nil {
+					fmt.Println(err)
+				}
+			}()
 
-		watcher, e := watch.CreateWatch(1).
-			WithHandlers(notExpectFileChange(config.Name(), test.Name(), nestedFile.Name()), expectFileChange(code.Name(), done)).
-			OnPaths(watchTmpDir)
-		Expect(e).ToNot(HaveOccurred())
+			watcher, e := watch.CreateWatch(1).
+				WithHandlers(ignoreChangesOf(config.Name(), test.Name(), nestedFile.Name()),
+					expectChangesOf(code.Name(), done)).
+				OnPaths(watchTmpDir)
+			Expect(e).ToNot(HaveOccurred())
 
-		defer watcher.Close()
+			defer watcher.Close()
 
-		// when
-		watcher.Start()
-		_, _ = test.WriteString(" should not be watched")
-		_, _ = config.WriteString(" should not be watched")
-		_, _ = nestedFile.WriteString("\n// TODO implement me but now ignore")
-		_, _ = code.WriteString("\n // Bla! Should trigger watch reaction")
+			// when
+			watcher.Start()
+			_, _ = test.WriteString(" should not be watched")
+			_, _ = config.WriteString(" should not be watched")
+			_, _ = nestedFile.WriteString("\n// TODO implement me but now ignore")
+			_, _ = code.WriteString("\n // Bla! Should trigger watch reaction")
 
-		// then
-		Eventually(done).Should(BeClosed())
+			// then
+			Eventually(done).Should(BeClosed())
+		})
 	})
 })
 
-func expectFileChange(fileName string, done chan<- struct{}) watch.Handler {
+// test doubles
+
+func expectChangesOf(fileName string, done chan<- struct{}) watch.Handler {
 	return func(events []fsnotify.Event) error {
 		defer GinkgoRecover()
 		Expect(events[0].Name).To(Equal(fileName))
@@ -193,7 +227,7 @@ func expectFileChange(fileName string, done chan<- struct{}) watch.Handler {
 	}
 }
 
-func notExpectFileChange(fileNames ...string) watch.Handler {
+func ignoreChangesOf(fileNames ...string) watch.Handler {
 	return func(events []fsnotify.Event) error {
 		defer GinkgoRecover()
 		for _, event := range events {


### PR DESCRIPTION
- fix(tp): do not wrap slice in a quote as it will be doubled
- fix(watch): always resolve to absolute path
- fix(flag): exclusion should be empty by default
- chore: removes unneeded import
