### PR TITLE
chore: introduces hook package to handle shutdowns in one place

### DIFF
--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/cmd/execute"
 	"github.com/maistra/istio-workspace/pkg/cmd/serve"
 	"github.com/maistra/istio-workspace/pkg/cmd/version"
+	"github.com/maistra/istio-workspace/pkg/hook"
 	"github.com/maistra/istio-workspace/pkg/log"
 )
 
@@ -46,6 +47,7 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Log.Error(err, "failed executing command")
+		hook.Close()
 		os.Exit(23)
 	}
 }

--- a/e2e/error_path_test.go
+++ b/e2e/error_path_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Smoke End To End Tests - Faulty scenarios", func() {
 		It("should return non 0 on failed command", func() {
 			completion := testshell.ExecuteInDir(".", "bash", "-c", "ike missing-command")
 			<-completion.Done()
-			Expect(completion.Status().Exit).Should(Equal(23))
+			Expect(completion.Status().Exit).Should(Not(BeZero()))
 		})
 
 	})

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -500,7 +500,7 @@ func Stop(ike *cmd.Cmd) {
 
 func FailOnCmdError(command *cmd.Cmd, t test.TestReporter) {
 	<-command.Done()
-	if command.Status().Exit != 0 {
+	if command.Status().Exit != 0 && command.Status().Exit != 130 { // do not panic on SIGINT
 		t.Errorf("failed executing %s with code %d", command.Name, command.Status().Exit)
 	}
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/maistra/istio-workspace/pkg/cmd/config"
 	"github.com/maistra/istio-workspace/pkg/cmd/format"
 	"github.com/maistra/istio-workspace/pkg/cmd/version"
+	"github.com/maistra/istio-workspace/pkg/hook"
 	"github.com/maistra/istio-workspace/pkg/log"
 	v "github.com/maistra/istio-workspace/version"
 )
@@ -36,12 +37,16 @@ func NewCmd() *cobra.Command {
 			"For detailed documentation please visit https://istio-workspace-docs.netlify.com/\n\n",
 		BashCompletionFunction: completion.BashCompletionFunc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			hook.Listen()
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				if flag.Changed && strings.Join(flag.Annotations["silent"], "") == "true" {
 					log.SetLogger(log.CreateOperatorAwareLoggerWithLevel("root", zapcore.ErrorLevel))
 				}
 			})
 
+			return errors.Wrap(config.SetupConfigSources(loadConfigFileName(cmd)), "failed setting config sources")
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
 			if v.Released() {
 				go func() {
 					latestRelease, _ := version.LatestRelease()
@@ -53,8 +58,6 @@ func NewCmd() *cobra.Command {
 					}
 				}()
 			}
-
-			return errors.Wrap(config.SetupConfigSources(loadConfigFileName(cmd)), "failed setting config sources")
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shouldPrintVersion, _ := cmd.Flags().GetBool("version")
@@ -66,7 +69,9 @@ func NewCmd() *cobra.Command {
 
 			return nil
 		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			hook.Close()
+
 			defer func() {
 				close(releaseInfo)
 			}()
@@ -81,6 +86,9 @@ func NewCmd() *cobra.Command {
 			}
 
 			return nil
+		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			hook.Close()
 		},
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -70,8 +70,6 @@ func NewCmd() *cobra.Command {
 			return nil
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			hook.Close()
-
 			defer func() {
 				close(releaseInfo)
 			}()

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -45,9 +45,7 @@ func Listen() {
 			signal.Stop(hooks.done)
 		}()
 
-		o := <-hooks.done
-
-		if o == nil {
+		if _, ok := <-hooks.done; !ok {
 			// Channel has been closed by calling Close(). Do nothing. Normal termination.
 			return
 		}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -1,0 +1,70 @@
+package hook
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+type Handler func() error
+
+type hookHandler struct {
+	sync.Mutex
+	f    []Handler
+	done chan os.Signal
+}
+
+var hooks hookHandler
+
+// Register adds Handlers to be invoked when the command is terminated.
+func Register(handlers ...Handler) {
+	hooks.Lock()
+	defer hooks.Unlock()
+	hooks.f = append(hooks.f, handlers...)
+}
+
+// Reset re-instantiate underlying hooks.
+func Reset() {
+	hooks.Lock()
+	defer hooks.Unlock()
+	hooks.f = []Handler{}
+	hooks.done = make(chan os.Signal, 1)
+}
+
+// Listen starts go routine in the background waiting for owning process to be terminated, and when it happens
+// it invokes defined Handlers sequentially. Every invocation will reset hooks.
+func Listen() {
+	Reset()
+
+	signal.Notify(hooks.done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		defer func() {
+			signal.Stop(hooks.done)
+		}()
+
+		o := <-hooks.done
+
+		if o == nil {
+			// Channel has been closed by calling Close(). Do nothing. Normal termination.
+			return
+		}
+
+		for _, hook := range hooks.f {
+			if err := hook(); err != nil {
+				fmt.Printf("failed handling shutdown hook: %s", err.Error())
+			}
+		}
+
+		os.Exit(130) // INT exit code
+	}()
+}
+
+// Close closes underlying channel.
+func Close() {
+	hooks.Lock()
+	close(hooks.done)
+	hooks.Unlock()
+}

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/maistra/istio-workspace/pkg/hook"
 )
 
 // Cmd is an alias for cobra.Command to build fluent API for building commands in tests.
@@ -12,6 +14,8 @@ type Cmd cobra.Command
 
 // Run will run actual command.
 func Run(command *cobra.Command) *Cmd {
+	hook.Reset()
+
 	return (*Cmd)(command)
 }
 
@@ -43,6 +47,11 @@ func executeCommandC(cmd *cobra.Command, args ...string) (c *cobra.Command, outp
 	cmd.SetErr(buf)
 	cmd.Root().SetArgs(append(strings.Split(cmd.CommandPath(), " ")[1:], args...))
 	c, err = cmd.ExecuteC()
+
+	if err != nil {
+		// It is called as well in main.go on error. We need to close the channel to avoid leaking goroutine.
+		hook.Close()
+	}
 
 	return c, buf.String(), err
 }

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -49,7 +49,7 @@ func executeCommandC(cmd *cobra.Command, args ...string) (c *cobra.Command, outp
 	c, err = cmd.ExecuteC()
 
 	if err != nil {
-		// It is called as well in main.go on error. We need to close the channel to avoid leaking goroutine.
+		// It is called as well in main.go on error. We need to close the channel to avoid leaking goroutine in tests.
 		hook.Close()
 	}
 


### PR DESCRIPTION
#### Short description of what this resolves:

Moves shutdown hook logic to a single place and exposes a way to register multiple handlers.

#### Changes proposed in this pull request:

- new `hook` pkg with logic for registering shutdown hooks reacting on `io.Singal`
- small rework of `root` command 
- cmd tests adjustments

