### PR TITLE
fix(tests): extends timeouts in command tests

### DIFF
--- a/pkg/cmd/execute/cmd_test.go
+++ b/pkg/cmd/execute/cmd_test.go
@@ -37,6 +37,8 @@ var _ = Describe("Usage of ike execute command", func() {
 
 	Context("watching file changes", func() {
 
+		const cmdTimeout = 2 * time.Second
+
 		tmpPath := NewTmpPath()
 
 		BeforeEach(func() {
@@ -68,7 +70,7 @@ var _ = Describe("Usage of ike execute command", func() {
 
 			// then
 			var output string
-			Eventually(outputChan).Should(Receive(&output))
+			Eventually(outputChan, cmdTimeout).Should(Receive(&output))
 			Expect(output).To(ContainSubstring("rating.java changed. Restarting process."))
 			Expect(strings.Count(output, "mvn clean install")).To(Equal(2), "Expected build to be re-run.")
 			Expect(strings.Count(output, "java -jar rating.jar")).To(Equal(2), "Expected process to be restarted.")
@@ -97,7 +99,7 @@ var _ = Describe("Usage of ike execute command", func() {
 
 			// then
 			var output string
-			Eventually(outputChan).Should(Receive(&output))
+			Eventually(outputChan, cmdTimeout).Should(Receive(&output))
 			Expect(output).ToNot(ContainSubstring("rating.java changed. Restarting process."))
 			Expect(strings.Count(output, "java -jar rating.jar")).To(Equal(1), "Expected process to be executed once.")
 		})
@@ -126,7 +128,7 @@ var _ = Describe("Usage of ike execute command", func() {
 
 			// then
 			var output string
-			Eventually(outputChan).Should(Receive(&output))
+			Eventually(outputChan, cmdTimeout).Should(Receive(&output))
 			Expect(output).ToNot(ContainSubstring("rating.java changed. Restarting process."))
 			Expect(strings.Count(output, "mvn clean install")).To(Equal(1), "Expected process to be started once.")
 			Expect(strings.Count(output, "java -jar rating.jar")).To(Equal(1), "Expected build to be executed once.")
@@ -155,7 +157,7 @@ var _ = Describe("Usage of ike execute command", func() {
 
 			// then
 			var output string
-			Eventually(outputChan).Should(Receive(&output))
+			Eventually(outputChan, cmdTimeout).Should(Receive(&output))
 			Expect(output).To(ContainSubstring("rating.java changed. Restarting process."))
 			Expect(strings.Count(output, "mvn clean install")).To(Equal(0), "Expected build to not be executed.")
 			Expect(strings.Count(output, "java -jar rating.jar")).To(Equal(2), "Expected process to be restarted.")
@@ -189,7 +191,7 @@ var _ = Describe("Usage of ike execute command", func() {
 
 			// then
 			var output string
-			Eventually(outputChan).Should(Receive(&output))
+			Eventually(outputChan, cmdTimeout).Should(Receive(&output))
 			Expect(output).To(ContainSubstring("rating.java changed. Restarting process."))
 			Expect(strings.Count(output, "mvn clean install")).To(Equal(0), "Expected build to not be executed.")
 		})

--- a/pkg/cmd/execute/ike_execute_kill_test.go
+++ b/pkg/cmd/execute/ike_execute_kill_test.go
@@ -38,11 +38,15 @@ var _ = Describe("ike execute - managing spawned processes", func() {
 				"--run", "sleepy",
 			)
 
-			time.AfterFunc(50*time.Millisecond, func() {
-				_ = syscall.Kill(ikeExecute.Status().PID, syscall.SIGINT)
+			time.AfterFunc(100*time.Millisecond, func() {
+				pid := ikeExecute.Status().PID
+				if killErr := syscall.Kill(pid, syscall.SIGINT); killErr != nil {
+					fmt.Printf("failed killing process with pid %d. error: %v\n", pid, killErr.Error())
+				}
+
 			})
 
-			Eventually(ikeExecute.Done(), 100*time.Millisecond).Should(BeClosed())
+			Eventually(ikeExecute.Done(), 2*time.Second).Should(BeClosed())
 
 			pid, exists, err := findPID(ikeExecute.Status().Stdout)
 			Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
#### Short description of what this resolves:

Some of the tests, e.g. where shutdown hook is involved, can become flaky. It's evident in slow/constrained environments. Based on my retry runs (`ginkgo run -retry XXXXX`), so not really a scientific method, it seems that increasing timeouts can mitigate the issue. At least it unborked another PR that was struggling with it.

#### Changes proposed in this pull request:

- increases timeouts in tests


