### PR TITLE
docs: re-uses microk8s installation steps from docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,17 +188,21 @@ jobs:
           name: "Install Microk8s"
           command: |
             cd ~/.snaps
+            # tag::microk8s-snap[]
             sudo snap ack core.assert
             sudo snap install core.snap
             sudo snap ack microk8s.assert
             sudo snap install microk8s.snap --classic
+            # end::microk8s-snap[]
       - save_cache:
           <<: *save-snaps
       - run:
           name: "Launch Microk8s"
           command: |
+            # tag::microk8s-kubectl[]
             sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
             export KUBECONFIG=/tmp/kubeconfig
+            # end::microk8s-kubectl[]
 
             # wait until a k8s node is ready
             sleep 10
@@ -214,7 +218,10 @@ jobs:
             # Allow intra-pod communication
             sudo iptables -P FORWARD ACCEPT
 
-            echo n | sudo microk8s.enable dns registry istio rbac
+            echo n | \
+            # tag::microk8s-addons[]
+            sudo microk8s.enable dns registry istio rbac
+            # end::microk8s-addons[]
 
             # wait until the registry is up and running
             sleep 10
@@ -239,7 +246,9 @@ jobs:
             echo "Istio enabled"
 
             echo "Installing Tekton"
+            # tag::tekton-install[]
             kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.27.3/release.yaml
+            # end::tekton-install[]
             sleep 10
             n=0
             until [ $n -ge 10 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - run:
           name: "Install official kubectl"
           command: |
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.5/bin/linux/amd64/kubectl
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.22.16/bin/linux/amd64/kubectl
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             echo "Installed kubectl\n$(kubectl version)\n"
       - run:

--- a/docs/modules/ROOT/pages/dev_guide.adoc
+++ b/docs/modules/ROOT/pages/dev_guide.adoc
@@ -71,22 +71,27 @@ MicroK8s is a lightweight, upstream Kubernetes distribution which you can run on
 
 Check https://microk8s.io/docs[official docs] to see how you can install it on your OS.
 
+. Here's how we install it in our CircleCI setup:
++
+[source,shell,indent=0]
+----
+include::example$config.yml[tag=microk8s-snap]
+----
 
 ==== Needed customizations
 
 . Enable following services:
 +
-[source,bash]
+[source,shell,indent=0]
 ----
-microk8s.enable dns registry istio 
+include::example$config.yml[tag=microk8s-addons]
 ----
 
 . Point `kubectl` to `microk8s` instance, for example:
 +
-[source,bash]
+[source,shell,indent=0]
 ----
-sudo microk8s.kubectl config view --raw > /tmp/kubeconfig
-export KUBECONFIG=/tmp/kubeconfig
+include::example$config.yml[tag=microk8s-kubectl]
 ----
 
 [NOTE]
@@ -109,7 +114,7 @@ ENV_FILE=microk8s.env make test-e2e
 IKE_E2E_MANAGE_CLUSTER=false
 ISTIO_NS=istio-system
 IKE_IMAGE_TAG=latest
-TELEPRESENCE_VERSION=0.105
+TELEPRESENCE_VERSION=0.109
 IKE_CLUSTER_HOST=localhost
 IKE_ISTIO_INGRESS=http://localhost:31380
 IKE_INTERNAL_CONTAINER_REGISTRY=localhost:32000


### PR DESCRIPTION
- docs: defines sections from microk8s
- chore(circle): bumps kubectl to latest 1.22 version
