### PR TITLE
feat: supports Gateway resource defined in another namespace

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters-settings:
       - commentFormatting # https://github.com/go-critic/go-critic/issues/755
       - hugeParam # seems to be premature optimization based on https://github.com/Maistra/istio-workspace/pull/378#discussion_r392208906
   nestif:
-    min-complexity: 8
+    min-complexity: 10
   unused:
     check-exported: true
   gocognit:

--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,7 @@ tekton-publish: ## Prepares Tekton tasks for release and opens a PR on the Tekto
 ## Istio-workspace sample project deployment
 # ##########################################################################
 
+TEST_GW_NAMESPACE?=$(TEST_NAMESPACE)
 deploy-test-%:
 	$(eval scenario:=$(subst deploy-test-,,$@))
 	$(call header,"Deploying test $(scenario) app to $(TEST_NAMESPACE)")
@@ -486,15 +487,16 @@ deploy-test-%:
 	# end::privileged[]
 	oc adm policy add-scc-to-user privileged -z default -n $(TEST_GW_NAMESPACE) || true
 
+	TEST_NAMESPACE=$(TEST_NAMESPACE) TEST_GW_NAMESPACE=$(TEST_GW_NAMESPACE) \
 	go run ./test/cmd/test-scenario/ $(scenario) | $(k8s) apply -f -
 
 
-# TODO FIX undeploying gw if in another ns
 undeploy-test-%:
 	$(eval scenario:=$(subst undeploy-test-,,$@))
 	$(call header,"Undeploying test $(scenario) app from $(TEST_NAMESPACE)")
 
-	go run ./test/cmd/test-scenario/ $(scenario) | $(k8s) delete -n $(TEST_NAMESPACE) -f -
+	TEST_NAMESPACE=$(TEST_NAMESPACE) TEST_GW_NAMESPACE=$(TEST_GW_NAMESPACE) \
+	go run ./test/cmd/test-scenario/ $(scenario) | $(k8s) delete -f -
 
 # ##########################################################################
 ##@ Helpers

--- a/Makefile
+++ b/Makefile
@@ -472,19 +472,24 @@ deploy-test-%:
 	$(call header,"Deploying test $(scenario) app to $(TEST_NAMESPACE)")
 
 	$(k8s) create namespace $(TEST_NAMESPACE) || true
+	$(k8s) create namespace $(TEST_GW_NAMESPACE) || true
 
 	# Do not remove line breaks as they're intentionally set for docs toolchain to always get right snippet
 	# tag::anyuid[]
 	oc adm policy add-scc-to-user anyuid -z default -n $(TEST_NAMESPACE) || true
 	# end::anyuid[]
+	oc adm policy add-scc-to-user anyuid -z default -n $(TEST_GW_NAMESPACE) || true
 
 	# Do not remove line breaks as they're intentionally set for docs toolchain to always get right snippet
 	# tag::privileged[]
 	oc adm policy add-scc-to-user privileged -z default -n $(TEST_NAMESPACE) || true
 	# end::privileged[]
+	oc adm policy add-scc-to-user privileged -z default -n $(TEST_GW_NAMESPACE) || true
 
 	go run ./test/cmd/test-scenario/ $(scenario) | $(k8s) apply -f -
 
+
+# TODO FIX undeploying gw if in another ns
 undeploy-test-%:
 	$(eval scenario:=$(subst undeploy-test-,,$@))
 	$(call header,"Undeploying test $(scenario) app from $(TEST_NAMESPACE)")

--- a/api/maistra/v1alpha1/session_types.go
+++ b/api/maistra/v1alpha1/session_types.go
@@ -161,18 +161,10 @@ type Source struct {
 	Kind      string `json:"kind,omitempty"`
 }
 
-func (s *Source) GetNamespaceName() string {
-	return s.Namespace + "/" + s.Name
-}
-
 type Target struct {
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Kind      string `json:"kind,omitempty"`
-}
-
-func (t *Target) GetNamespaceName() string {
-	return t.Namespace + "/" + t.Name
 }
 
 // +genclient

--- a/api/maistra/v1alpha1/session_types.go
+++ b/api/maistra/v1alpha1/session_types.go
@@ -155,14 +155,24 @@ type Condition struct {
 }
 
 type Source struct {
-	Name string `json:"name,omitempty"`
-	Ref  string `json:"ref,omitempty"`
-	Kind string `json:"kind,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Ref       string `json:"ref,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+}
+
+func (s *Source) GetNamespaceName() string {
+	return s.Namespace + "/" + s.Name
 }
 
 type Target struct {
-	Name string `json:"name,omitempty"`
-	Kind string `json:"kind,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+}
+
+func (t *Target) GetNamespaceName() string {
+	return t.Namespace + "/" + t.Name
 }
 
 // +genclient
@@ -233,7 +243,6 @@ func (s *Session) AddCondition(condition Condition) {
 		if (stored.Source.Kind == sessionKind &&
 			matchSource &&
 			*stored.Type == *condition.Type) ||
-
 			(stored.Source.Kind != sessionKind &&
 				matchSource) {
 			s.Status.Conditions[i] = &condition

--- a/config/crd/bases/workspace.maistra.io_sessions.yaml
+++ b/config/crd/bases/workspace.maistra.io_sessions.yaml
@@ -130,6 +130,8 @@ spec:
                           type: string
                         name:
                           type: string
+                        namespace:
+                          type: string
                         ref:
                           type: string
                       type: object
@@ -143,6 +145,8 @@ spec:
                         kind:
                           type: string
                         name:
+                          type: string
+                        namespace:
                           type: string
                       type: object
                     type:

--- a/controllers/session/conditions.go
+++ b/controllers/session/conditions.go
@@ -10,16 +10,17 @@ import (
 )
 
 func createConditionForLocatedRef(ref model.Ref, located model.LocatorStatus) istiov1alpha1.Condition {
-	message := located.Kind + "/" + located.Name + " status " + ref.KindName.String() + ": "
+	message := located.GetNamespaceName() + "[" + located.Kind + "] status " + ref.KindName.String() + ": "
 	reason := "Scheduled"
 	typeStr := createType(located.Action, located.Kind)
 	status := "true"
 
 	return istiov1alpha1.Condition{
 		Source: istiov1alpha1.Source{
-			Kind: located.Kind,
-			Name: located.Name,
-			Ref:  ref.KindName.String(),
+			Kind:      located.Kind,
+			Name:      located.Name,
+			Namespace: located.Namespace,
+			Ref:       ref.KindName.String(),
 		},
 		Message: &message,
 		Reason:  &reason,
@@ -29,7 +30,7 @@ func createConditionForLocatedRef(ref model.Ref, located model.LocatorStatus) is
 }
 
 func createConditionForModifiedRef(ref model.Ref, modified model.ModificatorStatus) istiov1alpha1.Condition {
-	message := modified.Kind + "/" + modified.Name + " modified to satisfy " + ref.KindName.String() + ": "
+	message := modified.GetNamespaceName() + "[" + modified.Kind + "] modified to satisfy " + ref.KindName.String() + ": "
 	if modified.Error != nil {
 		message += modified.Error.Error()
 	} else {
@@ -38,8 +39,9 @@ func createConditionForModifiedRef(ref model.Ref, modified model.ModificatorStat
 	var target *istiov1alpha1.Target
 	if modified.Target != nil {
 		target = &istiov1alpha1.Target{
-			Kind: modified.Target.Kind,
-			Name: modified.Target.Name,
+			Kind:      modified.Target.Kind,
+			Name:      modified.Target.Name,
+			Namespace: modified.Target.Namespace,
 		}
 	}
 	status := strconv.FormatBool(modified.Success)
@@ -49,9 +51,10 @@ func createConditionForModifiedRef(ref model.Ref, modified model.ModificatorStat
 
 	return istiov1alpha1.Condition{
 		Source: istiov1alpha1.Source{
-			Kind: modified.Kind,
-			Name: modified.Name,
-			Ref:  ref.KindName.String(),
+			Kind:      modified.Kind,
+			Name:      modified.Name,
+			Namespace: modified.Namespace,
+			Ref:       ref.KindName.String(),
 		},
 		Target:  target,
 		Message: &message,

--- a/controllers/session/session_controller.go
+++ b/controllers/session/session_controller.go
@@ -182,6 +182,7 @@ func (r *ReconcileSession) Reconcile(orgCtx context.Context, request reconcile.R
 	// Fetch the Session instance
 	session := &istiov1alpha1.Session{}
 	err := c.Get(context.Background(), request.NamespacedName, session)
+
 	if err != nil {
 		if errorsK8s.IsNotFound(err) {
 			return reconcile.Result{}, nil

--- a/controllers/session/validation.go
+++ b/controllers/session/validation.go
@@ -30,9 +30,10 @@ func chainValidator(ctx model.SessionContext, ref model.Ref, session *istiov1alp
 			status := strconv.FormatBool(err == nil)
 			session.AddCondition(istiov1alpha1.Condition{
 				Source: istiov1alpha1.Source{
-					Kind: "Session",
-					Name: ctx.Name,
-					Ref:  ref.KindName.String(),
+					Kind:      "Session",
+					Name:      ctx.Name,
+					Namespace: ctx.Namespace,
+					Ref:       ref.KindName.String(),
 				},
 				Reason:  &reason,
 				Type:    &typeName,

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -55,7 +55,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 				<-testshell.Execute(`oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge`).Done()
 
-				<-testshell.Execute(NewProjectCmd(GetRepositoryName())).Done()
+				<-testshell.Execute(CreateNamespaceCmd(GetRepositoryName())).Done()
 				UpdateSecurityConstraintsFor(GetRepositoryName())
 			}
 		}
@@ -89,8 +89,8 @@ var CompletionProject2 = "ike-autocompletion-test-" + naming.RandName(16)
 
 func createProjectsForCompletionTests() {
 	testshell.ExecuteAll(
-		NewProjectCmd(CompletionProject1),
-		NewProjectCmd(CompletionProject2),
+		CreateNamespaceCmd(CompletionProject1),
+		CreateNamespaceCmd(CompletionProject2),
 	)
 	testshell.ExecuteAll(DeployNoopLoopCmd("my-deployment", CompletionProject1)...)
 	testshell.ExecuteAll(DeployNoopLoopCmd("other-1-deployment", CompletionProject2)...)
@@ -99,8 +99,8 @@ func createProjectsForCompletionTests() {
 
 func deleteProjectsForCompletionTests() {
 	testshell.ExecuteAll(
-		DeleteProjectCmd(CompletionProject1),
-		DeleteProjectCmd(CompletionProject2),
+		DeleteNamespaceCmd(CompletionProject1),
+		DeleteNamespaceCmd(CompletionProject2),
 	)
 }
 

--- a/e2e/error_path_test.go
+++ b/e2e/error_path_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Smoke End To End Tests - Faulty scenarios", func() {
 			namespace = generateNamespaceName()
 			tmpDir = tmpFs.Dir("namespace-" + namespace)
 
-			<-testshell.Execute(NewProjectCmd(namespace)).Done()
+			<-testshell.Execute(CreateNamespaceCmd(namespace)).Done()
 
 			PrepareEnv(namespace)
 			InstallLocalOperator(namespace)

--- a/e2e/error_path_test.go
+++ b/e2e/error_path_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Smoke End To End Tests - Faulty scenarios", func() {
 
 			<-testshell.Execute(CreateNamespaceCmd(namespace)).Done()
 
-			PrepareEnv(namespace)
+			PrepareEnvForOpenshift(namespace)
 			InstallLocalOperator(namespace)
 			Eventually(AllDeploymentsAndPodsReady(namespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
 		})

--- a/e2e/gw_in_another_ns_test.go
+++ b/e2e/gw_in_another_ns_test.go
@@ -41,7 +41,7 @@ var _ = Describe("End To End Tests - non standard scenarios", func() {
 
 		AfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				DumpEnvironmentDebugInfo(namespace, tmpDir)
+				PrintFailureDetails(namespace, tmpDir)
 			} else {
 				CleanupNamespace(namespace, false)
 				tmpFs.Cleanup()

--- a/e2e/gw_in_another_ns_test.go
+++ b/e2e/gw_in_another_ns_test.go
@@ -1,0 +1,110 @@
+package e2e_test
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/maistra/istio-workspace/e2e/infra"
+	"github.com/maistra/istio-workspace/test"
+	testshell "github.com/maistra/istio-workspace/test/shell"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = PDescribe("End To End Tests - non standard scenarios", func() {
+
+	Context("using ike with scenarios", func() {
+
+		var (
+			namespace,
+			gwNamespace,
+			scenario,
+			sessionName,
+			tmpDir string
+		)
+
+		tmpFs := test.NewTmpFileSystem(GinkgoT())
+
+		JustBeforeEach(func() {
+			namespace = generateNamespaceName()
+			tmpDir = tmpFs.Dir("namespace-" + namespace)
+
+			<-testshell.Execute(CreateNamespaceCmd(namespace)).Done()
+
+			PrepareEnv(namespace)
+
+			InstallLocalOperator(namespace)
+			Eventually(AllDeploymentsAndPodsReady(namespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
+			DeployTestScenario(scenario, namespace)
+			sessionName = GenerateSessionName()
+		})
+
+		AfterEach(func() {
+			if CurrentSpecReport().Failed() {
+				DumpEnvironmentDebugInfo(namespace, tmpDir)
+			} else {
+				CleanupNamespace(namespace, false)
+				tmpFs.Cleanup()
+			}
+		})
+
+		Context("Gateway in another namespace", func() {
+
+			var restoreEnvVars func()
+
+			BeforeEach(func() {
+				gwNamespace = generateNamespaceName()
+				<-testshell.Execute(CreateNamespaceCmd(gwNamespace)).Done()
+				restoreEnvVars = test.TemporaryEnvVars("TEST_GW_NAMESPACE", gwNamespace)
+			})
+
+			AfterEach(func() {
+				<-testshell.Execute(DeleteNamespaceCmd(gwNamespace)).Done()
+				restoreEnvVars()
+			})
+
+			BeforeEach(func() {
+				scenario = "scenario-1" //nolint:goconst //reason no need for constant (yet)
+			})
+
+			It("should watch for changes in connected service and serve it", func() {
+				EnsureAllDeploymentPodsAreReady(namespace)
+				EnsureProdRouteIsReachable(namespace, ContainSubstring("productpage-v1"))
+				deploymentCount := GetResourceCount("deployment", namespace)
+
+				// given we have details code locally
+				CreateFile(tmpDir+"/productpage.py", PublisherService)
+
+				ike := RunIke(tmpDir, "develop",
+					"--deployment", "deployment/productpage-v1",
+					"--port", "9080",
+					"--method", "inject-tcp",
+					"--watch",
+					"--run", "python productpage.py 9080",
+					"--route", "header:x-test-suite=smoke",
+					"--session", sessionName,
+					"--namespace", namespace,
+				)
+				defer func() {
+					Stop(ike)
+				}()
+				go FailOnCmdError(ike, GinkgoT())
+
+				EnsureCorrectNumberOfResources(deploymentCount+1, "deployment", namespace)
+				EnsureAllDeploymentPodsAreReady(namespace)
+				EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("PublisherA"))
+
+				// then modify the service
+				modifiedDetails := strings.Replace(PublisherService, "PublisherA", "Publisher Ike", 1)
+				CreateFile(tmpDir+"/productpage.py", modifiedDetails)
+
+				EnsureSessionRouteIsReachable(namespace, sessionName, ContainSubstring("Publisher Ike"))
+
+				Stop(ike)
+				EnsureProdRouteIsReachable(namespace, ContainSubstring("productpage-v1"))
+			})
+		})
+
+	})
+
+})

--- a/e2e/gw_in_another_ns_test.go
+++ b/e2e/gw_in_another_ns_test.go
@@ -26,7 +26,7 @@ var _ = Describe("End To End Tests - non standard scenarios", func() {
 
 		tmpFs := test.NewTmpFileSystem(GinkgoT())
 
-		PContext("Gateway in another namespace", func() {
+		Context("Gateway in another namespace", func() {
 
 			var restoreEnvVars func()
 
@@ -34,7 +34,7 @@ var _ = Describe("End To End Tests - non standard scenarios", func() {
 				scenario = "scenario-1" //nolint:goconst //reason no need for constant (yet)
 
 				namespace = generateNamespaceName()
-				gwNamespace = generateNamespaceName()
+				gwNamespace = "gw-" + namespace
 				tmpDir = tmpFs.Dir("namespace-" + namespace)
 
 				<-testshell.Execute(CreateNamespaceCmd(namespace)).Done()

--- a/e2e/gw_in_another_ns_test.go
+++ b/e2e/gw_in_another_ns_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = PDescribe("End To End Tests - non standard scenarios", func() {
+var _ = Describe("End To End Tests - non standard scenarios", func() {
 
 	Context("using ike with scenarios", func() {
 
@@ -48,7 +48,7 @@ var _ = PDescribe("End To End Tests - non standard scenarios", func() {
 			}
 		})
 
-		Context("Gateway in another namespace", func() {
+		PContext("Gateway in another namespace", func() {
 
 			var restoreEnvVars func()
 

--- a/e2e/infra/cluster_setup.go
+++ b/e2e/infra/cluster_setup.go
@@ -86,8 +86,8 @@ func UsePrebuiltImages() bool {
 	return os.Getenv("PRE_BUILT_IMAGES") != ""
 }
 
-// PrepareEnv sets up a environmental specific things.
-func PrepareEnv(namespace string) {
+// PrepareEnvForOpenshift sets up an environmental specific things.
+func PrepareEnvForOpenshift(namespace string) {
 	if RunsOnOpenshift {
 		UpdateSecurityConstraintsFor(namespace)
 		if !UsePrebuiltImages() {

--- a/e2e/infra/deployment.go
+++ b/e2e/infra/deployment.go
@@ -27,11 +27,11 @@ func DeleteFile(filePath string) {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
-func NewProjectCmd(name string) string {
+func CreateNamespaceCmd(name string) string {
 	return "kubectl create namespace " + name
 }
 
-func DeleteProjectCmd(name string) string {
+func DeleteNamespaceCmd(name string) string {
 	return "kubectl delete namespace " + name + " --wait=false"
 }
 

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -14,7 +14,7 @@ func BuildOperator() (registry string) {
 	namespace := setOperatorNamespace()
 	registry = SetExternalContainerRegistry()
 	setContainerRepository(GetRepositoryName())
-	shell.Execute(NewProjectCmd(namespace)).Done() // Ignore failure if ns already exists
+	shell.Execute(CreateNamespaceCmd(namespace)).Done() // Ignore failure if ns already exists
 	if RunsOnOpenshift {
 		EnablePullingImages(namespace)
 		shell.WaitForSuccess(

--- a/e2e/infra/istio_operators_setup.go
+++ b/e2e/infra/istio_operators_setup.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/maistra/istio-workspace/test/shell"
 	"github.com/onsi/gomega"
@@ -35,6 +36,20 @@ func InstallLocalOperator(namespace string) {
 	gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
 	shell.WaitForSuccess(
 		shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run"),
+	)
+}
+
+func InstallMultiNamespaceOperator(namespace string, watchNs ...string) {
+	SetInternalContainerRegistry()
+
+	watchNs = append(watchNs, namespace)
+	err := os.Setenv("OPERATOR_NAMESPACE", namespace)
+	gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
+	err = os.Setenv("OPERATOR_WATCH_NAMESPACE", strings.Join(watchNs, ","))
+	gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
+
+	shell.WaitForSuccess(
+		shell.ExecuteInDir(shell.GetProjectDir(), "make", "bundle-run-multi"),
 	)
 }
 

--- a/e2e/infra/test_service.go
+++ b/e2e/infra/test_service.go
@@ -43,6 +43,7 @@ func BuildTestServicePreparedImage(callerName string) (registry string) {
 
 // DeployTestScenario deploys a test scenario into the specified namespace.
 func DeployTestScenario(scenario, namespace string) {
+	fmt.Printf("test gw ns: %s\n", os.Getenv("TEST_GW_NAMESPACE"))
 	projectDir := shell.GetProjectDir()
 	SetInternalContainerRegistry()
 	setContainerEnvForTestServiceDeploy(namespace)

--- a/e2e/install_mode_test.go
+++ b/e2e/install_mode_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Operator installation", func() {
 
 		CreateNamespace := func() {
 			for _, namespace := range namespaces {
-				<-shell.Execute(NewProjectCmd(namespace)).Done()
+				<-shell.Execute(CreateNamespaceCmd(namespace)).Done()
 			}
 		}
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 
 				Context("basic deployment modifications", func() {
 
-					It("should watch for changes in connected service and serve it", func() {
+					FIt("should watch for changes in connected service and serve it", func() {
 						EnsureAllDeploymentPodsAreReady(namespace)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("productpage-v1"))
 						deploymentCount := GetResourceCount("deployment", namespace)

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 
 			<-testshell.Execute(CreateNamespaceCmd(namespace)).Done()
 
-			PrepareEnv(namespace)
+			PrepareEnvForOpenshift(namespace)
 
 			InstallLocalOperator(namespace)
 			Eventually(AllDeploymentsAndPodsReady(namespace), 10*time.Minute, 5*time.Second).Should(BeTrue())
@@ -68,7 +68,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 
 				Context("basic deployment modifications", func() {
 
-					FIt("should watch for changes in connected service and serve it", func() {
+					It("should watch for changes in connected service and serve it", func() {
 						EnsureAllDeploymentPodsAreReady(namespace)
 						EnsureProdRouteIsReachable(namespace, ContainSubstring("productpage-v1"))
 						deploymentCount := GetResourceCount("deployment", namespace)

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 			namespace = generateNamespaceName()
 			tmpDir = tmpFs.Dir("namespace-" + namespace)
 
-			<-testshell.Execute(NewProjectCmd(namespace)).Done()
+			<-testshell.Execute(CreateNamespaceCmd(namespace)).Done()
 
 			PrepareEnv(namespace)
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 			Context("http protocol", func() {
 
 				BeforeEach(func() {
-					scenario = "scenario-1" 
+					scenario = "scenario-1"
 					registry = GetInternalContainerRegistry()
 				})
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Smoke End To End Tests", func() {
 			Context("http protocol", func() {
 
 				BeforeEach(func() {
-					scenario = "scenario-1" //nolint:goconst //reason no need for constant (yet)
+					scenario = "scenario-1" 
 					registry = GetInternalContainerRegistry()
 				})
 

--- a/pkg/istio/destinationrule.go
+++ b/pkg/istio/destinationrule.go
@@ -117,7 +117,7 @@ func actionCreateDestinationRule(ctx model.SessionContext, ref model.Ref, store 
 	destinationRule := istionetwork.DestinationRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.ConcatToMax(63, "dr", ref.KindName.Name, dr.Spec.Host, ctx.Name),
-			Namespace: ctx.Namespace,
+			Namespace: ref.Namespace,
 		},
 		Spec: istionetworkv1alpha3.DestinationRule{
 			Host: dr.Spec.Host,

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -134,17 +134,17 @@ func mutateGateway(ctx model.SessionContext, source istionetwork.Gateway) (mutat
 		hosts := server.Hosts
 		for _, host := range hosts {
 			newHost := ctx.Name + "." + host
-			if !existInList(existingHosts, host) && !existInList(existingHosts, newHost) {
+			if !isInSlice(existingHosts, host) && !isInSlice(existingHosts, newHost) {
 				existingHosts = append(existingHosts, newHost)
 				hosts = append(hosts, newHost)
 			}
-			if existInList(existingHosts, newHost) {
+			if isInSlice(existingHosts, newHost) {
 				addedHosts = append(addedHosts, newHost)
 			}
 		}
 		for _, existing := range existingHosts {
 			baseHost := strings.Join(strings.Split(existing, ".")[1:], ".")
-			if !existInList(hosts, existing) && existInList(hosts, baseHost) {
+			if !isInSlice(hosts, existing) && isInSlice(hosts, baseHost) {
 				hosts = append(hosts, existing)
 			}
 		}
@@ -168,7 +168,7 @@ func revertGateway(ctx model.SessionContext, source istionetwork.Gateway) istion
 		hosts := server.Hosts
 		for i := 0; i < len(hosts); i++ {
 			host := hosts[i]
-			if existInList(existingHosts, host) && strings.HasPrefix(host, ctx.Name+".") {
+			if isInSlice(existingHosts, host) && strings.HasPrefix(host, ctx.Name+".") {
 				toBeRemovedHosts = append(toBeRemovedHosts, host)
 				hosts = append(hosts[:i], hosts[i+1:]...)
 				i--
@@ -202,7 +202,7 @@ func getGateways(ctx model.SessionContext, namespace string, opts ...client.List
 	return &gateways, errors.WrapWithDetails(err, "failed finding virtual services in namespace", "namespace", namespace)
 }
 
-func existInList(hosts []string, host string) bool {
+func isInSlice(hosts []string, host string) bool {
 	for _, eh := range hosts {
 		if eh == host {
 			return true

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -66,7 +66,7 @@ func actionModifyGateway(ctx model.SessionContext, ref model.Ref, report model.M
 		report(model.ModificatorStatus{
 			LocatorStatus: resource,
 			Success:       false,
-			Error:         errors.WrapIfWithDetails(err, "failed updateing gateway", "kind", GatewayKind, "name", mutatedGw.Name)})
+			Error:         errors.WrapIfWithDetails(err, "failed updating gateway", "kind", GatewayKind, "name", mutatedGw.Name)})
 
 		return
 	}
@@ -82,7 +82,6 @@ func actionModifyGateway(ctx model.SessionContext, ref model.Ref, report model.M
 
 func actionRevertGateway(ctx model.SessionContext, ref model.Ref, report model.ModificatorStatusReporter, resource model.LocatorStatus) {
 	gw, err := getGateway(ctx, resource.Namespace, resource.Name)
-	patch := client.MergeFrom(gw.DeepCopy())
 	if err != nil {
 		if k8sErrors.IsNotFound(err) { // Not found, nothing to clean
 			report(model.ModificatorStatus{
@@ -100,6 +99,7 @@ func actionRevertGateway(ctx model.SessionContext, ref model.Ref, report model.M
 	}
 
 	ctx.Log.Info("Found Gateway", "name", resource.Name)
+	patch := client.MergeFrom(gw.DeepCopy())
 	mutatedGw := revertGateway(ctx, *gw)
 	if err = reference.Remove(ctx.ToNamespacedName(), &mutatedGw); err != nil {
 		ctx.Log.Error(err, "failed to remove relation reference", "kind", mutatedGw.Kind, "name", mutatedGw.Name)

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -36,7 +36,7 @@ func GatewayModificator(ctx model.SessionContext, ref model.Ref, store model.Loc
 			report(model.ModificatorStatus{
 				LocatorStatus: resource,
 				Success:       false,
-				Error:         errors.Errorf("Unknown action type for modificator: %v", resource.Action)})
+				Error:         errors.Errorf("Unsupported action type for modificator: %v", resource.Action)})
 		}
 	}
 }
@@ -52,7 +52,7 @@ func actionModifyGateway(ctx model.SessionContext, ref model.Ref, report model.M
 		return
 	}
 
-	ctx.Log.Info("Found Gateway", "name", gw.Name)
+	ctx.Log.Info("Found Gateway", "name", resource.Name, "namespace", resource.Namespace)
 	patch := client.MergeFrom(gw.DeepCopy())
 	mutatedGw, addedHosts := mutateGateway(ctx, *gw)
 
@@ -98,7 +98,7 @@ func actionRevertGateway(ctx model.SessionContext, ref model.Ref, report model.M
 		return
 	}
 
-	ctx.Log.Info("Found Gateway", "name", resource.Name)
+	ctx.Log.Info("Found Gateway", "name", resource.Name, "namespace", resource.Namespace)
 	patch := client.MergeFrom(gw.DeepCopy())
 	mutatedGw := revertGateway(ctx, *gw)
 	if err = reference.Remove(ctx.ToNamespacedName(), &mutatedGw); err != nil {
@@ -111,7 +111,7 @@ func actionRevertGateway(ctx model.SessionContext, ref model.Ref, report model.M
 		report(model.ModificatorStatus{
 			LocatorStatus: resource,
 			Success:       false,
-			Error:         errors.WrapIfWithDetails(err, "failed updateing gateway", "kind", GatewayKind, "name", mutatedGw.Name)})
+			Error:         errors.WrapIfWithDetails(err, "failed updating gateway", "kind", GatewayKind, "name", mutatedGw.Name)})
 
 		return
 	}

--- a/pkg/istio/gateway.go
+++ b/pkg/istio/gateway.go
@@ -42,7 +42,7 @@ func GatewayModificator(ctx model.SessionContext, ref model.Ref, store model.Loc
 }
 
 func actionModifyGateway(ctx model.SessionContext, ref model.Ref, report model.ModificatorStatusReporter, resource model.LocatorStatus) {
-	gw, err := getGateway(ctx, ctx.Namespace, resource.Name)
+	gw, err := getGateway(ctx, resource.Namespace, resource.Name)
 	if err != nil {
 		report(model.ModificatorStatus{
 			LocatorStatus: resource,

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -207,7 +207,6 @@ func actionDeleteVirtualService(ctx model.SessionContext, report model.Modificat
 
 func actionModifyVirtualService(ctx model.SessionContext, ref model.Ref, store model.LocatorStatusStore, report model.ModificatorStatusReporter, resource model.LocatorStatus) {
 	vs, err := getVirtualService(ctx, resource.Namespace, resource.Name)
-	patch := client.MergeFrom(vs.DeepCopy())
 	if err != nil {
 		report(model.ModificatorStatus{
 			LocatorStatus: resource,
@@ -223,6 +222,7 @@ func actionModifyVirtualService(ctx model.SessionContext, ref model.Ref, store m
 
 		return
 	}
+	patch := client.MergeFrom(vs.DeepCopy())
 	mutatedVs, err := mutateVirtualService(ctx, store, hostName, *vs)
 	if err != nil {
 		report(model.ModificatorStatus{
@@ -250,12 +250,13 @@ func actionModifyVirtualService(ctx model.SessionContext, ref model.Ref, store m
 
 func actionRevertVirtualService(ctx model.SessionContext, ref model.Ref, store model.LocatorStatusStore, report model.ModificatorStatusReporter, resource model.LocatorStatus) {
 	vs, err := getVirtualService(ctx, resource.Namespace, resource.Name)
-	patch := client.MergeFrom(vs.DeepCopy())
 	if err != nil {
 		report(model.ModificatorStatus{LocatorStatus: resource, Success: false, Error: err})
 
 		return
 	}
+
+	patch := client.MergeFrom(vs.DeepCopy())
 	mutatedVs := revertVirtualService(model.GetDeletedVersion(store), *vs)
 	if err = reference.Remove(ctx.ToNamespacedName(), &mutatedVs); err != nil {
 		ctx.Log.Error(err, "failed to add relation reference", "kind", mutatedVs.Kind, "name", mutatedVs.Name)

--- a/pkg/istio/virtualservice.go
+++ b/pkg/istio/virtualservice.go
@@ -488,13 +488,14 @@ func getHostsFromGateway(ctx model.SessionContext, store model.LocatorStatusStor
 	gwByName := func(store model.LocatorStatusStore, gatewayName string) []model.LocatorStatus {
 		var f []model.LocatorStatus
 		for _, g := range store(GatewayKind) {
-			if g.Name == gatewayName {
+			if g.GetNamespaceName() == gatewayName || g.Name == gatewayName {
 				f = append(f, g)
 			}
 		}
 
 		return f
 	}
+
 	for _, gateway := range gateways {
 		for _, gwTarget := range gwByName(store, gateway) {
 			for _, host := range strings.Split(gwTarget.Labels[LabelIkeHosts], ",") {

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -101,7 +101,7 @@ func VirtualServiceGatewayLocator(ctx model.SessionContext, ref model.Ref, store
 		}
 	}
 
-	return errors.Wrapf(errs, "failed locating the Gateways that are connected to VirtualServices. Namespace: %s, Name: %s", ref.Namespace, ref.KindName.String())
+	return errors.WrapWithDetails(errs, "failed locating the Gateways that are connected to VirtualServices. Namespace: %s, Name: %s", ref.Namespace, ref.KindName.String())
 }
 
 func findNewHosts(server *v1alpha3.Server, existingHosts, hosts []string) []string {

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -51,7 +51,18 @@ func VirtualServiceGatewayLocator(ctx model.SessionContext, ref model.Ref, store
 			vs := vss.Items[i]
 			if gateways, connected := connectedToGateway(vs); connected {
 				for _, gwName := range gateways {
-					gw, err := getGateway(ctx, ctx.Namespace, gwName)
+					gwName := gwName // pin
+					// Gateways in other namespaces may be referred to
+					// by <gateway namespace>/<gateway name>;
+					// specifying a gateway with no namespace qualifier
+					// is the same as specifying the VirtualService’s namespace.
+					gwNs := vs.Namespace // default if not specified otherwise
+					gwNameNs := strings.Split(gwName, "/")
+					if len(gwNameNs) > 1 {
+						gwNs = gwNameNs[0]
+						gwName = gwNameNs[1]
+					}
+					gw, err := getGateway(ctx, gwNs, gwName)
 					if err != nil {
 						errs = errors.Append(errs, err)
 

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -106,7 +106,7 @@ func VirtualServiceGatewayLocator(ctx model.SessionContext, ref model.Ref, store
 
 func findNewHosts(server *v1alpha3.Server, existingHosts, hosts []string) []string {
 	for _, host := range server.Hosts {
-		if !existInList(existingHosts, host) {
+		if !isInSlice(existingHosts, host) {
 			hosts = append(hosts, host)
 		}
 	}

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -79,7 +79,7 @@ func VirtualServiceGatewayLocator(ctx model.SessionContext, ref model.Ref, store
 					report(model.LocatorStatus{
 						Resource: model.Resource{
 							Kind:      GatewayKind,
-							Namespace: gw.Namespace,
+							Namespace: gwNs,
 							Name:      gwName,
 						},
 						Labels: map[string]string{LabelIkeHosts: strings.Join(hosts, ",")}, Action: model.ActionModify})

--- a/pkg/istio/virtualservicegateway.go
+++ b/pkg/istio/virtualservicegateway.go
@@ -101,7 +101,7 @@ func VirtualServiceGatewayLocator(ctx model.SessionContext, ref model.Ref, store
 		}
 	}
 
-	return errors.Wrapf(errs, "failed locating the Gateways that are connected to VirtualServices %s", ref.KindName.String())
+	return errors.Wrapf(errs, "failed locating the Gateways that are connected to VirtualServices. Namespace: %s, Name: %s", ref.Namespace, ref.KindName.String())
 }
 
 func findNewHosts(server *v1alpha3.Server, existingHosts, hosts []string) []string {

--- a/pkg/k8s/deployment.go
+++ b/pkg/k8s/deployment.go
@@ -178,7 +178,7 @@ func actionCreateDeployment(ctx model.SessionContext, ref model.Ref, store model
 
 func actionDeleteDeployment(ctx model.SessionContext, report model.ModificatorStatusReporter, resource model.LocatorStatus) {
 	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: resource.Name, Namespace: ctx.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: resource.Name, Namespace: resource.Namespace},
 	}
 	ctx.Log.Info("Found Deployment", "name", resource.Name)
 	err := ctx.Client.Delete(ctx, deployment)

--- a/pkg/model/sync.go
+++ b/pkg/model/sync.go
@@ -14,7 +14,7 @@ var (
 	resources = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "resources_total",
-			Help: "Number of resources proccessed",
+			Help: "Number of resources processed",
 		},
 		resourceVectors,
 	)
@@ -32,7 +32,7 @@ func init() {
 	metrics.Registry.MustRegister(resources, resourceFailures)
 }
 
-// Sync is the entry point for ensuring the desired state for the given Ref is up to date.
+// Sync is the entry point for ensuring the desired state for the given Ref is up-to-date.
 type Sync func(SessionContext, Ref, ModificatorController, LocatedReporter, ModificatorStatusReporter)
 
 func NewSync(locators []Locator, modificators []Modificator) Sync {

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -189,3 +189,7 @@ type Resource struct {
 	Kind      string
 	Name      string
 }
+
+func (r *Resource) GetNamespaceName() string {
+	return r.Namespace + "/" + r.Name
+}

--- a/pkg/openshift/deploymentconfig.go
+++ b/pkg/openshift/deploymentconfig.go
@@ -183,9 +183,9 @@ func actionCreateDeploymentConfig(ctx model.SessionContext, ref model.Ref, store
 
 func actionDeleteDeploymentConfig(ctx model.SessionContext, report model.ModificatorStatusReporter, resource model.LocatorStatus) {
 	deployment := &appsv1.DeploymentConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: resource.Name, Namespace: ctx.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: resource.Name, Namespace: resource.Namespace},
 	}
-	ctx.Log.Info("Found DeploymentConfig", "name", resource.Name)
+	ctx.Log.Info("Found DeploymentConfig", "name", resource.Name, "namespace", resource.Namespace)
 	err := ctx.Client.Delete(ctx, deployment)
 	if err != nil {
 		if errorsK8s.IsNotFound(err) {

--- a/test/cmd/test-scenario/generator/generators.go
+++ b/test/cmd/test-scenario/generator/generators.go
@@ -206,6 +206,11 @@ func VirtualService(service Entry) runtime.Object {
 
 // Gateway basic SubGenerator for the kind Gateway.
 func Gateway() runtime.Object {
+	gatewayNs := GatewayNamespace
+	if gatewayNs == "" {
+		gatewayNs = Namespace
+	}
+
 	return &istionetwork.Gateway{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: "networking.istio.io/v1alpha3",
@@ -213,7 +218,7 @@ func Gateway() runtime.Object {
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test-gateway",
-			Namespace: Namespace,
+			Namespace: gatewayNs,
 		},
 		Spec: istiov1alpha3.Gateway{
 			Selector: map[string]string{

--- a/test/cmd/test-scenario/generator/generators.go
+++ b/test/cmd/test-scenario/generator/generators.go
@@ -217,7 +217,7 @@ func Gateway() runtime.Object {
 			Kind:       "Gateway",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-gateway",
+			Name:      GatewayName,
 			Namespace: gatewayNs,
 		},
 		Spec: istiov1alpha3.Gateway{

--- a/test/cmd/test-scenario/generator/modifiers.go
+++ b/test/cmd/test-scenario/generator/modifiers.go
@@ -11,10 +11,15 @@ import (
 
 // ConnectToGateway modifier to connect VirtualService to a Gateway. Combine with ForService.
 func ConnectToGateway(hostname string) Modifier {
+	gatewayNs := GatewayNamespace
+	if gatewayNs == "" {
+		gatewayNs = Namespace
+	}
+	
 	return func(service Entry, object runtime.Object) {
 		if obj, ok := object.(*istionetwork.VirtualService); ok {
 			obj.Spec.Hosts = []string{hostname}
-			obj.Spec.Gateways = append(obj.Spec.Gateways, "test-gateway")
+			obj.Spec.Gateways = append(obj.Spec.Gateways, gatewayNs+"/test-gateway")
 			for i := 0; i < len(obj.Spec.Http); i++ {
 				http := obj.Spec.Http[i]
 				for n := 0; n < len(http.Route); n++ {

--- a/test/cmd/test-scenario/generator/modifiers.go
+++ b/test/cmd/test-scenario/generator/modifiers.go
@@ -15,7 +15,7 @@ func ConnectToGateway(hostname string) Modifier {
 	if gatewayNs == "" {
 		gatewayNs = Namespace
 	}
-	
+
 	return func(service Entry, object runtime.Object) {
 		if obj, ok := object.(*istionetwork.VirtualService); ok {
 			obj.Spec.Hosts = []string{hostname}

--- a/test/cmd/test-scenario/generator/modifiers.go
+++ b/test/cmd/test-scenario/generator/modifiers.go
@@ -11,15 +11,10 @@ import (
 
 // ConnectToGateway modifier to connect VirtualService to a Gateway. Combine with ForService.
 func ConnectToGateway(hostname string) Modifier {
-	gatewayNs := GatewayNamespace
-	if gatewayNs == "" {
-		gatewayNs = Namespace
-	}
-
 	return func(service Entry, object runtime.Object) {
 		if obj, ok := object.(*istionetwork.VirtualService); ok {
 			obj.Spec.Hosts = []string{hostname}
-			obj.Spec.Gateways = append(obj.Spec.Gateways, gatewayNs+"/test-gateway")
+			obj.Spec.Gateways = append(obj.Spec.Gateways, getGatewayName())
 			for i := 0; i < len(obj.Spec.Http); i++ {
 				http := obj.Spec.Http[i]
 				for n := 0; n < len(http.Route); n++ {

--- a/test/cmd/test-scenario/generator/scenarios.go
+++ b/test/cmd/test-scenario/generator/scenarios.go
@@ -7,6 +7,7 @@ import (
 var (
 	Namespace        = ""
 	GatewayNamespace = ""
+	GatewayName      = "test-gateway"
 )
 
 // TestScenario1HTTPThreeServicesInSequence is a basic test setup with a few services
@@ -116,4 +117,13 @@ func IncompleteMissingVirtualServices(out io.Writer) {
 		ForService(reviews, Call(HTTP(), ratings)),
 		GatewayOnHost(GatewayHost),
 	)
+}
+
+func getGatewayName() string {
+	gatewayName := GatewayName
+	if GatewayNamespace != "" {
+		gatewayName = GatewayNamespace + "/" + gatewayName
+	}
+
+	return gatewayName
 }

--- a/test/cmd/test-scenario/generator/scenarios.go
+++ b/test/cmd/test-scenario/generator/scenarios.go
@@ -5,7 +5,8 @@ import (
 )
 
 var (
-	Namespace = ""
+	Namespace        = ""
+	GatewayNamespace = ""
 )
 
 // TestScenario1HTTPThreeServicesInSequence is a basic test setup with a few services

--- a/test/cmd/test-scenario/main.go
+++ b/test/cmd/test-scenario/main.go
@@ -20,8 +20,12 @@ func main() {
 		generator.GatewayHost = h
 	}
 
-	if h, f := os.LookupEnv("TEST_NAMESPACE"); f {
-		generator.Namespace = h
+	if ns, found := os.LookupEnv("TEST_NAMESPACE"); found {
+		generator.Namespace = ns
+	}
+
+	if gwNs, found := os.LookupEnv("TEST_GW_NAMESPACE"); found {
+		generator.GatewayNamespace = gwNs
 	}
 
 	scenarios := map[string]func(io.Writer){


### PR DESCRIPTION
This change enables routing through Gateway defined in another namespace. It requires cluster-wide or multiple ns operator installations (although the latter seems to be discouraged by operator-sdk due to potential tenancy issues).

In addition, it comes with an e2e test demonstrating such a use case.

#### Important note

What this PR doesn't verify yet is `mesh` gateway special case.


Fixes #1099